### PR TITLE
Load Product Category Generator

### DIFF
--- a/gm2-category-sort.php
+++ b/gm2-category-sort.php
@@ -56,6 +56,7 @@ function gm2_category_sort_init() {
     require_once GM2_CAT_SORT_PATH . 'includes/class-sitemap.php';
     require_once GM2_CAT_SORT_PATH . 'includes/class-term-meta.php';
     require_once GM2_CAT_SORT_PATH . 'includes/class-category-importer.php';
+    require_once GM2_CAT_SORT_PATH . 'includes/class-product-category-generator.php';
     require_once GM2_CAT_SORT_PATH . 'includes/class-product-category-importer.php';
     require_once GM2_CAT_SORT_PATH . 'includes/class-auto-assign.php';
     


### PR DESCRIPTION
## Summary
- include class-product-category-generator.php when plugin loads
- run `vendor/bin/phpunit`

## Testing
- `bash bin/install-phpunit.sh`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_684d80159edc8327b0077e9822159efb