### PR TITLE
Handle primary category canonical links

### DIFF
--- a/includes/class-canonical.php
+++ b/includes/class-canonical.php
@@ -13,7 +13,18 @@ class Gm2_Category_Sort_Canonical {
         if (is_product_taxonomy()) {
             $term = get_queried_object();
             if ($term && !is_wp_error($term)) {
-                $canonical = get_term_link($term);
+                // Check for a primary category and canonicalize to it when set.
+                $primary_id = get_term_meta( $term->term_id, 'gm2_primary_category', true );
+                if ( $primary_id ) {
+                    $primary = get_term( (int) $primary_id, 'product_cat' );
+                    if ( $primary && ! is_wp_error( $primary ) ) {
+                        $canonical = get_term_link( $primary );
+                    }
+                }
+
+                if ( ! $canonical ) {
+                    $canonical = get_term_link( $term );
+                }
             }
         } elseif (function_exists('wc_get_page_permalink')) {
             $canonical = wc_get_page_permalink('shop');


### PR DESCRIPTION
## Summary
- resolve canonical link against gm2_primary_category when present

## Testing
- `php -l includes/class-canonical.php` *(fails: `php` not found)*
- `php -v` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b42e019d4832798c6bced19dc79fb