### PR TITLE
Document WooCommerce template usage

### DIFF
--- a/includes/class-ajax.php
+++ b/includes/class-ajax.php
@@ -105,6 +105,9 @@ class Gm2_Category_Sort_Ajax {
         $GLOBALS['wp_query'] = $query;
 
         ob_start();
+        // Product markup is generated solely via WooCommerce template
+        // functions. Altering these calls may change or remove the
+        // structured data that WooCommerce outputs.
         if ($query->have_posts()) {
             woocommerce_product_loop_start();
             while ($query->have_posts()) {


### PR DESCRIPTION
## Summary
- note that product markup must come from WooCommerce template functions

## Testing
- `npm test` *(fails: could not find `package.json`)*
- `composer test` *(fails: command not found)*
- `make test` *(fails: no rule `test`)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a4100e71c8327b07a14b9a199a149