### PR TITLE
Add tests for importer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.DS_Store
+.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -66,3 +66,17 @@ If you customize the script, include this value in your requests.
 
 ## License
 This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.
+
+## Testing
+
+To run the PHPUnit test suite:
+
+1. Install PHPUnit (version 9 or newer).
+2. From the project root run:
+
+```bash
+phpunit
+```
+
+The tests use stubbed WordPress functions so no WordPress installation is required.
+

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php">
+    <testsuites>
+        <testsuite name="Gm2 Category Sort Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/CategoryImporterTest.php
+++ b/tests/CategoryImporterTest.php
@@ -1,0 +1,71 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class CategoryImporterTest extends TestCase {
+
+    protected function setUp(): void {
+        gm2_test_reset_terms();
+    }
+
+    private function createCsvFile(string $contents): string {
+        $file = tempnam(sys_get_temp_dir(), 'gm2_csv');
+        file_put_contents($file, $contents);
+        return $file;
+    }
+
+    public function test_import_creates_category_hierarchy() {
+        $csv = "Parent,Child1,Grandchild\nParent,Child2\n";
+        $file = $this->createCsvFile($csv);
+
+        $result = Gm2_Category_Sort_Category_Importer::import_from_csv($file);
+        unlink($file);
+
+        $this->assertTrue($result);
+        $calls = $GLOBALS['gm2_insert_calls'];
+        $this->assertCount(4, $calls);
+
+        $parent_id = $calls[0]['id'];
+        $this->assertSame('Parent', $calls[0]['name']);
+        $this->assertSame(0, $calls[0]['parent']);
+
+        $this->assertSame('Child1', $calls[1]['name']);
+        $this->assertSame($parent_id, $calls[1]['parent']);
+        $child1_id = $calls[1]['id'];
+
+        $this->assertSame('Grandchild', $calls[2]['name']);
+        $this->assertSame($child1_id, $calls[2]['parent']);
+
+        $this->assertSame('Child2', $calls[3]['name']);
+        $this->assertSame($parent_id, $calls[3]['parent']);
+    }
+
+    public function test_import_skips_duplicate_rows() {
+        $csv = "Cat1,Sub\nCat1,Sub\n";
+        $file = $this->createCsvFile($csv);
+        $result = Gm2_Category_Sort_Category_Importer::import_from_csv($file);
+        unlink($file);
+
+        $this->assertTrue($result);
+        $calls = $GLOBALS['gm2_insert_calls'];
+        $this->assertCount(2, $calls);
+        $cat_id = $calls[0]['id'];
+        $this->assertSame('Cat1', $calls[0]['name']);
+        $this->assertSame(0, $calls[0]['parent']);
+        $this->assertSame('Sub', $calls[1]['name']);
+        $this->assertSame($cat_id, $calls[1]['parent']);
+    }
+
+    public function test_import_ignores_empty_lines() {
+        $csv = "Cat1,Sub1\n\nCat2\n";
+        $file = $this->createCsvFile($csv);
+        $result = Gm2_Category_Sort_Category_Importer::import_from_csv($file);
+        unlink($file);
+
+        $this->assertTrue($result);
+        $calls = $GLOBALS['gm2_insert_calls'];
+        $this->assertCount(3, $calls);
+        $this->assertSame('Cat1', $calls[0]['name']);
+        $this->assertSame('Sub1', $calls[1]['name']);
+        $this->assertSame('Cat2', $calls[2]['name']);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,58 @@
+<?php
+require_once __DIR__ . '/../includes/class-category-importer.php';
+
+// Minimal WP_Error class for tests.
+if ( ! class_exists( 'WP_Error' ) ) {
+    class WP_Error {
+        public $errors = [];
+        public function __construct( $code = '', $message = '' ) {
+            if ( $code ) {
+                $this->errors[ $code ] = [ $message ];
+            }
+        }
+        public function get_error_message() {
+            $error = reset( $this->errors );
+            return $error ? $error[0] : '';
+        }
+    }
+}
+
+function is_wp_error( $thing ) {
+    return $thing instanceof WP_Error;
+}
+
+function __( $text, $domain = null ) {
+    return $text;
+}
+
+// Globals for stubbed WordPress functions.
+$GLOBALS['gm2_test_terms'] = [];
+$GLOBALS['gm2_next_id'] = 1;
+$GLOBALS['gm2_insert_calls'] = [];
+
+function gm2_test_reset_terms() {
+    $GLOBALS['gm2_test_terms'] = [];
+    $GLOBALS['gm2_next_id'] = 1;
+    $GLOBALS['gm2_insert_calls'] = [];
+}
+
+gm2_test_reset_terms();
+
+function term_exists( $name, $taxonomy = null, $parent = 0 ) {
+    $terms = $GLOBALS['gm2_test_terms'];
+    if ( isset( $terms[ $parent ][ $name ] ) ) {
+        return [ 'term_id' => $terms[ $parent ][ $name ] ];
+    }
+    return false;
+}
+
+function wp_insert_term( $name, $taxonomy, $args = [] ) {
+    $parent = $args['parent'] ?? 0;
+    $id = $GLOBALS['gm2_next_id']++;
+    if ( ! isset( $GLOBALS['gm2_test_terms'][ $parent ] ) ) {
+        $GLOBALS['gm2_test_terms'][ $parent ] = [];
+    }
+    $GLOBALS['gm2_test_terms'][ $parent ][ $name ] = $id;
+    $GLOBALS['gm2_insert_calls'][] = [ 'name' => $name, 'parent' => $parent, 'id' => $id ];
+    return [ 'term_id' => $id ];
+}


### PR DESCRIPTION
## Summary
- add PHPUnit configuration and bootstrap
- test category importer for hierarchy handling, duplicate rows and empty lines
- ignore phpunit cache and document test instructions in README

## Testing
- `phpunit -c phpunit.xml --colors=never`

------
https://chatgpt.com/codex/tasks/task_e_684b60eb6c5083279682636b84214e5f