### PR TITLE
Add README and MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Your Name
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Gm2 Category Sort
+
+Gm2 Category Sort adds a product category sorting widget for WooCommerce shops when using Elementor. Visitors can filter products by category through a collapsible tree of categories.
+
+## Requirements
+- WordPress 5.0 or higher
+- [WooCommerce](https://woocommerce.com/)
+- [Elementor](https://elementor.com/)
+
+## Installation
+1. Download or clone this repository into the `wp-content/plugins` directory of your WordPress installation.
+2. Make sure WooCommerce and Elementor are installed and activated.
+3. Activate **Gm2 Category Sort** from the **Plugins** screen in WordPress.
+
+## Usage
+1. Edit a WooCommerce shop or archive page with Elementor.
+2. Search for the **GM2 Category Sort** widget and drag it into your layout.
+3. Choose optional parent categories and select the filter logic (Simple or Advanced) in the widget settings.
+4. Save the page. On the frontend, shoppers can expand categories and filter the product list.
+
+## License
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary
- document the Gm2 Category Sort plugin usage in README
- include MIT open source license

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f80473d18832791e5342faee779ab