### PR TITLE
Add product category meta fields

### DIFF
--- a/gm2-category-sort.php
+++ b/gm2-category-sort.php
@@ -54,6 +54,7 @@ function gm2_category_sort_init() {
     require_once GM2_CAT_SORT_PATH . 'includes/class-canonical.php';
     require_once GM2_CAT_SORT_PATH . 'includes/class-schema.php';
     require_once GM2_CAT_SORT_PATH . 'includes/class-sitemap.php';
+    require_once GM2_CAT_SORT_PATH . 'includes/class-term-meta.php';
     
     // Initialize components
     Gm2_Category_Sort_Enqueuer::init();
@@ -61,6 +62,7 @@ function gm2_category_sort_init() {
     Gm2_Category_Sort_Ajax::init();
     Gm2_Category_Sort_Canonical::init();
     Gm2_Category_Sort_Sitemap::init();
+    Gm2_Category_Sort_Term_Meta::init();
     
     add_filter('pre_get_document_title', 'gm2_category_sort_modify_title');
     add_action('wp_head', 'gm2_category_sort_meta_description');

--- a/includes/class-term-meta.php
+++ b/includes/class-term-meta.php
@@ -1,0 +1,74 @@
+<?php
+class Gm2_Category_Sort_Term_Meta {
+    public static function init() {
+        add_action( 'init', [ __CLASS__, 'register_meta' ] );
+        add_action( 'product_cat_add_form_fields', [ __CLASS__, 'add_fields' ] );
+        add_action( 'product_cat_edit_form_fields', [ __CLASS__, 'edit_fields' ] );
+        add_action( 'created_product_cat', [ __CLASS__, 'save_fields' ] );
+        add_action( 'edited_product_cat', [ __CLASS__, 'save_fields' ] );
+    }
+
+    public static function register_meta() {
+        register_meta( 'term', 'gm2_primary_category', [
+            'type'              => 'boolean',
+            'single'            => true,
+            'object_subtype'    => 'product_cat',
+            'show_in_rest'      => true,
+            'sanitize_callback' => 'wp_validate_boolean',
+        ] );
+
+        register_meta( 'term', 'gm2_synonyms', [
+            'type'              => 'string',
+            'single'            => true,
+            'object_subtype'    => 'product_cat',
+            'show_in_rest'      => true,
+            'sanitize_callback' => 'sanitize_textarea_field',
+        ] );
+    }
+
+    public static function add_fields() {
+        ?>
+        <div class="form-field">
+            <label for="gm2_primary_category"><?php esc_html_e( 'Primary Category', 'gm2-category-sort' ); ?></label>
+            <input type="checkbox" name="gm2_primary_category" id="gm2_primary_category" value="1">
+            <p class="description"><?php esc_html_e( 'Mark this as a primary category.', 'gm2-category-sort' ); ?></p>
+        </div>
+        <div class="form-field">
+            <label for="gm2_synonyms"><?php esc_html_e( 'Synonyms', 'gm2-category-sort' ); ?></label>
+            <textarea name="gm2_synonyms" id="gm2_synonyms" rows="3" cols="40"></textarea>
+            <p class="description"><?php esc_html_e( 'Comma-separated synonyms used in search.', 'gm2-category-sort' ); ?></p>
+        </div>
+        <?php
+    }
+
+    public static function edit_fields( $term ) {
+        $primary  = get_term_meta( $term->term_id, 'gm2_primary_category', true );
+        $synonyms = get_term_meta( $term->term_id, 'gm2_synonyms', true );
+        ?>
+        <tr class="form-field">
+            <th scope="row"><label for="gm2_primary_category"><?php esc_html_e( 'Primary Category', 'gm2-category-sort' ); ?></label></th>
+            <td>
+                <label>
+                    <input type="checkbox" name="gm2_primary_category" id="gm2_primary_category" value="1" <?php checked( $primary, true ); ?>>
+                    <?php esc_html_e( 'Mark this as a primary category.', 'gm2-category-sort' ); ?>
+                </label>
+            </td>
+        </tr>
+        <tr class="form-field">
+            <th scope="row"><label for="gm2_synonyms"><?php esc_html_e( 'Synonyms', 'gm2-category-sort' ); ?></label></th>
+            <td>
+                <textarea name="gm2_synonyms" id="gm2_synonyms" rows="3" cols="40"><?php echo esc_textarea( $synonyms ); ?></textarea>
+                <p class="description"><?php esc_html_e( 'Comma-separated synonyms used in search.', 'gm2-category-sort' ); ?></p>
+            </td>
+        </tr>
+        <?php
+    }
+
+    public static function save_fields( $term_id ) {
+        $primary  = isset( $_POST['gm2_primary_category'] ) ? 1 : 0;
+        $synonyms = isset( $_POST['gm2_synonyms'] ) ? sanitize_textarea_field( $_POST['gm2_synonyms'] ) : '';
+
+        update_term_meta( $term_id, 'gm2_primary_category', $primary );
+        update_term_meta( $term_id, 'gm2_synonyms', $synonyms );
+    }
+}


### PR DESCRIPTION
## Summary
- register `gm2_primary_category` and `gm2_synonyms` meta keys for `product_cat`
- expose the new meta fields on the product category edit screen in the admin

## Testing
- `php -l includes/class-term-meta.php`
- `php -l gm2-category-sort.php`


------
https://chatgpt.com/codex/tasks/task_e_684b4025278c8327b376e369219cd34e