### PR TITLE
Add schema output for category tree

### DIFF
--- a/gm2-category-sort.php
+++ b/gm2-category-sort.php
@@ -35,6 +35,7 @@ function gm2_category_sort_init() {
     require_once GM2_CAT_SORT_PATH . 'includes/class-renderer.php';
     require_once GM2_CAT_SORT_PATH . 'includes/class-ajax.php';
     require_once GM2_CAT_SORT_PATH . 'includes/class-canonical.php';
+    require_once GM2_CAT_SORT_PATH . 'includes/class-schema.php';
     
     // Initialize components
     Gm2_Category_Sort_Enqueuer::init();

--- a/includes/class-renderer.php
+++ b/includes/class-renderer.php
@@ -40,7 +40,11 @@ class Gm2_Category_Sort_Renderer {
     
     private function render_category_tree() {
         $roots = $this->get_root_categories();
-        
+
+        if ( class_exists( 'Gm2_Category_Sort_Schema' ) ) {
+            Gm2_Category_Sort_Schema::set_categories( $roots );
+        }
+
         if (empty($roots)) {
             echo '<div class="gm2-no-categories">';
             echo __('No categories found.', 'gm2-category-sort');

--- a/includes/class-schema.php
+++ b/includes/class-schema.php
@@ -1,0 +1,55 @@
+<?php
+class Gm2_Category_Sort_Schema {
+    private static $schema_data = null;
+
+    /**
+     * Store categories and hook output in wp_head.
+     *
+     * @param array $categories Array of WP_Term objects.
+     */
+    public static function set_categories( $categories ) {
+        self::$schema_data = self::build_schema( $categories );
+        if ( ! has_action( 'wp_head', [ __CLASS__, 'output_schema' ] ) ) {
+            add_action( 'wp_head', [ __CLASS__, 'output_schema' ] );
+        }
+    }
+
+    /**
+     * Build ItemList schema data from terms.
+     *
+     * @param array $categories Array of WP_Term objects.
+     * @return array Schema data.
+     */
+    public static function build_schema( $categories ) {
+        $items    = [];
+        $position = 1;
+        foreach ( $categories as $cat ) {
+            if ( ! $cat || is_wp_error( $cat ) ) {
+                continue;
+            }
+            $items[] = [
+                '@type'   => 'ListItem',
+                'position'=> $position++,
+                'name'    => $cat->name,
+                'id'      => $cat->term_id,
+            ];
+        }
+
+        return [
+            '@context'        => 'https://schema.org',
+            '@type'           => 'ItemList',
+            'itemListElement' => $items,
+        ];
+    }
+
+    /**
+     * Echo the JSON-LD schema.
+     */
+    public static function output_schema() {
+        if ( empty( self::$schema_data ) ) {
+            return;
+        }
+        echo '<script type="application/ld+json">' . wp_json_encode( self::$schema_data ) . '</script>' . "\n";
+        self::$schema_data = null;
+    }
+}


### PR DESCRIPTION
## Summary
- generate JSON-LD ItemList from categories
- echo schema in `wp_head` when widget renders

## Testing
- `php -l gm2-category-sort.php`
- `php -l includes/class-schema.php`
- `php -l includes/class-renderer.php`


------
https://chatgpt.com/codex/tasks/task_e_684a0efecc2c83279eb6eb3f53832d7f