### PR TITLE
Add product category generator script

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,28 @@ When uploading through the admin screen a progress bar shows the import status
 so large files can be processed incrementally. Each request handles about 50
 rows. For huge imports consider WP‑CLI which displays a terminal progress bar.
 
+### Generate Category Assignments from Research CSV
+
+The `scripts/generate_product_categories.py` helper reads
+`Research/wc-products.csv` and the category tree at
+`Research/Category Tree With Synonyms-Auto Enhance-13 JUN - Category Tree With Synonyms-Auto Enhance-13 JUN.csv`.
+It builds a mapping of category names and their synonyms, scans the product
+data for matches and writes a CSV suitable for the **Assign Product Categories**
+importer.
+
+Run the script from the project root:
+
+```bash
+python3 scripts/generate_product_categories.py \
+  --products Research/wc-products.csv \
+  --categories "Research/Category Tree With Synonyms-Auto Enhance-13 JUN - Category Tree With Synonyms-Auto Enhance-13 JUN.csv" \
+  --output product-categories.csv
+```
+
+The resulting `product-categories.csv` follows the same structure as
+`assets/example-product-categories.csv` where the first column contains the SKU
+and subsequent columns list category names.
+
 ## SEO Improvements
 
 When active filters are applied, the plugin outputs a canonical link pointing to

--- a/scripts/generate_product_categories.py
+++ b/scripts/generate_product_categories.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Generate product category assignments from research CSV files."""
+
+import argparse
+import csv
+import os
+import re
+from typing import Dict, List
+
+
+def parse_cell(cell: str):
+    cell = cell.strip()
+    if '(' in cell and cell.endswith(')') and cell.rfind('(') < cell.rfind(')'):
+        idx = cell.index('(')
+        name = cell[:idx].strip()
+        syns = [s.strip() for s in cell[idx + 1 : -1].split(',') if s.strip()]
+    else:
+        name = cell
+        syns = []
+    return name, syns
+
+
+def load_category_mapping(path: str):
+    mapping: Dict[str, List[str]] = {}
+    patterns: Dict[str, re.Pattern] = {}
+    with open(path, newline='', encoding='utf-8') as f:
+        reader = csv.reader(f)
+        for row in reader:
+            hierarchy: List[str] = []
+            for cell in row:
+                cell = cell.strip()
+                if not cell:
+                    continue
+                name, syns = parse_cell(cell)
+                hierarchy.append(name)
+                for term in [name] + syns:
+                    key = term.lower()
+                    if key not in mapping:
+                        mapping[key] = hierarchy.copy()
+                        patterns[key] = re.compile(r"(?<!\w)" + re.escape(key) + r"(?!\w)")
+    return [(k, mapping[k], patterns[k]) for k in mapping]
+
+
+def build_text(row: Dict[str, str]) -> str:
+    parts = [row.get('Name', ''), row.get('Short description', ''), row.get('Description', ''), row.get('Brands', '')]
+    for i in range(1, 23):
+        parts.append(row.get(f'Attribute {i} name', ''))
+        parts.append(row.get(f'Attribute {i} value(s)', ''))
+    return ' '.join(parts).lower()
+
+
+def assign_categories(text: str, mapping) -> List[str]:
+    cats: List[str] = []
+    for term, path, pattern in mapping:
+        if pattern.search(text):
+            for c in path:
+                if c not in cats:
+                    cats.append(c)
+    return cats
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Generate product category assignments.')
+    parser.add_argument('--products', default='Research/wc-products.csv', help='Path to products CSV')
+    parser.add_argument('--categories', default='Research/Category Tree With Synonyms-Auto Enhance-13 JUN - Category Tree With Synonyms-Auto Enhance-13 JUN.csv', help='Path to category tree CSV')
+    parser.add_argument('--output', default='product-categories.csv', help='Output CSV path')
+    args = parser.parse_args()
+
+    mapping = load_category_mapping(args.categories)
+
+    with open(args.products, newline='', encoding='utf-8-sig') as pf, open(args.output, 'w', newline='', encoding='utf-8') as out:
+        reader = csv.DictReader(pf)
+        writer = csv.writer(out)
+        for row in reader:
+            sku = row.get('SKU', '').strip()
+            if not sku:
+                continue
+            text = build_text(row)
+            cats = assign_categories(text, mapping)
+            if cats:
+                writer.writerow([sku] + cats)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add helper script to parse research files and produce `product-categories.csv`
- document steps to run the script in README

## Testing
- `phpunit` *(fails: command not found)*
- `python3 scripts/generate_product_categories.py --products sample_products.csv --categories "Research/Category Tree With Synonyms-Auto Enhance-13 JUN - Category Tree With Synonyms-Auto Enhance-13 JUN.csv" --output tmp-output.csv`


------
https://chatgpt.com/codex/tasks/task_e_684cbc0693b08327894af896ca512734