### PR TITLE
Add depth classes to category nodes and tests

### DIFF
--- a/includes/class-renderer.php
+++ b/includes/class-renderer.php
@@ -86,7 +86,7 @@ class Gm2_Category_Sort_Renderer {
         $is_selected = in_array($term->term_id, $this->selected_categories);
         $selected_class = $is_selected ? 'selected' : '';
         
-        echo '<li class="gm2-category-node">';
+        echo '<li class="gm2-category-node depth-' . intval( $depth ) . '">';
         echo '<div class="gm2-category-header">';
         
         // Add indentation for child nodes
@@ -99,7 +99,7 @@ class Gm2_Category_Sort_Renderer {
             'gm2_filter_type' => $this->settings['filter_type'],
             'gm2_simple_operator' => $this->settings['simple_operator'] ?? 'IN',
         ]);
-        echo '<a class="gm2-category-name ' . $selected_class . '" data-term-id="' . esc_attr($term->term_id) . '" href="' . esc_url($href) . '">' . esc_html($term->name) . '</a>';
+        echo '<a class="gm2-category-name depth-' . intval( $depth ) . ' ' . $selected_class . '" data-term-id="' . esc_attr($term->term_id) . '" href="' . esc_url($href) . '">' . esc_html($term->name) . '</a>';
 
         $synonyms = isset($term->gm2_synonyms) ? $term->gm2_synonyms : array_filter(array_map('trim', explode(',', (string) get_term_meta($term->term_id, 'gm2_synonyms', true))));
         if (!empty($synonyms)) {
@@ -115,7 +115,7 @@ class Gm2_Category_Sort_Renderer {
                     'gm2_filter_type' => $this->settings['filter_type'],
                     'gm2_simple_operator' => $this->settings['simple_operator'] ?? 'IN',
                 ]);
-                echo '<a class="gm2-category-synonym" data-term-id="' . esc_attr($term->term_id) . '" href="' . esc_url($href) . '">' . esc_html($syn) . '</a>';
+                echo '<a class="gm2-category-synonym depth-' . intval( $depth ) . '" data-term-id="' . esc_attr($term->term_id) . '" href="' . esc_url($href) . '">' . esc_html($syn) . '</a>';
                 $first = false;
             }
             echo ')</span>';

--- a/tests/RendererTest.php
+++ b/tests/RendererTest.php
@@ -1,0 +1,28 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class RendererTest extends TestCase {
+    protected function setUp(): void {
+        gm2_test_reset_terms();
+    }
+
+    public function test_depth_classes_rendered() {
+        $root = wp_insert_term( 'Root', 'product_cat' );
+        $child = wp_insert_term( 'Child', 'product_cat', [ 'parent' => $root['term_id'] ] );
+
+        $renderer = new Gm2_Category_Sort_Renderer( [ 'filter_type' => 'simple', 'widget_id' => '1' ] );
+
+        $ref = new ReflectionClass( $renderer );
+        $method = $ref->getMethod( 'render_category_node' );
+        $method->setAccessible( true );
+
+        ob_start();
+        $term = (object) [ 'term_id' => $root['term_id'], 'name' => 'Root', 'gm2_synonyms' => [] ];
+        $method->invoke( $renderer, $term, 0 );
+        $html = ob_get_clean();
+
+        $this->assertStringContainsString( 'gm2-category-node depth-0', $html );
+        $this->assertStringContainsString( 'gm2-category-name depth-0', $html );
+        $this->assertStringContainsString( 'depth-1', $html );
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,6 +2,7 @@
 require_once __DIR__ . '/../includes/class-category-importer.php';
 require_once __DIR__ . '/../includes/class-product-category-importer.php';
 require_once __DIR__ . '/../includes/class-product-category-generator.php';
+require_once __DIR__ . '/../includes/class-renderer.php';
 
 // Minimal WP_Error class for tests.
 if ( ! class_exists( 'WP_Error' ) ) {
@@ -99,3 +100,72 @@ function wp_set_object_terms( $object_id, $terms, $taxonomy, $append = false ) {
     ];
     return $terms;
 }
+
+if ( ! function_exists( 'delete_option' ) ) {
+    function delete_option( $name ) {
+        unset( $GLOBALS['gm2_options'][ $name ] );
+        return true;
+    }
+}
+
+if ( ! function_exists( 'wp_count_posts' ) ) {
+    function wp_count_posts( $post_type ) {
+        $count = isset( $GLOBALS['gm2_product_objects'] ) ? count( $GLOBALS['gm2_product_objects'] ) : 0;
+        return (object) [ 'publish' => $count ];
+    }
+}
+
+// Basic stubs for renderer tests and others.
+if ( ! function_exists( 'get_terms' ) ) {
+    function get_terms( $args ) {
+        $parent  = isset( $args['parent'] ) ? (int) $args['parent'] : null;
+        $include = isset( $args['include'] ) ? (array) $args['include'] : null;
+        $terms   = [];
+        foreach ( $GLOBALS['gm2_test_terms'] as $p => $cats ) {
+            foreach ( $cats as $name => $id ) {
+                if ( $parent !== null && (int) $p !== $parent ) {
+                    continue;
+                }
+                if ( $include && ! in_array( $id, $include, true ) ) {
+                    continue;
+                }
+                $terms[] = (object) [
+                    'term_id' => $id,
+                    'parent'  => $p,
+                    'name'    => $name,
+                ];
+            }
+        }
+        return $terms;
+    }
+}
+
+if ( ! function_exists( 'get_term_meta' ) ) {
+    function get_term_meta( $term_id, $key, $single = true ) {
+        foreach ( $GLOBALS['gm2_meta_updates'] as $meta ) {
+            if ( $meta['term_id'] === $term_id && $meta['key'] === $key ) {
+                return $meta['value'];
+            }
+        }
+        return '';
+    }
+}
+
+if ( ! function_exists( 'esc_attr' ) ) {
+    function esc_attr( $text ) { return $text; }
+}
+
+if ( ! function_exists( 'esc_url' ) ) {
+    function esc_url( $url ) { return $url; }
+}
+
+if ( ! function_exists( 'esc_html' ) ) {
+    function esc_html( $text ) { return $text; }
+}
+
+if ( ! function_exists( 'add_query_arg' ) ) {
+    function add_query_arg( $params ) {
+        return '?' . http_build_query( $params );
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `depth-$depth` classes to category nodes and links
- expose renderer to tests and add missing WP stubs
- add a new PHPUnit test verifying depth classes

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_684da36ce83c832789991cf9e8962271