### PR TITLE
Add synonym support to CSV import

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ Upload a CSV through **Tools → Import Categories** in the admin area or run
 `wp gm2-category-sort import &lt;file&gt;` from WP‑CLI. An example file is
 available at `assets/example-categories.csv`.
 
+Synonyms can be specified by appending them in parentheses after a category
+name within the same cell. If the synonyms contain commas, wrap the cell in
+quotes:
+
+```
+"Wheel Covers (hubcaps,wheel caps)",Accessories
+```
+These values are stored in the category's **Synonyms** field during import.
+
 ## SEO Improvements
 
 When active filters are applied, the plugin outputs a canonical link pointing to
@@ -66,6 +75,8 @@ Edit any product category and enter comma-separated words in the **Synonyms**
 field. Each synonym is rendered as an extra filter link beside the category
 name so shoppers can select it directly. These synonyms only appear in the page
 content and are not included in the JSON‑LD schema or meta tags.
+Synonyms may also be imported via CSV using the `(syn1,syn2)` syntax described
+above.
 
 ## Primary Category
 

--- a/assets/example-categories.csv
+++ b/assets/example-categories.csv
@@ -1,3 +1,3 @@
-Wheel Simulators,By Brand & Model,Ford Wheel Simulators,F350 Wheel Simulators
+"Wheel Simulators (Hubcaps,Wheel Covers)",By Brand & Model,Ford Wheel Simulators,F350 Wheel Simulators
 Wheel Simulators,By Brand & Model,Chevy Wheel Simulators,3500 Wheel Simulators
 

--- a/includes/class-category-importer.php
+++ b/includes/class-category-importer.php
@@ -122,6 +122,12 @@ class Gm2_Category_Sort_Category_Importer {
                     continue;
                 }
 
+                $synonyms = '';
+                if ( preg_match( '/^(.*?)\s*\(([^)]*)\)$/', $name, $m ) ) {
+                    $name     = trim( $m[1] );
+                    $synonyms = trim( $m[2] );
+                }
+
                 $existing = term_exists( $name, 'product_cat', $parent );
                 if ( is_array( $existing ) ) {
                     $parent = (int) $existing['term_id'];
@@ -132,6 +138,10 @@ class Gm2_Category_Sort_Category_Importer {
                         return $result;
                     }
                     $parent = (int) $result['term_id'];
+                }
+
+                if ( $synonyms !== '' ) {
+                    update_term_meta( $parent, 'gm2_synonyms', $synonyms );
                 }
             }
         }

--- a/tests/CategoryImporterTest.php
+++ b/tests/CategoryImporterTest.php
@@ -68,4 +68,26 @@ class CategoryImporterTest extends TestCase {
         $this->assertSame('Sub1', $calls[1]['name']);
         $this->assertSame('Cat2', $calls[2]['name']);
     }
+
+    public function test_import_sets_synonyms() {
+        $csv = "\"Parent (SynA,SynB)\",\"Child (Alt)\"\n";
+        $file = $this->createCsvFile($csv);
+        $result = Gm2_Category_Sort_Category_Importer::import_from_csv($file);
+        unlink($file);
+
+        $this->assertTrue($result);
+        $calls = $GLOBALS['gm2_insert_calls'];
+        $this->assertCount(2, $calls);
+        $parent_id = $calls[0]['id'];
+        $child_id  = $calls[1]['id'];
+
+        $meta = $GLOBALS['gm2_meta_updates'];
+        $this->assertCount(2, $meta);
+        $this->assertSame($parent_id, $meta[0]['term_id']);
+        $this->assertSame('gm2_synonyms', $meta[0]['key']);
+        $this->assertSame('SynA,SynB', $meta[0]['value']);
+        $this->assertSame($child_id, $meta[1]['term_id']);
+        $this->assertSame('gm2_synonyms', $meta[1]['key']);
+        $this->assertSame('Alt', $meta[1]['value']);
+    }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -29,11 +29,13 @@ function __( $text, $domain = null ) {
 $GLOBALS['gm2_test_terms'] = [];
 $GLOBALS['gm2_next_id'] = 1;
 $GLOBALS['gm2_insert_calls'] = [];
+$GLOBALS['gm2_meta_updates'] = [];
 
 function gm2_test_reset_terms() {
     $GLOBALS['gm2_test_terms'] = [];
     $GLOBALS['gm2_next_id'] = 1;
     $GLOBALS['gm2_insert_calls'] = [];
+    $GLOBALS['gm2_meta_updates'] = [];
 }
 
 gm2_test_reset_terms();
@@ -55,4 +57,12 @@ function wp_insert_term( $name, $taxonomy, $args = [] ) {
     $GLOBALS['gm2_test_terms'][ $parent ][ $name ] = $id;
     $GLOBALS['gm2_insert_calls'][] = [ 'name' => $name, 'parent' => $parent, 'id' => $id ];
     return [ 'term_id' => $id ];
+}
+
+function update_term_meta( $term_id, $key, $value ) {
+    $GLOBALS['gm2_meta_updates'][] = [
+        'term_id' => $term_id,
+        'key'     => $key,
+        'value'   => $value,
+    ];
 }


### PR DESCRIPTION
## Summary
- support `category (syn1,syn2)` syntax when importing categories from CSV
- keep synonym metadata when importing
- document synonym format in README
- show example synonyms in example CSV
- test synonym import logic

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_684b5a08c78883278509d3de86f8aeb3