### PR TITLE
Add sitemap generation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ accepted. You may also append `-asc` or `-desc` to control direction when
 applicable. These values are translated to `WP_Query` parameters through the
 `gm2_get_orderby_args` helper, so the AJAX output matches the chosen order.
 
+## Sitemap
+
+Run `wp gm2-category-sort sitemap` from the command line to regenerate a
+sitemap of category combinations. The file is saved to
+`wp-content/uploads/gm2-category-sort-sitemap.xml`. You can submit this URL to
+search engines for indexing.
+
 ## Security
 AJAX filtering uses a nonce exposed to JavaScript as `gm2CategorySort.nonce`.
 If you customize the script, include this value in your requests.

--- a/gm2-category-sort.php
+++ b/gm2-category-sort.php
@@ -36,12 +36,14 @@ function gm2_category_sort_init() {
     require_once GM2_CAT_SORT_PATH . 'includes/class-ajax.php';
     require_once GM2_CAT_SORT_PATH . 'includes/class-canonical.php';
     require_once GM2_CAT_SORT_PATH . 'includes/class-schema.php';
+    require_once GM2_CAT_SORT_PATH . 'includes/class-sitemap.php';
     
     // Initialize components
     Gm2_Category_Sort_Enqueuer::init();
     Gm2_Category_Sort_Query_Handler::init();
     Gm2_Category_Sort_Ajax::init();
     Gm2_Category_Sort_Canonical::init();
+    Gm2_Category_Sort_Sitemap::register_cli();
     
     // Register widget for both modern and legacy Elementor hooks
     add_action('elementor/widgets/register', 'gm2_register_widget');

--- a/includes/class-sitemap.php
+++ b/includes/class-sitemap.php
@@ -1,0 +1,78 @@
+<?php
+class Gm2_Category_Sort_Sitemap {
+
+    /**
+     * Generate sitemap XML file for category filter combinations.
+     *
+     * @return string Path to the generated sitemap file.
+     */
+    public static function generate() {
+        $terms = get_terms([
+            'taxonomy'   => 'product_cat',
+            'hide_empty' => false,
+        ]);
+
+        if (is_wp_error($terms) || empty($terms)) {
+            return '';
+        }
+
+        $shop_url = function_exists('wc_get_page_permalink')
+            ? wc_get_page_permalink('shop')
+            : home_url('/');
+
+        $urls     = [];
+        $term_ids = [];
+        foreach ($terms as $term) {
+            $term_ids[] = $term->term_id;
+            $urls[]     = add_query_arg(
+                ['gm2_cat' => $term->term_id],
+                $shop_url
+            );
+        }
+
+        $count = count($term_ids);
+        for ($i = 0; $i < $count; $i++) {
+            for ($j = $i + 1; $j < $count; $j++) {
+                $urls[] = add_query_arg([
+                    'gm2_cat'        => $term_ids[$i] . ',' . $term_ids[$j],
+                    'gm2_filter_type'=> 'advanced',
+                ], $shop_url);
+            }
+        }
+
+        $xml = new SimpleXMLElement(
+            '<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>'
+        );
+        foreach ($urls as $loc) {
+            $url = $xml->addChild('url');
+            $url->addChild('loc', esc_url_raw($loc));
+        }
+
+        $upload_dir = wp_upload_dir();
+        $file       = trailingslashit($upload_dir['basedir']) . 'gm2-category-sort-sitemap.xml';
+        $xml->asXML($file);
+
+        return $file;
+    }
+
+    /**
+     * Register WP-CLI command for generating the sitemap.
+     */
+    public static function register_cli() {
+        if (defined('WP_CLI') && WP_CLI) {
+            \WP_CLI::add_command('gm2-category-sort sitemap', [__CLASS__, 'cli_generate']);
+        }
+    }
+
+    /**
+     * Handle WP-CLI sitemap generation.
+     */
+    public static function cli_generate() {
+        $file = self::generate();
+        if ($file) {
+            \WP_CLI::success("Sitemap generated at: $file");
+        } else {
+            \WP_CLI::error('Failed to generate sitemap.');
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- generate XML sitemap for category combinations
- expose `gm2-category-sort sitemap` WP‑CLI command
- document the sitemap URL

## Testing
- `php -l includes/class-sitemap.php`
- `php -l gm2-category-sort.php`

------
https://chatgpt.com/codex/tasks/task_e_684a0fd770888327be2c6c25cf36044a