### PR TITLE
Return sitemap URL from ajax

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -375,7 +375,15 @@ jQuery(document).ready(function($) {
             nonce: nonce
         }, function(resp) {
             if (resp && resp.success) {
-                alert(gm2CategorySort.sitemap_success || 'Sitemap generated');
+                if (resp.data && resp.data.url) {
+                    const url = resp.data.url;
+                    if (navigator.clipboard && window.isSecureContext) {
+                        navigator.clipboard.writeText(url).catch(function() {});
+                    }
+                    alert((gm2CategorySort.sitemap_success || 'Sitemap generated') + '\n' + url);
+                } else {
+                    alert(gm2CategorySort.sitemap_success || 'Sitemap generated');
+                }
             } else {
                 alert(gm2CategorySort.error_message);
             }

--- a/includes/class-sitemap.php
+++ b/includes/class-sitemap.php
@@ -97,7 +97,12 @@ class Gm2_Category_Sort_Sitemap {
         check_ajax_referer('gm2_generate_sitemap', 'nonce');
         $file = self::generate();
         if ($file) {
-            wp_send_json_success(['file' => $file]);
+            $upload_dir = wp_upload_dir();
+            $url = trailingslashit($upload_dir['baseurl']) . basename($file);
+            wp_send_json_success([
+                'file' => $file,
+                'url'  => $url,
+            ]);
         }
 
         wp_send_json_error('failed');


### PR DESCRIPTION
## Summary
- return public sitemap URL when generating sitemap via AJAX
- alert and copy URL to clipboard after successful sitemap generation

## Testing
- `npm test` *(fails: package.json missing)*
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684a2656a3c08327970e868afe23752e