### PR TITLE
Enable auto scroll after product filtering

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -17,6 +17,13 @@ jQuery(document).ready(function($) {
         $('#gm2-loading-overlay').removeClass('gm2-visible');
     }
 
+    function gm2ScrollToProductList() {
+        const $list = $('ul.products').first();
+        if ($list.length) {
+            $('html, body').animate({ scrollTop: $list.offset().top }, 300);
+        }
+    }
+
     function gm2DisplayNoProducts($list, url, message) {
         if (!message) {
             message = 'No Products Found';
@@ -272,6 +279,7 @@ jQuery(document).ready(function($) {
             gm2DisplayNoProducts($oldList, url);
         }).always(function() {
             gm2HideLoading();
+            gm2ScrollToProductList();
         });
     }
 


### PR DESCRIPTION
## Summary
- enable scrolling to product list after AJAX filtering

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6848b016ed8c8327bdd89cb51c957a35