### PR TITLE
Fix layout reset after zero product filter

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -131,6 +131,16 @@
     font-style: italic;
 }
 
+/* Message shown when no products match the filter */
+.gm2-no-products {
+    padding: 15px;
+    text-align: center;
+    color: #888;
+    font-style: italic;
+    list-style: none;
+    width: 100%;
+}
+
 /* Loading overlay */
 #gm2-loading-overlay {
     position: fixed;

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -4,12 +4,41 @@ jQuery(document).ready(function($) {
         $('body').append('<div id="gm2-loading-overlay"><div class="gm2-spinner"></div></div>');
     }
 
+    const $initialList = $('ul.products').first();
+    if ($initialList.length) {
+        $initialList.data('original-classes', $initialList.attr('class'));
+    }
+
     function gm2ShowLoading() {
         $('#gm2-loading-overlay').addClass('gm2-visible');
     }
 
     function gm2HideLoading() {
         $('#gm2-loading-overlay').removeClass('gm2-visible');
+    }
+
+    function gm2DisplayNoProducts($list, url, message) {
+        if (!message) {
+            message = 'No Products Found';
+        }
+        if (!$list.data('original-classes')) {
+            $list.data('original-classes', $list.attr('class'));
+        }
+        const original = $list.data('original-classes') || $list.attr('class');
+        $list.attr('class', original);
+        $list.html('<li class="gm2-no-products">' + message + '</li>');
+
+        const $existingNav = $('.woocommerce-pagination').first();
+        if ($existingNav.length) {
+            $existingNav.remove();
+        }
+        const $existingCount = $('.woocommerce-result-count').first();
+        if ($existingCount.length) {
+            $existingCount.remove();
+        }
+
+        window.history.replaceState(null, '', url.toString());
+        gm2ReinitArchiveWidget($list);
     }
     // Expand/collapse functionality for all levels
     $(document).on('click', '.gm2-expand-button', function() {
@@ -133,7 +162,8 @@ jQuery(document).ready(function($) {
             }
         }
 
-        const match = $oldList.attr('class').match(/columns-(\d+)/);
+        const originalClasses = $oldList.data('original-classes') || $oldList.attr('class');
+        const match = originalClasses.match(/columns-(\d+)/);
         if (match) {
             columns = parseInt(match[1], 10);
         }
@@ -178,18 +208,20 @@ jQuery(document).ready(function($) {
                 }
             }
 
-            if (response && response.success && response.data && response.data.html) {
-                const $response = $(response.data.html);
+            if (response && response.success) {
+                const html = response.data && response.data.html ? response.data.html : '';
+                const $response = $(html);
                 let $newList = $response.filter('ul.products').first();
                 if (!$newList.length) {
                     $newList = $response.find('ul.products').first();
                 }
                 if (!$newList.length) {
-                    window.location.href = url.toString();
+                    let message = $response.filter('.woocommerce-info').first().text();
+                    gm2DisplayNoProducts($oldList, url, message);
                     return;
                 }
 
-                let oldClasses = $oldList.attr('class') || '';
+                let oldClasses = $oldList.data('original-classes') || $oldList.attr('class') || '';
                 const newClasses = $newList.attr('class') || '';
 
                 oldClasses = oldClasses.replace(/columns-\d+/g, '').trim();
@@ -198,6 +230,7 @@ jQuery(document).ready(function($) {
                     oldClasses += ' ' + columnMatch[0];
                 }
                 $oldList.attr('class', oldClasses.trim());
+                $oldList.data('original-classes', $oldList.attr('class'));
 
                 $oldList.html($newList.html());
 
@@ -206,6 +239,13 @@ jQuery(document).ready(function($) {
                     const $existingCount = $('.woocommerce-result-count').first();
                     if ($existingCount.length) {
                         $existingCount.replaceWith($(response.data.count));
+                    } else {
+                        const $ordering = $('.woocommerce-ordering').first();
+                        if ($ordering.length) {
+                            $ordering.before($(response.data.count));
+                        } else {
+                            $oldList.before($(response.data.count));
+                        }
                     }
                 }
 
@@ -226,11 +266,10 @@ jQuery(document).ready(function($) {
 
                 gm2ReinitArchiveWidget($oldList);
             } else {
-                alert(gm2CategorySort.error_message);
-                window.location.href = url.toString();
+                gm2DisplayNoProducts($oldList, url);
             }
         }).fail(function() {
-            alert(gm2CategorySort.error_message);
+            gm2DisplayNoProducts($oldList, url);
         }).always(function() {
             gm2HideLoading();
         });

--- a/gm2-category-sort.php
+++ b/gm2-category-sort.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Gm2 Category Sort
  * Description: Adds a collapsible category filter widget for WooCommerce products in Elementor.
- * Version: 1.0.8
+ * Version: 1.0.13
  * Author: ProjectsGm2
  * Text Domain: gm2-category-sort
  */
@@ -10,7 +10,7 @@
 defined('ABSPATH') || exit;
 
 // Plugin version used for cache busting
-define('GM2_CAT_SORT_VERSION', '1.0.8');
+define('GM2_CAT_SORT_VERSION', '1.0.13');
 
 // Define plugin constants
 define('GM2_CAT_SORT_PATH', plugin_dir_path(__FILE__));


### PR DESCRIPTION
## Summary
- restore the original product list classes when showing the `No Products Found` notice so the grid returns to normal on the next load
- bump plugin version for cache busting
- ensure the result count element is re-added if it was removed

## Testing
- `npm test` *(fails: could not read package.json)*
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684890d75f908327a6b192ca0c447343