### PR TITLE
Add product category assignment importer

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,21 @@ quotes:
 ```
 These values are stored in the category's **Synonyms** field during import.
 
+## Assign Product Categories
+
+You can also bulk assign existing categories to products. Each CSV row should
+begin with the product SKU followed by one or more category names:
+
+```
+SKU123,Accessories
+SKU124,Wheel Simulators,By Brand & Model
+```
+
+Upload a CSV through **Tools → Assign Product Categories** or run
+`wp gm2-category-sort assign-categories <file> --overwrite` to replace existing
+categories (omit `--overwrite` to append). An example file is available at
+`assets/example-product-categories.csv`.
+
 ## SEO Improvements
 
 When active filters are applied, the plugin outputs a canonical link pointing to

--- a/assets/example-product-categories.csv
+++ b/assets/example-product-categories.csv
@@ -1,0 +1,2 @@
+SKU123,Accessories
+SKU124,Wheel Simulators,By Brand & Model

--- a/gm2-category-sort.php
+++ b/gm2-category-sort.php
@@ -56,6 +56,7 @@ function gm2_category_sort_init() {
     require_once GM2_CAT_SORT_PATH . 'includes/class-sitemap.php';
     require_once GM2_CAT_SORT_PATH . 'includes/class-term-meta.php';
     require_once GM2_CAT_SORT_PATH . 'includes/class-category-importer.php';
+    require_once GM2_CAT_SORT_PATH . 'includes/class-product-category-importer.php';
     
     // Initialize components
     Gm2_Category_Sort_Enqueuer::init();
@@ -65,6 +66,7 @@ function gm2_category_sort_init() {
     Gm2_Category_Sort_Sitemap::init();
     Gm2_Category_Sort_Term_Meta::init();
     Gm2_Category_Sort_Category_Importer::init();
+    Gm2_Category_Sort_Product_Category_Importer::init();
     
     add_filter('pre_get_document_title', 'gm2_category_sort_modify_title');
     add_action('wp_head', 'gm2_category_sort_meta_description');

--- a/includes/class-product-category-importer.php
+++ b/includes/class-product-category-importer.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * Assign product categories to products from CSV files.
+ */
+class Gm2_Category_Sort_Product_Category_Importer {
+
+    /**
+     * Initialize importer by registering CLI and admin page.
+     */
+    public static function init() {
+        self::register_cli();
+        add_action( 'admin_menu', [ __CLASS__, 'register_admin_page' ] );
+    }
+
+    /**
+     * Register WP-CLI command.
+     */
+    public static function register_cli() {
+        if ( defined( 'WP_CLI' ) && WP_CLI ) {
+            \WP_CLI::add_command( 'gm2-category-sort assign-categories', [ __CLASS__, 'cli_import' ] );
+        }
+    }
+
+    /**
+     * Handle WP-CLI import.
+     *
+     * @param array $args       Positional arguments.
+     * @param array $assoc_args Associative args.
+     */
+    public static function cli_import( $args, $assoc_args ) {
+        $file = $args[0] ?? '';
+        if ( ! $file ) {
+            \WP_CLI::error( 'Please provide a CSV file path.' );
+        }
+
+        $overwrite = isset( $assoc_args['overwrite'] );
+        $result    = self::import_from_csv( $file, $overwrite );
+        if ( is_wp_error( $result ) ) {
+            \WP_CLI::error( $result->get_error_message() );
+        }
+
+        \WP_CLI::success( 'Categories assigned successfully.' );
+    }
+
+    /**
+     * Register the admin import page under Tools.
+     */
+    public static function register_admin_page() {
+        add_management_page(
+            __( 'Assign Product Categories', 'gm2-category-sort' ),
+            __( 'Assign Product Categories', 'gm2-category-sort' ),
+            'manage_options',
+            'gm2-product-category-import',
+            [ __CLASS__, 'admin_page' ]
+        );
+    }
+
+    /**
+     * Render the admin page and handle form submission.
+     */
+    public static function admin_page() {
+        $message  = '';
+        $error    = '';
+        $overwrite = false;
+
+        if ( isset( $_POST['gm2_product_category_import_nonce'] ) ) {
+            check_admin_referer( 'gm2_product_category_import', 'gm2_product_category_import_nonce' );
+            $overwrite = ! empty( $_POST['gm2_overwrite'] );
+
+            if ( ! empty( $_FILES['gm2_product_category_file']['tmp_name'] ) ) {
+                $file   = $_FILES['gm2_product_category_file']['tmp_name'];
+                $result = self::import_from_csv( $file, $overwrite );
+                if ( is_wp_error( $result ) ) {
+                    $error = $result->get_error_message();
+                } else {
+                    $message = __( 'Categories assigned successfully.', 'gm2-category-sort' );
+                }
+            } else {
+                $error = __( 'Please select a CSV file.', 'gm2-category-sort' );
+            }
+        }
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e( 'Assign Product Categories', 'gm2-category-sort' ); ?></h1>
+            <?php if ( $message ) : ?>
+                <div class="notice notice-success"><p><?php echo esc_html( $message ); ?></p></div>
+            <?php elseif ( $error ) : ?>
+                <div class="notice notice-error"><p><?php echo esc_html( $error ); ?></p></div>
+            <?php endif; ?>
+            <form method="post" enctype="multipart/form-data">
+                <?php wp_nonce_field( 'gm2_product_category_import', 'gm2_product_category_import_nonce' ); ?>
+                <input type="file" name="gm2_product_category_file" accept=".csv">
+                <label>
+                    <input type="checkbox" name="gm2_overwrite" value="1" <?php checked( $overwrite ); ?>>
+                    <?php esc_html_e( 'Overwrite existing categories', 'gm2-category-sort' ); ?>
+                </label>
+                <?php submit_button( __( 'Assign', 'gm2-category-sort' ) ); ?>
+            </form>
+        </div>
+        <?php
+    }
+
+    /**
+     * Assign categories from a CSV file.
+     *
+     * Each row starts with a product SKU followed by category names.
+     *
+     * @param string $file      CSV file path.
+     * @param bool   $overwrite Whether to overwrite existing categories.
+     * @return true|WP_Error
+     */
+    public static function import_from_csv( $file, $overwrite ) {
+        if ( ! file_exists( $file ) || ! is_readable( $file ) ) {
+            return new WP_Error( 'gm2_invalid_file', __( 'Invalid CSV file.', 'gm2-category-sort' ) );
+        }
+
+        $handle = fopen( $file, 'r' );
+        if ( ! $handle ) {
+            return new WP_Error( 'gm2_unreadable', __( 'Unable to read file.', 'gm2-category-sort' ) );
+        }
+
+        while ( ( $row = fgetcsv( $handle ) ) !== false ) {
+            if ( empty( $row ) ) {
+                continue;
+            }
+
+            $sku = trim( array_shift( $row ) );
+            if ( $sku === '' ) {
+                continue;
+            }
+
+            $product_id = wc_get_product_id_by_sku( $sku );
+            if ( ! $product_id ) {
+                continue;
+            }
+
+            $term_ids = [];
+            foreach ( $row as $name ) {
+                $name = trim( $name );
+                if ( $name === '' ) {
+                    continue;
+                }
+                $term = get_term_by( 'name', $name, 'product_cat' );
+                if ( $term && ! is_wp_error( $term ) ) {
+                    $term_ids[] = (int) $term->term_id;
+                }
+            }
+
+            if ( ! empty( $term_ids ) ) {
+                wp_set_object_terms( $product_id, $term_ids, 'product_cat', ! $overwrite );
+            }
+        }
+
+        fclose( $handle );
+        return true;
+    }
+}

--- a/tests/ProductCategoryImporterTest.php
+++ b/tests/ProductCategoryImporterTest.php
@@ -1,0 +1,46 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class ProductCategoryImporterTest extends TestCase {
+
+    protected function setUp(): void {
+        gm2_test_reset_terms();
+        // Setup some terms for lookup
+        $GLOBALS['gm2_test_terms'][0] = [ 'Cat1' => 1, 'Cat2' => 2 ];
+        $GLOBALS['gm2_products'] = [ 'SKU1' => 10, 'SKU2' => 20 ];
+    }
+
+    private function createCsv(string $contents): string {
+        $file = tempnam(sys_get_temp_dir(), 'gm2_prod');
+        file_put_contents($file, $contents);
+        return $file;
+    }
+
+    public function test_appends_categories() {
+        $csv = "SKU1,Cat1\n";
+        $file = $this->createCsv($csv);
+
+        Gm2_Category_Sort_Product_Category_Importer::import_from_csv($file, false);
+        unlink($file);
+
+        $calls = $GLOBALS['gm2_set_terms_calls'];
+        $this->assertCount(1, $calls);
+        $this->assertTrue($calls[0]['append']);
+        $this->assertSame(10, $calls[0]['object_id']);
+        $this->assertSame([1], $calls[0]['terms']);
+    }
+
+    public function test_overwrites_categories() {
+        $csv = "SKU2,Cat2\n";
+        $file = $this->createCsv($csv);
+
+        Gm2_Category_Sort_Product_Category_Importer::import_from_csv($file, true);
+        unlink($file);
+
+        $calls = $GLOBALS['gm2_set_terms_calls'];
+        $this->assertCount(1, $calls);
+        $this->assertFalse($calls[0]['append']);
+        $this->assertSame(20, $calls[0]['object_id']);
+        $this->assertSame([2], $calls[0]['terms']);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . '/../includes/class-category-importer.php';
+require_once __DIR__ . '/../includes/class-product-category-importer.php';
 
 // Minimal WP_Error class for tests.
 if ( ! class_exists( 'WP_Error' ) ) {
@@ -30,12 +31,16 @@ $GLOBALS['gm2_test_terms'] = [];
 $GLOBALS['gm2_next_id'] = 1;
 $GLOBALS['gm2_insert_calls'] = [];
 $GLOBALS['gm2_meta_updates'] = [];
+$GLOBALS['gm2_products'] = [];
+$GLOBALS['gm2_set_terms_calls'] = [];
 
 function gm2_test_reset_terms() {
     $GLOBALS['gm2_test_terms'] = [];
     $GLOBALS['gm2_next_id'] = 1;
     $GLOBALS['gm2_insert_calls'] = [];
     $GLOBALS['gm2_meta_updates'] = [];
+    $GLOBALS['gm2_products'] = [];
+    $GLOBALS['gm2_set_terms_calls'] = [];
 }
 
 gm2_test_reset_terms();
@@ -65,4 +70,31 @@ function update_term_meta( $term_id, $key, $value ) {
         'key'     => $key,
         'value'   => $value,
     ];
+}
+
+function get_term_by( $field, $value, $taxonomy ) {
+    if ( $field === 'name' && $taxonomy === 'product_cat' ) {
+        foreach ( $GLOBALS['gm2_test_terms'] as $parent => $terms ) {
+            foreach ( $terms as $name => $id ) {
+                if ( $name === $value ) {
+                    return (object) [ 'term_id' => $id ];
+                }
+            }
+        }
+    }
+    return false;
+}
+
+function wc_get_product_id_by_sku( $sku ) {
+    return $GLOBALS['gm2_products'][ $sku ] ?? 0;
+}
+
+function wp_set_object_terms( $object_id, $terms, $taxonomy, $append = false ) {
+    $GLOBALS['gm2_set_terms_calls'][] = [
+        'object_id' => $object_id,
+        'terms'     => $terms,
+        'taxonomy'  => $taxonomy,
+        'append'    => $append,
+    ];
+    return $terms;
 }


### PR DESCRIPTION
## Summary
- add new Product_Category_Importer class
- load Product_Category_Importer in plugin
- document CSV product assignment workflow
- provide example CSV
- extend test bootstrap with new stubs
- add PHPUnit tests for product category assignment

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_684c747112f88327b5e622723b6ce24f