### PR TITLE
Add str_contains polyfill and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Gm2 Category Sort adds a product category sorting widget for WooCommerce shops when using Elementor. Visitors can filter products by category through a collapsible tree of categories.
 
 ## Requirements
+- PHP 7.0 or higher
 - WordPress 5.0 or higher
 - [WooCommerce](https://woocommerce.com/)
 - [Elementor](https://elementor.com/)

--- a/gm2-category-sort.php
+++ b/gm2-category-sort.php
@@ -26,6 +26,7 @@ function gm2_category_sort_init() {
     }
     
     // Include non-widget files
+    require_once GM2_CAT_SORT_PATH . 'includes/utilities.php';
     require_once GM2_CAT_SORT_PATH . 'includes/class-enqueuer.php';
     require_once GM2_CAT_SORT_PATH . 'includes/class-query-handler.php';
     require_once GM2_CAT_SORT_PATH . 'includes/class-renderer.php';

--- a/includes/class-ajax.php
+++ b/includes/class-ajax.php
@@ -51,7 +51,7 @@ class Gm2_Category_Sort_Ajax {
          if ( $orderby ) {
             $orderby_value = $orderby;
             $order_dir     = '';
-            if ( str_contains( $orderby, '-' ) ) {
+            if ( gm2_str_contains( $orderby, '-' ) ) {
                 list( $orderby_value, $order_dir ) = array_pad( explode( '-', $orderby ), 2, '' );
             }
 

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Utility functions for Gm2 Category Sort
+ */
+
+if ( ! function_exists( 'gm2_str_contains' ) ) {
+    /**
+     * Polyfill for PHP\u2019s str_contains.
+     *
+     * Uses native str_contains on PHP 8+, otherwise falls back to strpos.
+     *
+     * @param string $haystack Full string to search.
+     * @param string $needle   Substring to look for.
+     * @return bool True if $needle is found within $haystack.
+     */
+    function gm2_str_contains( $haystack, $needle ) {
+        if ( function_exists( 'str_contains' ) ) {
+            return str_contains( $haystack, $needle );
+        }
+
+        return $needle === '' || strpos( $haystack, $needle ) !== false;
+    }
+}


### PR DESCRIPTION
## Summary
- polyfill `str_contains` using a new `gm2_str_contains()` helper
- load the utility file during plugin initialization
- use the new helper in Ajax handler
- document minimum PHP version

## Testing
- `php -l gm2-category-sort.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843176858c883279855ebc5402fef1a