### PR TITLE
Add nonce validation for AJAX product filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,9 @@ Gm2 Category Sort adds a product category sorting widget for WooCommerce shops w
 3. Choose optional parent categories and select the filter logic (Simple or Advanced) in the widget settings.
 4. Save the page. On the frontend, shoppers can expand categories and filter the product list.
 
+All AJAX requests use a security nonce. The nonce value is provided to the
+JavaScript as `gm2CategorySort.nonce` and must be sent as the `_ajax_nonce`
+parameter if you customize the request logic.
+
 ## License
 This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -141,6 +141,10 @@ jQuery(document).ready(function($) {
             gm2_paged: page
         };
 
+        if (typeof gm2CategorySort !== 'undefined' && gm2CategorySort.nonce) {
+            data._ajax_nonce = gm2CategorySort.nonce;
+        }
+
       if (typeof gm2CategorySort === 'undefined' || !gm2CategorySort.ajax_url) {
             window.location.href = url.toString();
             return;

--- a/includes/class-ajax.php
+++ b/includes/class-ajax.php
@@ -6,6 +6,7 @@ class Gm2_Category_Sort_Ajax {
     }
 
     public static function filter_products() {
+        check_ajax_referer('gm2_filter_products');
         $term_ids = [];
         if (!empty($_POST['gm2_cat'])) {
             $term_ids = array_map('intval', explode(',', $_POST['gm2_cat']));

--- a/includes/class-enqueuer.php
+++ b/includes/class-enqueuer.php
@@ -28,10 +28,15 @@ class Gm2_Category_Sort_Enqueuer {
             true
         );
 
+        $nonce = wp_create_nonce('gm2_filter_products');
+
         wp_localize_script(
             'gm2-category-sort-script',
             'gm2CategorySort',
-            ['ajax_url' => admin_url('admin-ajax.php')]
+            [
+                'ajax_url' => admin_url('admin-ajax.php'),
+                'nonce'    => $nonce,
+            ]
         );
     }
 }


### PR DESCRIPTION
## Summary
- create gm2_filter_products nonce when enqueuing scripts
- include nonce in AJAX calls
- verify nonce in product filter handler
- document the nonce usage

## Testing
- `php -l includes/class-enqueuer.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840d199e9348327b009f5fa7e759169