### PR TITLE
Add docs for filter_products

### DIFF
--- a/includes/class-ajax.php
+++ b/includes/class-ajax.php
@@ -5,6 +5,23 @@ class Gm2_Category_Sort_Ajax {
         add_action('wp_ajax_nopriv_gm2_filter_products', [__CLASS__, 'filter_products']);
     }
 
+    /**
+     * Handle AJAX requests to filter and sort products.
+     *
+     * Expected POST parameters:
+     * - gm2_cat: comma-separated list of category IDs.
+     * - gm2_filter_type: "simple" or "advanced" filtering mode.
+     * - gm2_simple_operator: tax query operator for simple mode.
+     * - gm2_paged: current page number.
+     * - gm2_per_page: number of products per page.
+     * - orderby: orderby string for sorting products.
+     * - gm2_columns: number of columns in the product loop.
+     *
+     * Sends a JSON response with the rendered product HTML, result count and
+     * pagination for the filtered and sorted products.
+     *
+     * @return void
+     */
     public static function filter_products() {
         check_ajax_referer('gm2_filter_products', 'gm2_nonce');
 


### PR DESCRIPTION
## Summary
- document parameters for filter_products AJAX handler

## Testing
- `php -l includes/class-ajax.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68434ae1276883279c7af70e7c5a6f78