### PR TITLE
Fix product grid layout after AJAX filtering

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -28,6 +28,7 @@ jQuery(document).ready(function($) {
             $(this).addClass('selected');
         }
         
+        gm2RefreshSelectedList($widget);
         gm2UpdateProductFiltering($widget);
     }
     
@@ -39,7 +40,32 @@ jQuery(document).ready(function($) {
         
         $target.remove();
         $widget.find('.gm2-category-name[data-term-id="' + termId + '"]').removeClass('selected');
+        gm2RefreshSelectedList($widget);
         gm2UpdateProductFiltering($widget);
+    }
+
+    function gm2RefreshSelectedList($widget) {
+        const $container = $widget.find('.gm2-selected-categories');
+        const $header = $widget.find('.gm2-selected-header');
+
+        $container.empty();
+
+        $widget.find('.gm2-category-name.selected').each(function() {
+            const termId = $(this).data('term-id');
+            const name = $(this).text().trim();
+            const $item = $('<div class="gm2-selected-category" data-term-id="' + termId + '"></div>');
+            $item.text(name);
+            $item.append('<span class="gm2-remove-category">✕</span>');
+            $container.append($item);
+        });
+
+        if ($container.children().length > 0) {
+            $header.show();
+            $container.show();
+        } else {
+            $header.hide();
+            $container.hide();
+        }
     }
     
     function gm2UpdateProductFiltering($widget) {
@@ -47,15 +73,15 @@ jQuery(document).ready(function($) {
         $widget.find('.gm2-category-name.selected').each(function() {
             selectedIds.push($(this).data('term-id'));
         });
-        
+
         const url = new URL(window.location.href);
         const filterType = $widget.data('filter-type');
         const simpleOperator = $widget.data('simple-operator') || 'IN';
-        
+
         if (selectedIds.length > 0) {
             url.searchParams.set('gm2_cat', selectedIds.join(','));
             url.searchParams.set('gm2_filter_type', filterType);
-            
+
             if (filterType === 'simple') {
                 url.searchParams.set('gm2_simple_operator', simpleOperator);
             }
@@ -64,12 +90,38 @@ jQuery(document).ready(function($) {
             url.searchParams.delete('gm2_filter_type');
             url.searchParams.delete('gm2_simple_operator');
         }
-        
-        // Remove pagination
+
         url.searchParams.delete('paged');
-        
-        // Reload page with new parameters
-        window.location.href = url.toString();
+
+        const data = {
+            action: 'gm2_filter_products',
+            gm2_cat: selectedIds.join(','),
+            gm2_filter_type: filterType,
+            gm2_simple_operator: simpleOperator,
+            gm2_columns: (function() {
+                const match = $('.products').first().attr('class').match(/columns-(\d+)/);
+                return match ? parseInt(match[1], 10) : 0;
+            })()
+        };
+
+        $.post(gm2CategorySort.ajax_url, data, function(response) {
+            if (response.success) {
+                const $newList = $(response.data.html);
+                const $oldList = $('.products').first();
+                $oldList.attr('class', $newList.attr('class'));
+                $oldList.html($newList.html());
+                window.history.replaceState(null, '', url.toString());
+
+                // Re‑initialize Elementor and WooCommerce behaviors
+                if (window.elementorFrontend && elementorFrontend.elementsHandler) {
+                    const $scope = $newList.closest('.elementor-widget');
+                    if ($scope.length) {
+                        elementorFrontend.elementsHandler.runReadyTrigger($scope);
+                    }
+                }
+                $(document.body).trigger('wc_fragment_refresh');
+            }
+        });
     }
     
     // Event delegation for dynamic elements

--- a/gm2-category-sort.php
+++ b/gm2-category-sort.php
@@ -9,6 +9,9 @@
 
 defined('ABSPATH') || exit;
 
+// Plugin version used for cache busting
+define('GM2_CAT_SORT_VERSION', '1.0.1');
+
 // Define plugin constants
 define('GM2_CAT_SORT_PATH', plugin_dir_path(__FILE__));
 define('GM2_CAT_SORT_URL', plugin_dir_url(__FILE__));
@@ -26,10 +29,12 @@ function gm2_category_sort_init() {
     require_once GM2_CAT_SORT_PATH . 'includes/class-enqueuer.php';
     require_once GM2_CAT_SORT_PATH . 'includes/class-query-handler.php';
     require_once GM2_CAT_SORT_PATH . 'includes/class-renderer.php';
+    require_once GM2_CAT_SORT_PATH . 'includes/class-ajax.php';
     
     // Initialize components
     Gm2_Category_Sort_Enqueuer::init();
     Gm2_Category_Sort_Query_Handler::init();
+    Gm2_Category_Sort_Ajax::init();
     
     // Register widget after Elementor is fully loaded
     add_action('elementor/widgets/register', 'gm2_register_widget');

--- a/includes/class-ajax.php
+++ b/includes/class-ajax.php
@@ -1,0 +1,66 @@
+<?php
+class Gm2_Category_Sort_Ajax {
+    public static function init() {
+        add_action('wp_ajax_gm2_filter_products', [__CLASS__, 'filter_products']);
+        add_action('wp_ajax_nopriv_gm2_filter_products', [__CLASS__, 'filter_products']);
+    }
+
+    public static function filter_products() {
+        $term_ids = [];
+        if (!empty($_POST['gm2_cat'])) {
+            $term_ids = array_map('intval', explode(',', $_POST['gm2_cat']));
+        }
+        $filter_type = sanitize_key($_POST['gm2_filter_type'] ?? 'simple');
+        $simple_operator = sanitize_key($_POST['gm2_simple_operator'] ?? 'IN');
+
+        $tax_query = [];
+        if (!empty($term_ids)) {
+            if ($filter_type === 'advanced' && class_exists('Gm2_Category_Sort_Query_Handler')) {
+                $category_query = Gm2_Category_Sort_Query_Handler::build_advanced_query($term_ids);
+            } else {
+                $category_query = [
+                    'taxonomy' => 'product_cat',
+                    'field' => 'term_id',
+                    'terms' => $term_ids,
+                    'operator' => $simple_operator,
+                    'include_children' => true,
+                ];
+            }
+            $tax_query[] = $category_query;
+        }
+
+        $args = [
+            'post_type'      => 'product',
+            'post_status'    => 'publish',
+            'posts_per_page' => wc_get_loop_prop('per_page'),
+            'paged'          => 1,
+            'tax_query'      => $tax_query,
+        ];
+
+        // Respect column settings from the current product archive
+        $columns = isset($_POST['gm2_columns']) ? absint($_POST['gm2_columns']) : 0;
+
+        wc_setup_loop([
+            'columns' => $columns ?: wc_get_loop_prop('columns'),
+        ]);
+
+        $query = new WP_Query($args);
+
+        ob_start();
+        if ($query->have_posts()) {
+            woocommerce_product_loop_start();
+            while ($query->have_posts()) {
+                $query->the_post();
+                wc_get_template_part('content', 'product');
+            }
+            woocommerce_product_loop_end();
+        } else {
+            woocommerce_no_products_found();
+        }
+        wp_reset_postdata();
+        wc_reset_loop();
+
+        $html = ob_get_clean();
+        wp_send_json_success(['html' => $html]);
+    }
+}

--- a/includes/class-enqueuer.php
+++ b/includes/class-enqueuer.php
@@ -16,7 +16,7 @@ class Gm2_Category_Sort_Enqueuer {
             'gm2-category-sort-style',
             GM2_CAT_SORT_URL . 'assets/css/style.css',
             [],
-            '1.0'
+            filemtime(GM2_CAT_SORT_PATH . 'assets/css/style.css')
         );
         
         // JavaScript
@@ -24,8 +24,16 @@ class Gm2_Category_Sort_Enqueuer {
             'gm2-category-sort-script',
             GM2_CAT_SORT_URL . 'assets/js/frontend.js',
             ['jquery'],
-            '1.0',
+            filemtime(GM2_CAT_SORT_PATH . 'assets/js/frontend.js'),
             true
+        );
+
+        wp_localize_script(
+            'gm2-category-sort-script',
+            'gm2CategorySort',
+            [
+                'ajax_url' => admin_url('admin-ajax.php')
+            ]
         );
     }
 }

--- a/includes/class-query-handler.php
+++ b/includes/class-query-handler.php
@@ -52,7 +52,7 @@ class Gm2_Category_Sort_Query_Handler {
         $query->set('tax_query', $tax_query);
     }
     
-    private static function build_advanced_query($term_ids) {
+    public static function build_advanced_query($term_ids) {
         // If only one category is selected, use simple IN query
         if (count($term_ids) === 1) {
             return [

--- a/includes/class-renderer.php
+++ b/includes/class-renderer.php
@@ -21,14 +21,16 @@ class Gm2_Category_Sort_Renderer {
                 <?php $this->render_category_tree(); ?>
             </div>
             
-            <?php if (!empty($this->selected_categories)) : ?>
-            <div class="gm2-selected-header">
+            <?php
+            $has_selected = !empty($this->selected_categories);
+            $style = $has_selected ? '' : 'style="display:none"';
+            ?>
+            <div class="gm2-selected-header" <?= $style ?>>
                 <?= __('Selected Categories:', 'gm2-category-sort') ?>
             </div>
-            <div class="gm2-selected-categories">
-                <?php $this->render_selected_categories(); ?>
+            <div class="gm2-selected-categories" <?= $style ?>>
+                <?php if ($has_selected) $this->render_selected_categories(); ?>
             </div>
-            <?php endif; ?>
         </div>
         <?php
         return ob_get_clean();


### PR DESCRIPTION
## Summary
- keep `.products` element and only replace its inner items
- preserve grid classes to maintain Elementor layout

## Testing
- `php -l gm2-category-sort.php`
- `php -l includes/class-ajax.php`
- `php -l includes/class-enqueuer.php`
- `php -l includes/class-query-handler.php`
- `php -l includes/class-renderer.php`
- `php -l includes/class-widget.php`
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_683f8b57d41483278a0846861c9aa272