### PR TITLE
Add daily sitemap cron

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ applicable. These values are translated to `WP_Query` parameters through the
 Administrators can edit any page containing the **GM2 Category Sort** widget and
 use the **Generate Sitemap** button found in the widget's settings panel to
 create or update the sitemap of category combinations. The file is saved to
-`wp-content/uploads/gm2-category-sort-sitemap.xml`. Submit this URL to search
-engines for indexing.
+`wp-content/uploads/gm2-category-sort-sitemap.xml` and is also regenerated
+automatically once per day via WP&nbsp;Cron. Submit this URL to search engines
+for indexing.
 
 ## Security
 AJAX filtering uses a nonce exposed to JavaScript as `gm2CategorySort.nonce`.

--- a/gm2-category-sort.php
+++ b/gm2-category-sort.php
@@ -15,6 +15,23 @@ define('GM2_CAT_SORT_VERSION', '1.0.13');
 // Define plugin constants
 define('GM2_CAT_SORT_PATH', plugin_dir_path(__FILE__));
 define('GM2_CAT_SORT_URL', plugin_dir_url(__FILE__));
+define('GM2_CAT_SORT_CRON_HOOK', 'gm2_category_sort_generate_sitemap');
+
+register_activation_hook( __FILE__, 'gm2_category_sort_activate' );
+register_deactivation_hook( __FILE__, 'gm2_category_sort_deactivate' );
+
+function gm2_category_sort_activate() {
+    if ( ! wp_next_scheduled( GM2_CAT_SORT_CRON_HOOK ) ) {
+        wp_schedule_event( time(), 'daily', GM2_CAT_SORT_CRON_HOOK );
+    }
+}
+
+function gm2_category_sort_deactivate() {
+    $timestamp = wp_next_scheduled( GM2_CAT_SORT_CRON_HOOK );
+    if ( $timestamp ) {
+        wp_unschedule_event( $timestamp, GM2_CAT_SORT_CRON_HOOK );
+    }
+}
 
 // Initialize plugin
 add_action('plugins_loaded', 'gm2_category_sort_init');

--- a/includes/class-sitemap.php
+++ b/includes/class-sitemap.php
@@ -63,6 +63,7 @@ class Gm2_Category_Sort_Sitemap {
     public static function init() {
         self::register_cli();
         add_action('wp_ajax_gm2_generate_sitemap', [__CLASS__, 'ajax_generate']);
+        add_action( GM2_CAT_SORT_CRON_HOOK, [ __CLASS__, 'generate' ] );
     }
 
     /**


### PR DESCRIPTION
## Summary
- hook daily sitemap generation in `Gm2_Category_Sort_Sitemap`
- schedule/unschedule the cron event on plugin activation and deactivation
- mention automatic regeneration in the README

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a2a098e108327b9dcdfd682c93482