### PR TITLE
Update query handler sanitization

### DIFF
--- a/includes/class-query-handler.php
+++ b/includes/class-query-handler.php
@@ -19,8 +19,8 @@ class Gm2_Category_Sort_Query_Handler {
         }
         
         $term_ids = array_map('intval', explode(',', $_GET['gm2_cat']));
-        $filter_type = $_GET['gm2_filter_type'] ?? 'simple';
-        $simple_operator = $_GET['gm2_simple_operator'] ?? 'IN';
+        $filter_type = sanitize_key($_GET['gm2_filter_type'] ?? 'simple');
+        $simple_operator = sanitize_key($_GET['gm2_simple_operator'] ?? 'IN');
         
         // Get existing tax query
         $tax_query = $query->get('tax_query') ?: [];


### PR DESCRIPTION
## Summary
- sanitize filter parameters in `modify_archive_query`

## Testing
- `php -l includes/class-query-handler.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683f86e96d6483279fbd82143f889ce8