### PR TITLE
Add overwrite option for auto assign

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ remove the BOM before reading the headers.
 
 The plugin can analyze existing products and automatically assign categories
 based on their titles, descriptions and attribute values. Run the tool from
-**Tools → Auto Assign Categories** in the admin area and click **Start Auto
+**Tools → Auto Assign Categories** in the admin area and choose whether to
+**Add categories** or **Overwrite categories** before clicking **Start Auto
 Assign**. As each product is processed it appears in the log window:
 
 ```
@@ -134,6 +135,7 @@ $ wp gm2-category-sort auto-assign
 Assigning categories  20/20 (100%)
 Success: Auto assign complete.
 ```
+Add `--overwrite` to replace existing categories instead of appending.
 
 During analysis common negative phrases such as `not for`, `does not fit` or
 `without` are detected and prevent category matches. The tool also performs

--- a/assets/js/auto-assign.js
+++ b/assets/js/auto-assign.js
@@ -10,12 +10,13 @@ jQuery(function($){
         });
     }
 
-    function step(offset, reset){
+    function step(offset, reset, overwrite){
         $.post(ajaxurl, {
             action: 'gm2_auto_assign_step',
             nonce: gm2AutoAssign.nonce,
             offset: offset,
-            reset: reset ? 1 : 0
+            reset: reset ? 1 : 0,
+            overwrite: overwrite ? 1 : 0
         }).done(function(resp){
             if(!resp.success){
                 log.append('<div class="error">'+ (resp.data || gm2AutoAssign.error) +'</div>');
@@ -23,7 +24,7 @@ jQuery(function($){
             }
             append(resp.data.items);
             if(!resp.data.done){
-                step(resp.data.offset, false);
+                step(resp.data.offset, false, overwrite);
             }else{
                 log.append('<div>'+ gm2AutoAssign.completed +'</div>');
             }
@@ -35,6 +36,7 @@ jQuery(function($){
     btn.on('click', function(e){
         e.preventDefault();
         log.empty();
-        step(0, true);
+        var overwrite = $('input[name="gm2_overwrite"]:checked').val();
+        step(0, true, overwrite);
     });
 });

--- a/includes/class-auto-assign.php
+++ b/includes/class-auto-assign.php
@@ -76,6 +76,17 @@ class Gm2_Category_Sort_Auto_Assign {
         <div class="wrap">
             <h1><?php esc_html_e( 'Auto Assign Categories', 'gm2-category-sort' ); ?></h1>
             <p><?php esc_html_e( 'Analyze products and assign categories based on product text and attribute values.', 'gm2-category-sort' ); ?></p>
+            <p>
+                <label>
+                    <input type="radio" name="gm2_overwrite" value="0" checked>
+                    <?php esc_html_e( 'Add categories', 'gm2-category-sort' ); ?>
+                </label>
+                &nbsp;
+                <label>
+                    <input type="radio" name="gm2_overwrite" value="1">
+                    <?php esc_html_e( 'Overwrite categories', 'gm2-category-sort' ); ?>
+                </label>
+            </p>
             <p><button id="gm2-auto-assign-start" class="button button-primary"><?php esc_html_e( 'Start Auto Assign', 'gm2-category-sort' ); ?></button></p>
             <div id="gm2-auto-assign-log" style="background:#fff;border:1px solid #ccc;padding:10px;max-height:400px;overflow:auto;">
                 <?php foreach ( $log as $line ) : ?>
@@ -157,7 +168,8 @@ class Gm2_Category_Sort_Auto_Assign {
 
         check_ajax_referer( 'gm2_auto_assign', 'nonce' );
 
-        $reset    = ! empty( $_POST['reset'] );
+        $reset     = ! empty( $_POST['reset'] );
+        $overwrite = ! empty( $_POST['overwrite'] );
         $progress = get_option( 'gm2_auto_assign_progress', [ 'offset' => 0, 'log' => [] ] );
         if ( $reset ) {
             $progress = [ 'offset' => 0, 'log' => [] ];
@@ -203,7 +215,7 @@ class Gm2_Category_Sort_Auto_Assign {
                 }
             }
             if ( $term_ids ) {
-                wp_set_object_terms( $product_id, $term_ids, 'product_cat', true );
+                wp_set_object_terms( $product_id, $term_ids, 'product_cat', ! $overwrite );
             }
 
             $items[] = [
@@ -236,7 +248,8 @@ class Gm2_Category_Sort_Auto_Assign {
      * @param array $assoc_args Associative arguments.
      */
     public static function cli_run( $args, $assoc_args ) {
-        $mapping = self::build_mapping();
+        $overwrite = ! empty( $assoc_args['overwrite'] );
+        $mapping   = self::build_mapping();
 
         $query = new WP_Query(
             [
@@ -282,7 +295,7 @@ class Gm2_Category_Sort_Auto_Assign {
                 }
             }
             if ( $term_ids ) {
-                wp_set_object_terms( $product_id, $term_ids, 'product_cat', true );
+                wp_set_object_terms( $product_id, $term_ids, 'product_cat', ! $overwrite );
             }
 
             if ( $progress ) {

--- a/tests/AutoAssignTest.php
+++ b/tests/AutoAssignTest.php
@@ -165,11 +165,29 @@ class AutoAssignTest extends TestCase {
         $this->assertContains( $parent_id, $calls[0]['terms'] );
         $this->assertContains( $child_id, $calls[0]['terms'] );
         $this->assertSame( [ $parent_id ], $calls[1]['terms'] );
+        $this->assertTrue( $calls[0]['append'] );
+        $this->assertTrue( $calls[1]['append'] );
 
         $result = $GLOBALS['gm2_json_result'];
         $this->assertTrue( $result['success'] );
         $this->assertSame( [ 'Parent', 'Child' ], $result['data']['items'][0]['cats'] );
         $this->assertSame( [ 'Parent' ], $result['data']['items'][1]['cats'] );
+    }
+
+    public function test_ajax_handler_overwrites_categories() {
+        list( $parent_id, $child_id ) = $this->create_categories();
+        $this->create_products();
+
+        $_POST['nonce'] = 't';
+        $_POST['reset'] = '1';
+        $_POST['overwrite'] = '1';
+
+        Gm2_Category_Sort_Auto_Assign::ajax_step();
+
+        $calls = $GLOBALS['gm2_set_terms_calls'];
+        $this->assertCount( 2, $calls );
+        $this->assertFalse( $calls[0]['append'] );
+        $this->assertFalse( $calls[1]['append'] );
     }
 
     public function test_cli_assigns_categories() {
@@ -183,6 +201,8 @@ class AutoAssignTest extends TestCase {
         $this->assertContains( $parent_id, $calls[0]['terms'] );
         $this->assertContains( $child_id, $calls[0]['terms'] );
         $this->assertSame( [ $parent_id ], $calls[1]['terms'] );
+        $this->assertTrue( $calls[0]['append'] );
+        $this->assertTrue( $calls[1]['append'] );
 
         $this->assertContains( 'Auto assign complete.', \WP_CLI::$success_messages );
     }
@@ -203,6 +223,18 @@ class AutoAssignTest extends TestCase {
         $this->assertContains( $child_id, $calls[0]['terms'] );
         $this->assertContains( $parent_id, $calls[0]['terms'] );
         $this->assertSame( [ $wheel['term_id'] ], $calls[1]['terms'] );
+    }
+
+    public function test_cli_overwrites_categories() {
+        list( $parent_id, $child_id ) = $this->create_categories();
+        $this->create_products();
+
+        Gm2_Category_Sort_Auto_Assign::cli_run( [], [ 'overwrite' => 1 ] );
+
+        $calls = $GLOBALS['gm2_set_terms_calls'];
+        $this->assertCount( 2, $calls );
+        $this->assertFalse( $calls[0]['append'] );
+        $this->assertFalse( $calls[1]['append'] );
     }
 }
 }


### PR DESCRIPTION
## Summary
- add overwrite radio buttons for admin UI
- let JS send overwrite flag
- respect overwrite flag in AJAX handler and WP-CLI command
- document overwrite flag
- check append/overwrite behaviours in tests

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_684d8d0eaf548327997263a192beeed0