### PR TITLE
Fix message when filter returns no products

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -131,6 +131,16 @@
     font-style: italic;
 }
 
+/* Message shown when no products match the filter */
+.gm2-no-products {
+    padding: 15px;
+    text-align: center;
+    color: #888;
+    font-style: italic;
+    list-style: none;
+    width: 100%;
+}
+
 /* Loading overlay */
 #gm2-loading-overlay {
     position: fixed;

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -185,7 +185,23 @@ jQuery(document).ready(function($) {
                     $newList = $response.find('ul.products').first();
                 }
                 if (!$newList.length) {
-                    window.location.href = url.toString();
+                    let message = $response.filter('.woocommerce-info').first().text();
+                    if (!message) {
+                        message = 'No Products Found';
+                    }
+                    $oldList.attr('class', 'products');
+                    $oldList.html('<li class="gm2-no-products">' + message + '</li>');
+
+                    const $existingNav = $('.woocommerce-pagination').first();
+                    if ($existingNav.length) {
+                        $existingNav.remove();
+                    }
+                    const $existingCount = $('.woocommerce-result-count').first();
+                    if ($existingCount.length) {
+                        $existingCount.remove();
+                    }
+                    window.history.replaceState(null, '', url.toString());
+                    gm2ReinitArchiveWidget($oldList);
                     return;
                 }
 


### PR DESCRIPTION
## Summary
- display a friendly message when category filtering returns no results
- style the message

## Testing
- `npm test` *(fails: ENOENT no package.json)*
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684890d75f908327a6b192ca0c447343