### PR TITLE
Add sitemap generation button

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ accepted. You may also append `-asc` or `-desc` to control direction when
 applicable. These values are translated to `WP_Query` parameters through the
 `gm2_get_orderby_args` helper, so the AJAX output matches the chosen order.
 
+## Sitemap
+
+Administrators can edit any page containing the **GM2 Category Sort** widget and
+use the **Generate Sitemap** button found in the widget's settings panel to
+create or update the sitemap of category combinations. The file is saved to
+`wp-content/uploads/gm2-category-sort-sitemap.xml`. Submit this URL to search
+engines for indexing.
+
 ## Security
 AJAX filtering uses a nonce exposed to JavaScript as `gm2CategorySort.nonce`.
 If you customize the script, include this value in your requests.

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -181,3 +181,9 @@
     0% { transform: rotate(0deg); }
     100% { transform: rotate(360deg); }
 }
+
+/* Hide sitemap button in the preview */
+.elementor-widget-gm2-category-sort .gm2-generate-sitemap {
+    display: none;
+}
+

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -362,4 +362,28 @@ jQuery(document).ready(function($) {
     $(document).on('submit', 'form.woocommerce-ordering', function(e) {
         e.preventDefault();
     });
+
+    // Generate sitemap via AJAX
+    $(document).on('click', '.gm2-generate-sitemap', function(e) {
+        e.preventDefault();
+        const $btn = $(this);
+        const nonce = $btn.data('nonce') || (gm2CategorySort.sitemap_nonce || '');
+        $btn.prop('disabled', true);
+        gm2ShowLoading();
+        $.post(gm2CategorySort.ajax_url, {
+            action: 'gm2_generate_sitemap',
+            nonce: nonce
+        }, function(resp) {
+            if (resp && resp.success) {
+                alert(gm2CategorySort.sitemap_success || 'Sitemap generated');
+            } else {
+                alert(gm2CategorySort.error_message);
+            }
+        }).fail(function() {
+            alert(gm2CategorySort.error_message);
+        }).always(function() {
+            $btn.prop('disabled', false);
+            gm2HideLoading();
+        });
+    });
 });

