### PR TITLE
Improve category tree semantic markup

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -8,11 +8,15 @@
 .gm2-parent-categories-container {
     display: block;
     width: 100%;
+    list-style: none;
+    margin: 0;
+    padding: 0;
 }
 
 .gm2-category-node {
     width: 100%;
     margin-bottom: 5px;
+    list-style: none;
 }
 
 .gm2-category-header {
@@ -73,6 +77,7 @@
     padding-left: 30px;
     border-left: 1px dashed #e0e0e0;
     margin-left: 10px;
+    list-style: none;
 }
 
 /* Existing styles */

--- a/includes/class-renderer.php
+++ b/includes/class-renderer.php
@@ -19,9 +19,9 @@ class Gm2_Category_Sort_Renderer {
              data-columns="<?= esc_attr(wc_get_loop_prop('columns')) ?>"
              data-per-page="<?= esc_attr(wc_get_loop_prop('per_page')) ?>">
              
-            <div class="gm2-category-tree">
+            <nav class="gm2-category-tree">
                 <?php $this->render_category_tree(); ?>
-            </div>
+            </nav>
             
             <?php
             $has_selected = !empty($this->selected_categories);
@@ -48,13 +48,13 @@ class Gm2_Category_Sort_Renderer {
             return;
         }
         
-        echo '<div class="gm2-parent-categories-container">';
+        echo '<ul class="gm2-parent-categories-container">';
         foreach ($roots as $root) {
             if (is_wp_error($root) || !is_object($root)) continue;
-            
+
             $this->render_category_node($root, 0);
         }
-        echo '</div>';
+        echo '</ul>';
     }
     
     private function render_category_node($term, $depth) {
@@ -69,7 +69,7 @@ class Gm2_Category_Sort_Renderer {
         $is_selected = in_array($term->term_id, $this->selected_categories);
         $selected_class = $is_selected ? 'selected' : '';
         
-        echo '<div class="gm2-category-node">';
+        echo '<li class="gm2-category-node">';
         echo '<div class="gm2-category-header">';
         
         // Add indentation for child nodes
@@ -92,14 +92,14 @@ class Gm2_Category_Sort_Renderer {
         
         if ($has_children) {
             // Only show immediate children, grandchildren should be hidden
-            echo '<div class="gm2-child-categories" style="display:none">';
+            echo '<ul class="gm2-child-categories" style="display:none">';
             foreach ($children as $child) {
                 // Render child node at next depth level
                 $this->render_category_node($child, $depth + 1);
             }
-            echo '</div>';
+            echo '</ul>';
         }
-        echo '</div>';
+        echo '</li>';
     }
     
     private function render_selected_categories() {


### PR DESCRIPTION
## Summary
- render category tree using `<nav>` wrapper
- use nested `<ul>`/`<li>` instead of `<div>` containers
- update styles for new list structure

## Testing
- `php -l includes/class-renderer.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a0c5738c48327aaccf1046024f062