### PR TITLE
Fix escaping in category renderer

### DIFF
--- a/includes/class-renderer.php
+++ b/includes/class-renderer.php
@@ -73,7 +73,7 @@ class Gm2_Category_Sort_Renderer {
         echo $indent;
         
         echo '<div class="gm2-category-name-container">';
-        echo '<div class="gm2-category-name ' . $selected_class . '" data-term-id="' . $term->term_id . '">' . $term->name . '</div>';
+        echo '<div class="gm2-category-name ' . $selected_class . '" data-term-id="' . esc_attr($term->term_id) . '">' . esc_html($term->name) . '</div>';
         
         if ($has_children) {
             echo '<button class="gm2-expand-button" data-expanded="false">+</button>';


### PR DESCRIPTION
## Summary
- escape data attributes in `render_category_node`
- use `esc_html` when printing term name

## Testing
- `php -l includes/class-renderer.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683f8028f9b48327819f1fa4d6832ac9