### PR TITLE
Handle UTF‑8 BOM in CSV headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,11 @@ fields spanning multiple lines and large field sizes. With Python you can open
 the file using `newline=''` and call `csv.field_size_limit(sys.maxsize)` or use
 `pandas.read_csv` so the description column is read correctly.
 
+WooCommerce exports sometimes prefix the first column header with a UTF-8 byte
+order mark. The helper script and importers detect this marker and strip it so
+`SKU` columns work as expected. If you process the CSV yourself be sure to
+remove the BOM before reading the headers.
+
 ## SEO Improvements
 
 When active filters are applied, the plugin outputs a canonical link pointing to

--- a/includes/class-category-importer.php
+++ b/includes/class-category-importer.php
@@ -110,9 +110,15 @@ class Gm2_Category_Sort_Category_Importer {
             return new WP_Error( 'gm2_unreadable', __( 'Unable to read file.', 'gm2-category-sort' ) );
         }
 
+        $first_row = true;
         while ( ( $row = fgetcsv( $handle ) ) !== false ) {
             if ( empty( $row ) ) {
                 continue;
+            }
+
+            if ( $first_row && isset( $row[0] ) ) {
+                $row[0]  = preg_replace( "/^\xEF\xBB\xBF/", '', $row[0] );
+                $first_row = false;
             }
 
             $parent = 0;

--- a/includes/class-product-category-importer.php
+++ b/includes/class-product-category-importer.php
@@ -174,7 +174,8 @@ class Gm2_Category_Sort_Product_Category_Importer {
             }
         }
 
-        $count = 0;
+        $count      = 0;
+        $first_row  = ( 0 === $offset );
         while ( ( $row = fgetcsv( $handle ) ) !== false ) {
             if ( $limit && $count >= $limit ) {
                 break;
@@ -182,6 +183,11 @@ class Gm2_Category_Sort_Product_Category_Importer {
 
             if ( empty( $row ) ) {
                 continue;
+            }
+
+            if ( $first_row && isset( $row[0] ) ) {
+                $row[0]  = preg_replace( "/^\xEF\xBB\xBF/", '', $row[0] );
+                $first_row = false;
             }
 
             $sku = trim( array_shift( $row ) );

--- a/scripts/generate_product_categories.py
+++ b/scripts/generate_product_categories.py
@@ -70,6 +70,8 @@ def main():
 
     with open(args.products, newline='', encoding='utf-8-sig') as pf, open(args.output, 'w', newline='', encoding='utf-8') as out:
         reader = csv.DictReader(pf)
+        if reader.fieldnames and reader.fieldnames[0].startswith('\ufeff'):
+            reader.fieldnames[0] = reader.fieldnames[0].lstrip('\ufeff')
         writer = csv.writer(out)
         for row in reader:
             sku = row.get('SKU', '').strip()

--- a/tests/CategoryImporterTest.php
+++ b/tests/CategoryImporterTest.php
@@ -90,4 +90,16 @@ class CategoryImporterTest extends TestCase {
         $this->assertSame('gm2_synonyms', $meta[1]['key']);
         $this->assertSame('Alt', $meta[1]['value']);
     }
+
+    public function test_import_strips_bom() {
+        $bom = "\xEF\xBB\xBF";
+        $csv = $bom . "Parent\n";
+        $file = $this->createCsvFile($csv);
+        Gm2_Category_Sort_Category_Importer::import_from_csv($file);
+        unlink($file);
+
+        $calls = $GLOBALS['gm2_insert_calls'];
+        $this->assertCount(1, $calls);
+        $this->assertSame('Parent', $calls[0]['name']);
+    }
 }

--- a/tests/ProductCategoryImporterTest.php
+++ b/tests/ProductCategoryImporterTest.php
@@ -43,4 +43,17 @@ class ProductCategoryImporterTest extends TestCase {
         $this->assertSame(20, $calls[0]['object_id']);
         $this->assertSame([2], $calls[0]['terms']);
     }
+
+    public function test_strips_bom_from_sku() {
+        $bom = "\xEF\xBB\xBF";
+        $csv = $bom . "SKU1,Cat1\n";
+        $file = $this->createCsv($csv);
+
+        Gm2_Category_Sort_Product_Category_Importer::import_from_csv($file, false);
+        unlink($file);
+
+        $calls = $GLOBALS['gm2_set_terms_calls'];
+        $this->assertCount(1, $calls);
+        $this->assertSame(10, $calls[0]['object_id']);
+    }
 }


### PR DESCRIPTION
## Summary
- strip BOM from first column when importing categories or product assignments
- sanitize headers in generate_product_categories.py
- document BOM quirk in README
- test the new behavior

## Testing
- `bin/install-phpunit.sh`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_684cc80d7110832789bf46cfb15270b4