### PR TITLE
Add loading overlay for AJAX operations

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -130,3 +130,31 @@
     color: #888;
     font-style: italic;
 }
+
+/* Loading overlay */
+#gm2-loading-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(255, 255, 255, 0.6);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 9999;
+}
+
+#gm2-loading-overlay .gm2-spinner {
+    border: 4px solid #f3f3f3;
+    border-top: 4px solid #555;
+    border-radius: 50%;
+    width: 40px;
+    height: 40px;
+    animation: gm2-spin 1s linear infinite;
+}
+
+@keyframes gm2-spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,4 +1,16 @@
 jQuery(document).ready(function($) {
+    // Add loading overlay to the page
+    if (!$('#gm2-loading-overlay').length) {
+        $('body').append('<div id="gm2-loading-overlay"><div class="gm2-spinner"></div></div>');
+    }
+
+    function gm2ShowLoading() {
+        $('#gm2-loading-overlay').show();
+    }
+
+    function gm2HideLoading() {
+        $('#gm2-loading-overlay').hide();
+    }
     // Expand/collapse functionality for all levels
     $(document).on('click', '.gm2-expand-button', function() {
         const $button = $(this);
@@ -156,7 +168,7 @@ jQuery(document).ready(function($) {
             window.location.href = url.toString();
             return;
         }
-        
+        gm2ShowLoading();
         $.post(gm2CategorySort.ajax_url, data, function(response) {
             if (typeof response === 'string') {
                 try {
@@ -219,6 +231,8 @@ jQuery(document).ready(function($) {
             }
         }).fail(function() {
             alert(gm2CategorySort.error_message);
+        }).always(function() {
+            gm2HideLoading();
         });
     }
 


### PR DESCRIPTION
## Summary
- show a full page spinner overlay while products load via AJAX

## Testing
- `npm test --silent` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_684469c7fe5c8327a7a149ea024cf436