### PR TITLE
Add canonical tag output when category filter active

### DIFF
--- a/gm2-category-sort.php
+++ b/gm2-category-sort.php
@@ -34,11 +34,13 @@ function gm2_category_sort_init() {
     require_once GM2_CAT_SORT_PATH . 'includes/class-query-handler.php';
     require_once GM2_CAT_SORT_PATH . 'includes/class-renderer.php';
     require_once GM2_CAT_SORT_PATH . 'includes/class-ajax.php';
+    require_once GM2_CAT_SORT_PATH . 'includes/class-canonical.php';
     
     // Initialize components
     Gm2_Category_Sort_Enqueuer::init();
     Gm2_Category_Sort_Query_Handler::init();
     Gm2_Category_Sort_Ajax::init();
+    Gm2_Category_Sort_Canonical::init();
     
     // Register widget for both modern and legacy Elementor hooks
     add_action('elementor/widgets/register', 'gm2_register_widget');

--- a/includes/class-canonical.php
+++ b/includes/class-canonical.php
@@ -1,0 +1,35 @@
+<?php
+class Gm2_Category_Sort_Canonical {
+    public static function init() {
+        add_action('wp_head', [__CLASS__, 'maybe_output_canonical']);
+    }
+
+    public static function maybe_output_canonical() {
+        if (!self::has_filter_params()) {
+            return;
+        }
+
+        $canonical = '';
+        if (is_product_taxonomy()) {
+            $term = get_queried_object();
+            if ($term && !is_wp_error($term)) {
+                $canonical = get_term_link($term);
+            }
+        } elseif (function_exists('wc_get_page_permalink')) {
+            $canonical = wc_get_page_permalink('shop');
+        }
+
+        if ($canonical) {
+            echo '<link rel="canonical" href="' . esc_url($canonical) . '" />\n';
+        }
+    }
+
+    private static function has_filter_params() {
+        foreach (['gm2_cat', 'gm2_filter_type', 'gm2_simple_operator'] as $key) {
+            if (isset($_GET[$key])) {
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
- output a canonical link when gm2 filter params are present
- load the canonical handler during plugin init

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a06f87bf88327bbc2d6d5f4c2159b