### PR TITLE
Use URL identifier in schema output

### DIFF
--- a/includes/class-schema.php
+++ b/includes/class-schema.php
@@ -31,7 +31,7 @@ class Gm2_Category_Sort_Schema {
                 '@type'   => 'ListItem',
                 'position'=> $position++,
                 'name'    => $cat->name,
-                'id'      => $cat->term_id,
+                '@id'     => get_term_link( $cat ),
             ];
         }
 


### PR DESCRIPTION
## Summary
- use URLs as `@id` values in the ItemList schema

## Testing
- `php -l includes/class-schema.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684a441f24808327928da5166cca7eb4