--- a/gm2-category-sort.php
+++ b/gm2-category-sort.php
@@ -36,12 +36,14 @@ function gm2_category_sort_init() {
     require_once GM2_CAT_SORT_PATH . 'includes/class-ajax.php';
     require_once GM2_CAT_SORT_PATH . 'includes/class-canonical.php';
     require_once GM2_CAT_SORT_PATH . 'includes/class-schema.php';
+    require_once GM2_CAT_SORT_PATH . 'includes/class-sitemap.php';
     
     // Initialize components
     Gm2_Category_Sort_Enqueuer::init();
     Gm2_Category_Sort_Query_Handler::init();
     Gm2_Category_Sort_Ajax::init();
     Gm2_Category_Sort_Canonical::init();
+    Gm2_Category_Sort_Sitemap::init();
     
     // Register widget for both modern and legacy Elementor hooks
     add_action('elementor/widgets/register', 'gm2_register_widget');

--- a/includes/class-enqueuer.php
+++ b/includes/class-enqueuer.php
@@ -3,11 +3,12 @@ class Gm2_Category_Sort_Enqueuer {
     
     public static function init() {
         add_action('wp_enqueue_scripts', [__CLASS__, 'enqueue_assets']);
+        add_action('elementor/editor/after_enqueue_scripts', [__CLASS__, 'enqueue_editor_assets']);
     }
-    
-    public static function enqueue_assets() {
-        // Don't enqueue in the admin area unless doing AJAX
-        if (is_admin() && !wp_doing_ajax()) {
+
+    public static function enqueue_assets($force = false) {
+        // Don't enqueue in the admin area unless doing AJAX or forced (Elementor editor)
+        if (!$force && is_admin() && !wp_doing_ajax()) {
             return;
         }
         
@@ -29,15 +30,22 @@ class Gm2_Category_Sort_Enqueuer {
         );
 
         $nonce = wp_create_nonce('gm2_filter_products');
+        $sitemap_nonce = wp_create_nonce('gm2_generate_sitemap');
         wp_localize_script(
             'gm2-category-sort-script',
             'gm2CategorySort',
             [
                 'ajax_url' => admin_url('admin-ajax.php'),
                 'nonce'    => $nonce,
-                'error_message' => __( 'Error loading products. Please refresh the page.', 'gm2-category-sort' ),
+                'sitemap_nonce'   => $sitemap_nonce,
+                'sitemap_success' => __( 'Sitemap generated successfully.', 'gm2-category-sort' ),
+                'error_message'   => __( 'Error loading products. Please refresh the page.', 'gm2-category-sort' ),
             ]
         );
+    }
+
+    public static function enqueue_editor_assets() {
+        self::enqueue_assets(true);
     }
 }
 

--- a/includes/class-sitemap.php
+++ b/includes/class-sitemap.php
@@ -1,0 +1,105 @@
+<?php
+class Gm2_Category_Sort_Sitemap {
+
+    /**
+     * Generate sitemap XML file for category filter combinations.
+     *
+     * @return string Path to the generated sitemap file.
+     */
+    public static function generate() {
+        $terms = get_terms([
+            'taxonomy'   => 'product_cat',
+            'hide_empty' => false,
+        ]);
+
+        if (is_wp_error($terms) || empty($terms)) {
+            return '';
+        }
+
+        $shop_url = function_exists('wc_get_page_permalink')
+            ? wc_get_page_permalink('shop')
+            : home_url('/');
+
+        $urls     = [];
+        $term_ids = [];
+        foreach ($terms as $term) {
+            $term_ids[] = $term->term_id;
+            $urls[]     = add_query_arg(
+                ['gm2_cat' => $term->term_id],
+                $shop_url
+            );
+        }
+
+        $count = count($term_ids);
+        for ($i = 0; $i < $count; $i++) {
+            for ($j = $i + 1; $j < $count; $j++) {
+                $urls[] = add_query_arg([
+                    'gm2_cat'        => $term_ids[$i] . ',' . $term_ids[$j],
+                    'gm2_filter_type'=> 'advanced',
+                ], $shop_url);
+            }
+        }
+
+        $xml = new SimpleXMLElement(
+            '<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>'
+        );
+        foreach ($urls as $loc) {
+            $url = $xml->addChild('url');
+            $url->addChild('loc', esc_url_raw($loc));
+        }
+
+        $upload_dir = wp_upload_dir();
+        $file       = trailingslashit($upload_dir['basedir']) . 'gm2-category-sort-sitemap.xml';
+        $xml->asXML($file);
+
+        return $file;
+    }
+
+    /**
+     * Initialize sitemap functionality.
+     *
+     * Registers CLI and AJAX handlers.
+     */
+    public static function init() {
+        self::register_cli();
+        add_action('wp_ajax_gm2_generate_sitemap', [__CLASS__, 'ajax_generate']);
+    }
+
+    /**
+     * Register WP-CLI command for generating the sitemap.
+     */
+    public static function register_cli() {
+        if (defined('WP_CLI') && WP_CLI) {
+            \WP_CLI::add_command('gm2-category-sort sitemap', [__CLASS__, 'cli_generate']);
+        }
+    }
+
+    /**
+     * Handle WP-CLI sitemap generation.
+     */
+    public static function cli_generate() {
+        $file = self::generate();
+        if ($file) {
+            \WP_CLI::success("Sitemap generated at: $file");
+        } else {
+            \WP_CLI::error('Failed to generate sitemap.');
+        }
+    }
+
+    /**
+     * Handle AJAX sitemap generation.
+     */
+    public static function ajax_generate() {
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error('unauthorized');
+        }
+
+        check_ajax_referer('gm2_generate_sitemap', 'nonce');
+        $file = self::generate();
+        if ($file) {
+            wp_send_json_success(['file' => $file]);
+        }
+
+        wp_send_json_error('failed');
+    }
+}

--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -93,6 +93,22 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
         ]);
         
         $this->end_controls_section();
+
+        if ( current_user_can( 'manage_options' ) ) {
+            $this->start_controls_section( 'gm2_tools_section', [
+                'label' => __( 'Tools', 'gm2-category-sort' ),
+                'tab'   => \Elementor\Controls_Manager::TAB_CONTENT,
+            ] );
+
+            $this->add_control( 'gm2_generate_sitemap', [
+                'type'            => \Elementor\Controls_Manager::RAW_HTML,
+                'raw'             => '<button type="button" class="gm2-generate-sitemap button" data-nonce="' . esc_attr( wp_create_nonce( 'gm2_generate_sitemap' ) ) . '">' . esc_html__( 'Generate Sitemap', 'gm2-category-sort' ) . '</button>',
+                'content_classes' => 'gm2-sitemap-tools',
+                'label_block'     => false,
+            ] );
+
+            $this->end_controls_section();
+        }
     }
     
     private function get_product_categories() {


### PR DESCRIPTION
## Summary
- create sitemap generation button for admins
- handle AJAX request to generate sitemap
- localize nonce for sitemap generation
- document sitemap location and usage
- hide the sitemap button from the widget preview

## Testing
- `php -l includes/class-sitemap.php` *(fails: command not found)*
- `php -l includes/class-renderer.php` *(fails: command not found)*
- `php -l includes/class-enqueuer.php` *(fails: command not found)*
- `php -l gm2-category-sort.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a0fd770888327be2c6c25cf36044a