### PR TITLE
Add AJAX-based filtering

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -47,15 +47,15 @@ jQuery(document).ready(function($) {
         $widget.find('.gm2-category-name.selected').each(function() {
             selectedIds.push($(this).data('term-id'));
         });
-        
+
         const url = new URL(window.location.href);
         const filterType = $widget.data('filter-type');
         const simpleOperator = $widget.data('simple-operator') || 'IN';
-        
+
         if (selectedIds.length > 0) {
             url.searchParams.set('gm2_cat', selectedIds.join(','));
             url.searchParams.set('gm2_filter_type', filterType);
-            
+
             if (filterType === 'simple') {
                 url.searchParams.set('gm2_simple_operator', simpleOperator);
             }
@@ -64,12 +64,22 @@ jQuery(document).ready(function($) {
             url.searchParams.delete('gm2_filter_type');
             url.searchParams.delete('gm2_simple_operator');
         }
-        
-        // Remove pagination
+
         url.searchParams.delete('paged');
-        
-        // Reload page with new parameters
-        window.location.href = url.toString();
+
+        const data = {
+            action: 'gm2_filter_products',
+            gm2_cat: selectedIds.join(','),
+            gm2_filter_type: filterType,
+            gm2_simple_operator: simpleOperator
+        };
+
+        $.post(gm2CategorySort.ajax_url, data, function(response) {
+            if (response.success) {
+                $('.products').first().replaceWith(response.data.html);
+                window.history.replaceState(null, '', url.toString());
+            }
+        });
     }
     
     // Event delegation for dynamic elements

--- a/gm2-category-sort.php
+++ b/gm2-category-sort.php
@@ -26,10 +26,12 @@ function gm2_category_sort_init() {
     require_once GM2_CAT_SORT_PATH . 'includes/class-enqueuer.php';
     require_once GM2_CAT_SORT_PATH . 'includes/class-query-handler.php';
     require_once GM2_CAT_SORT_PATH . 'includes/class-renderer.php';
+    require_once GM2_CAT_SORT_PATH . 'includes/class-ajax.php';
     
     // Initialize components
     Gm2_Category_Sort_Enqueuer::init();
     Gm2_Category_Sort_Query_Handler::init();
+    Gm2_Category_Sort_Ajax::init();
     
     // Register widget after Elementor is fully loaded
     add_action('elementor/widgets/register', 'gm2_register_widget');

--- a/includes/class-ajax.php
+++ b/includes/class-ajax.php
@@ -1,0 +1,58 @@
+<?php
+class Gm2_Category_Sort_Ajax {
+    public static function init() {
+        add_action('wp_ajax_gm2_filter_products', [__CLASS__, 'filter_products']);
+        add_action('wp_ajax_nopriv_gm2_filter_products', [__CLASS__, 'filter_products']);
+    }
+
+    public static function filter_products() {
+        $term_ids = [];
+        if (!empty($_POST['gm2_cat'])) {
+            $term_ids = array_map('intval', explode(',', $_POST['gm2_cat']));
+        }
+        $filter_type = sanitize_key($_POST['gm2_filter_type'] ?? 'simple');
+        $simple_operator = sanitize_key($_POST['gm2_simple_operator'] ?? 'IN');
+
+        $tax_query = [];
+        if (!empty($term_ids)) {
+            if ($filter_type === 'advanced' && class_exists('Gm2_Category_Sort_Query_Handler')) {
+                $category_query = Gm2_Category_Sort_Query_Handler::build_advanced_query($term_ids);
+            } else {
+                $category_query = [
+                    'taxonomy' => 'product_cat',
+                    'field' => 'term_id',
+                    'terms' => $term_ids,
+                    'operator' => $simple_operator,
+                    'include_children' => true,
+                ];
+            }
+            $tax_query[] = $category_query;
+        }
+
+        $args = [
+            'post_type' => 'product',
+            'post_status' => 'publish',
+            'posts_per_page' => wc_get_loop_prop('per_page'),
+            'paged' => 1,
+            'tax_query' => $tax_query,
+        ];
+
+        $query = new WP_Query($args);
+
+        ob_start();
+        if ($query->have_posts()) {
+            woocommerce_product_loop_start();
+            while ($query->have_posts()) {
+                $query->the_post();
+                wc_get_template_part('content', 'product');
+            }
+            woocommerce_product_loop_end();
+        } else {
+            woocommerce_no_products_found();
+        }
+        wp_reset_postdata();
+
+        $html = ob_get_clean();
+        wp_send_json_success(['html' => $html]);
+    }
+}

--- a/includes/class-enqueuer.php
+++ b/includes/class-enqueuer.php
@@ -27,5 +27,13 @@ class Gm2_Category_Sort_Enqueuer {
             '1.0',
             true
         );
+
+        wp_localize_script(
+            'gm2-category-sort-script',
+            'gm2CategorySort',
+            [
+                'ajax_url' => admin_url('admin-ajax.php')
+            ]
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add AJAX handler for filtering products
- enqueue AJAX URL for frontend JavaScript
- update JavaScript to fetch products via AJAX

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_683f8b57d41483278a0846861c9aa272