### PR TITLE
Handle AJAX errors with translated message

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -214,8 +214,11 @@ jQuery(document).ready(function($) {
 
                 gm2ReinitArchiveWidget($oldList);
             } else {
+                alert(gm2CategorySort.error_message);
                 window.location.href = url.toString();
             }
+        }).fail(function() {
+            alert(gm2CategorySort.error_message);
         });
     }
 

--- a/includes/class-enqueuer.php
+++ b/includes/class-enqueuer.php
@@ -35,6 +35,7 @@ class Gm2_Category_Sort_Enqueuer {
             [
                 'ajax_url' => admin_url('admin-ajax.php'),
                 'nonce'    => $nonce,
+                'error_message' => __( 'Error loading products. Please refresh the page.', 'gm2-category-sort' ),
             ]
         );
     }


### PR DESCRIPTION
## Summary
- show error alert when product filtering AJAX fails
- translate error message and expose to frontend script

## Testing
- `php -l gm2-category-sort.php` *(fails: php not installed)*


------
https://chatgpt.com/codex/tasks/task_e_68431940bd3083278d02212e83d99331