### PR TITLE
Return sitemap URL after AJAX generation

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -375,8 +375,8 @@ jQuery(document).ready(function($) {
             nonce: nonce
         }, function(resp) {
             if (resp && resp.success) {
-                if (resp.data && resp.data.url) {
-                    const url = resp.data.url;
+                const url = resp.data;
+                if (url) {
                     if (navigator.clipboard && window.isSecureContext) {
                         navigator.clipboard.writeText(url).catch(function() {});
                     }

--- a/includes/class-sitemap.php
+++ b/includes/class-sitemap.php
@@ -100,10 +100,7 @@ class Gm2_Category_Sort_Sitemap {
         if ($file) {
             $upload_dir = wp_upload_dir();
             $url = trailingslashit($upload_dir['baseurl']) . basename($file);
-            wp_send_json_success([
-                'file' => $file,
-                'url'  => $url,
-            ]);
+            wp_send_json_success($url);
         }
 
         wp_send_json_error('failed');


### PR DESCRIPTION
## Summary
- return a public URL from `ajax_generate`
- update JS to display and copy the returned sitemap URL

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_684afea2ef508327b5ce536720f20811