### PR TITLE
Improve PHPUnit setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.DS_Store
 .phpunit.result.cache
+vendor/

--- a/README.md
+++ b/README.md
@@ -143,13 +143,14 @@ This project is licensed under the MIT License. See [LICENSE](LICENSE) for detai
 
 ## Testing
 
-To run the PHPUnit test suite:
+To run the test suite:
 
-1. Install PHPUnit (version 9 or newer).
-2. From the project root run:
+1. Ensure PHP 7.3 or newer is available (required by PHPUnit 9).
+2. Execute `bin/install-phpunit.sh` to download PHPUnit (Composer will be used if present).
+3. From the project root run:
 
 ```bash
-phpunit
+vendor/bin/phpunit
 ```
 
 The tests use stubbed WordPress functions so no WordPress installation is required.

--- a/bin/install-phpunit.sh
+++ b/bin/install-phpunit.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -e
+
+# Install PHPUnit locally into vendor/bin if not already present
+PHPUNIT_BIN="$(dirname "$0")/../vendor/bin/phpunit"
+
+if [ -x "$PHPUNIT_BIN" ]; then
+  echo "PHPUnit already installed at $PHPUNIT_BIN"
+  exit 0
+fi
+
+mkdir -p "$(dirname "$PHPUNIT_BIN")"
+
+if command -v composer >/dev/null 2>&1; then
+  composer require --dev --no-progress --no-interaction phpunit/phpunit:^9
+else
+  curl -L https://phar.phpunit.de/phpunit-9.phar -o "$PHPUNIT_BIN"
+  chmod +x "$PHPUNIT_BIN"
+fi
+
+echo "PHPUnit installed at $PHPUNIT_BIN"
+


### PR DESCRIPTION
## Summary
- add `bin/install-phpunit.sh` helper script
- ignore Composer vendor directory
- document test setup in README

## Testing
- `./bin/install-phpunit.sh`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_684cbe9a969083278748f2346ef822c3