### PR TITLE
Update negation patterns and replacements

### DIFF
--- a/includes/class-product-category-generator.php
+++ b/includes/class-product-category-generator.php
@@ -6,9 +6,15 @@ class Gm2_Category_Sort_Product_Category_Generator {
 
     /** @var array<string,string> */
     protected static $replacements = [
-        'lugs'  => 'lug',
-        'holes' => 'hole',
-        'hh'    => 'hole',
+        'lugs'            => 'lug',
+        'holes'           => 'hole',
+        'hh'              => 'hole',
+        'hub caps'        => 'hubcap',
+        'hub cap'         => 'hubcap',
+        'wheelcovers'     => 'wheel cover',
+        'wheelcover'      => 'wheel cover',
+        'wheel-simulator' => 'wheel simulator',
+        'wheel-simulators'=> 'wheel simulator',
     ];
 
     /** @var string[] */
@@ -16,6 +22,7 @@ class Gm2_Category_Sort_Product_Category_Generator {
         'not\s+for\s+%s',
         'does\s+not\s+fit\s+%s',
         'without\s+%s',
+        'except\s+for\s+%s',
     ];
 
     /**

--- a/scripts/generate_product_categories.py
+++ b/scripts/generate_product_categories.py
@@ -12,12 +12,19 @@ REPLACEMENTS = {
     "lugs": "lug",
     "holes": "hole",
     "hh": "hole",
+    "hub caps": "hubcap",
+    "hub cap": "hubcap",
+    "wheelcovers": "wheel cover",
+    "wheelcover": "wheel cover",
+    "wheel-simulator": "wheel simulator",
+    "wheel-simulators": "wheel simulator",
 }
 
 NEGATION_PATTERNS = [
     r"not\s+for\s+{}",
     r"does\s+not\s+fit\s+{}",
     r"without\s+{}",
+    r"except\s+for\s+{}",
 ]
 
 

--- a/tests/ProductCategoryGeneratorTest.php
+++ b/tests/ProductCategoryGeneratorTest.php
@@ -50,6 +50,17 @@ class ProductCategoryGeneratorTest extends TestCase {
         $this->assertSame( [], $cats );
     }
 
+    public function test_ignores_except_for_phrases() {
+        $this->create_categories();
+
+        $mapping = Gm2_Category_Sort_Product_Category_Generator::build_mapping_from_globals();
+        $text    = 'All models except for alt type';
+
+        $cats = Gm2_Category_Sort_Product_Category_Generator::assign_categories( $text, $mapping );
+
+        $this->assertSame( [], $cats );
+    }
+
     public function test_matches_morphological_variants() {
         // Single category with variant terms
         $wheel = wp_insert_term( 'Wheel', 'product_cat' );
@@ -61,5 +72,17 @@ class ProductCategoryGeneratorTest extends TestCase {
         $cats = Gm2_Category_Sort_Product_Category_Generator::assign_categories( $text, $mapping );
 
         $this->assertSame( [ 'Wheel' ], $cats );
+    }
+
+    public function test_replacement_variants_are_normalized() {
+        $hub = wp_insert_term( 'Hubcap', 'product_cat' );
+        update_term_meta( $hub['term_id'], 'gm2_synonyms', 'Wheel Cover' );
+
+        $mapping = Gm2_Category_Sort_Product_Category_Generator::build_mapping_from_globals();
+        $text    = 'Premium wheelcovers and hub caps included';
+
+        $cats = Gm2_Category_Sort_Product_Category_Generator::assign_categories( $text, $mapping );
+
+        $this->assertSame( [ 'Hubcap' ], $cats );
     }
 }


### PR DESCRIPTION
## Summary
- support hubcap/wheelcover variant replacements
- support new `except for` negation phrases
- add tests for replacements and negations

## Testing
- `bash bin/install-phpunit.sh`
- `vendor/bin/phpunit` *(fails: `/usr/bin/env: ‘php’: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_684da23ccec48327aa5dcf5e36dd5f56