### PR TITLE
Support category synonyms

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -54,6 +54,22 @@
     font-weight: bold;
 }
 
+.gm2-synonyms {
+    margin-left: 5px;
+    font-style: italic;
+    color: #666;
+    font-size: 0.9em;
+}
+
+.gm2-category-synonym {
+    cursor: pointer;
+    color: #666;
+}
+
+.gm2-category-synonym:hover {
+    color: #3a8bff;
+}
+
 .gm2-expand-button {
     background: #f5f5f5;
     border: 1px solid #ddd;

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -80,17 +80,20 @@ jQuery(document).ready(function($) {
                 e.stopPropagation();
             }
         }
-        const $widget = $(this).closest('.gm2-category-sort');
-        const termId = $(this).data('term-id');
-        const isSelected = $(this).hasClass('selected');
-        
-        // Toggle selection
-        if (isSelected) {
-            $(this).removeClass('selected');
-        } else {
-            $(this).addClass('selected');
+        let $link = $(this);
+        if ($link.hasClass('gm2-category-synonym')) {
+            $link = $link.closest('.gm2-category-name-container').find('.gm2-category-name').first();
         }
-        
+        const $widget = $link.closest('.gm2-category-sort');
+        const isSelected = $link.hasClass('selected');
+
+        // Toggle selection on canonical label
+        if (isSelected) {
+            $link.removeClass('selected');
+        } else {
+            $link.addClass('selected');
+        }
+
         gm2RefreshSelectedList($widget);
         gm2UpdateProductFiltering($widget, 1);
         return false;
@@ -318,7 +321,7 @@ jQuery(document).ready(function($) {
     }
     
     // Event delegation for dynamic elements
-    $(document).on('click', '.gm2-category-name', gm2HandleCategoryClick);
+    $(document).on('click', '.gm2-category-name, .gm2-category-synonym', gm2HandleCategoryClick);
     $(document).on('click', '.gm2-remove-category', gm2HandleRemoveClick);
     $(document).on('click', '.woocommerce-pagination a', function(e) {
         const href = $(this).attr('href');


### PR DESCRIPTION
## Summary
- render synonyms next to category labels
- toggle canonical label selection when a synonym is clicked
- allow synonyms when building root categories and child nodes
- style synonym labels

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684b4396bac88327a17fdfc82ae1b95a