### PR TITLE
Convert category names to links

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -70,7 +70,16 @@ jQuery(document).ready(function($) {
         }
     });
 
-    function gm2HandleCategoryClick() {
+    function gm2HandleCategoryClick(e) {
+        // Prevent normal navigation so category filters run via AJAX
+        if (e && typeof e.preventDefault === 'function') {
+            e.preventDefault();
+            if (typeof e.stopImmediatePropagation === 'function') {
+                e.stopImmediatePropagation();
+            } else if (typeof e.stopPropagation === 'function') {
+                e.stopPropagation();
+            }
+        }
         const $widget = $(this).closest('.gm2-category-sort');
         const termId = $(this).data('term-id');
         const isSelected = $(this).hasClass('selected');
@@ -84,6 +93,7 @@ jQuery(document).ready(function($) {
         
         gm2RefreshSelectedList($widget);
         gm2UpdateProductFiltering($widget, 1);
+        return false;
     }
     
     function gm2HandleRemoveClick(e) {

--- a/includes/class-renderer.php
+++ b/includes/class-renderer.php
@@ -77,7 +77,12 @@ class Gm2_Category_Sort_Renderer {
         echo $indent;
         
         echo '<div class="gm2-category-name-container">';
-        echo '<div class="gm2-category-name ' . $selected_class . '" data-term-id="' . esc_attr($term->term_id) . '">' . esc_html($term->name) . '</div>';
+        $href = add_query_arg([
+            'gm2_cat' => $term->term_id,
+            'gm2_filter_type' => $this->settings['filter_type'],
+            'gm2_simple_operator' => $this->settings['simple_operator'] ?? 'IN',
+        ]);
+        echo '<a class="gm2-category-name ' . $selected_class . '" data-term-id="' . esc_attr($term->term_id) . '" href="' . esc_url($href) . '">' . esc_html($term->name) . '</a>';
         
         if ($has_children) {
             echo '<button class="gm2-expand-button" data-expanded="false">+</button>';


### PR DESCRIPTION
## Summary
- output category names as anchor tags
- include gm2 query parameters in each category link
- prevent default navigation for category links

## Testing
- `php -l includes/class-renderer.php` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6849f5d847448327b3e122ca3ea8c8b8