### PR TITLE
Fix product sorting

### DIFF
--- a/includes/class-ajax.php
+++ b/includes/class-ajax.php
@@ -48,14 +48,8 @@ class Gm2_Category_Sort_Ajax {
             'tax_query'      => $tax_query,
         ];
 
-         if ( $orderby ) {
-            $orderby_value = $orderby;
-            $order_dir     = '';
-            if ( gm2_str_contains( $orderby, '-' ) ) {
-                list( $orderby_value, $order_dir ) = array_pad( explode( '-', $orderby ), 2, '' );
-            }
-
-            $ordering_args = WC()->query->get_catalog_ordering_args( $orderby_value, strtoupper( $order_dir ) );
+        if ( $orderby ) {
+            $ordering_args = gm2_get_orderby_args( $orderby );
             $args          = array_merge( $args, $ordering_args );
         }
 
@@ -107,8 +101,6 @@ class Gm2_Category_Sort_Ajax {
         $pagination = ob_get_clean();
 
         $GLOBALS['wp_query'] = $prev_wp_query;
-
-        WC()->query->remove_ordering_args();
 
         wc_reset_loop();
 

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -21,3 +21,69 @@ if ( ! function_exists( 'gm2_str_contains' ) ) {
         return $needle === '' || strpos( $haystack, $needle ) !== false;
     }
 }
+
+if ( ! function_exists( 'gm2_get_orderby_args' ) ) {
+    /**
+     * Translate WooCommerce orderby values to WP_Query arguments.
+     *
+     * @param string $orderby Orderby string from the request, e.g. "price-desc".
+     * @return array Arguments for WP_Query.
+     */
+    function gm2_get_orderby_args( $orderby ) {
+        $orderby_value = $orderby;
+        $order_dir     = '';
+
+        if ( gm2_str_contains( $orderby, '-' ) ) {
+            list( $orderby_value, $order_dir ) = array_pad( explode( '-', $orderby ), 2, '' );
+        }
+
+        $order_dir = strtoupper( $order_dir );
+        $args      = [];
+
+        switch ( $orderby_value ) {
+            case 'price':
+                $args['meta_key'] = '_price';
+                $args['orderby']  = 'meta_value_num';
+                $args['order']    = $order_dir ? $order_dir : 'ASC';
+                break;
+
+            case 'popularity':
+                $args['meta_key'] = 'total_sales';
+                $args['orderby']  = 'meta_value_num';
+                $args['order']    = 'DESC';
+                break;
+
+            case 'rating':
+                $args['meta_key'] = '_wc_average_rating';
+                $args['orderby']  = 'meta_value_num';
+                $args['order']    = 'DESC';
+                break;
+
+            case 'date':
+                $args['orderby'] = 'date';
+                $args['order']   = $order_dir ? $order_dir : 'DESC';
+                break;
+
+            case 'rand':
+                $args['orderby'] = 'rand';
+                break;
+
+            case 'id':
+                $args['orderby'] = 'ID';
+                $args['order']   = $order_dir ? $order_dir : 'ASC';
+                break;
+
+            case 'title':
+                $args['orderby'] = 'title';
+                $args['order']   = $order_dir ? $order_dir : 'ASC';
+                break;
+
+            default:
+                $args['orderby'] = 'menu_order title';
+                $args['order']   = $order_dir ? $order_dir : 'ASC';
+                break;
+        }
+
+        return $args;
+    }
+}


### PR DESCRIPTION
## Summary
- add helper to build WP_Query order args
- use custom logic for orderby handling in AJAX
- remove dependency on WC_Query filters

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68433acaac6c8327b05a5353bdd1eeeb