### PR TITLE
Add advanced style controls

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -45,11 +45,18 @@
     flex-grow: 1;
 }
 
-.gm2-category-name:hover {
+.gm2-category-name.depth-0:hover,
+.gm2-category-name.depth-1:hover,
+.gm2-category-name.depth-2:hover,
+.gm2-category-synonym.depth-0:hover,
+.gm2-category-synonym.depth-1:hover,
+.gm2-category-synonym.depth-2:hover {
     color: #3a8bff;
 }
 
-.gm2-category-name.selected {
+.gm2-category-name.depth-0.selected,
+.gm2-category-name.depth-1.selected,
+.gm2-category-name.depth-2.selected {
     color: #3a8bff;
     font-weight: bold;
 }
@@ -66,9 +73,6 @@
     color: #666;
 }
 
-.gm2-category-synonym:hover {
-    color: #3a8bff;
-}
 
 .gm2-expand-button {
     background: #f5f5f5;

--- a/gm2-category-sort.php
+++ b/gm2-category-sort.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Gm2 Category Sort
  * Description: Adds a collapsible category filter widget for WooCommerce products in Elementor.
- * Version: 1.0.13
+ * Version: 1.0.14
  * Author: ProjectsGm2
  * Text Domain: gm2-category-sort
  */
@@ -10,7 +10,7 @@
 defined('ABSPATH') || exit;
 
 // Plugin version used for cache busting
-define('GM2_CAT_SORT_VERSION', '1.0.13');
+define('GM2_CAT_SORT_VERSION', '1.0.14');
 
 // Define plugin constants
 define('GM2_CAT_SORT_PATH', plugin_dir_path(__FILE__));

--- a/includes/class-renderer.php
+++ b/includes/class-renderer.php
@@ -115,7 +115,18 @@ class Gm2_Category_Sort_Renderer {
                     'gm2_filter_type' => $this->settings['filter_type'],
                     'gm2_simple_operator' => $this->settings['simple_operator'] ?? 'IN',
                 ]);
-                echo '<a class="gm2-category-synonym depth-' . intval( $depth ) . '" data-term-id="' . esc_attr($term->term_id) . '" href="' . esc_url($href) . '">' . esc_html($syn) . '</a>';
+                $icon_html = '';
+                if ( ! empty( $this->settings['synonym_icon']['value'] ) ) {
+                    $icon_html = \Elementor\Icons_Manager::render_icon( $this->settings['synonym_icon'], [ 'aria-hidden' => 'true' ] );
+                }
+                if ( ! empty( $icon_html ) && $this->settings['synonym_icon_position'] === 'after' ) {
+                    $link_content = esc_html($syn) . $icon_html;
+                } elseif ( ! empty( $icon_html ) ) {
+                    $link_content = $icon_html . esc_html($syn);
+                } else {
+                    $link_content = esc_html($syn);
+                }
+                echo '<a class="gm2-category-synonym depth-' . intval( $depth ) . '" data-term-id="' . esc_attr($term->term_id) . '" href="' . esc_url($href) . '">' . $link_content . '</a>';
                 $first = false;
             }
             echo ')</span>';

--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -94,6 +94,349 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
         
         $this->end_controls_section();
 
+        // Widget Box
+        $this->start_controls_section('gm2_widget_box_section', [
+            'label' => __('Widget Box', 'gm2-category-sort'),
+            'tab'   => \Elementor\Controls_Manager::TAB_STYLE,
+        ]);
+
+        $this->add_group_control(
+            \Elementor\Group_Control_Background::get_type(),
+            [
+                'name'     => 'widget_box_bg',
+                'selector' => '{{WRAPPER}} .gm2-category-sort',
+            ]
+        );
+
+        $this->add_group_control(
+            \Elementor\Group_Control_Border::get_type(),
+            [
+                'name'     => 'widget_box_border',
+                'selector' => '{{WRAPPER}} .gm2-category-sort',
+            ]
+        );
+
+        $this->add_responsive_control('widget_box_radius', [
+            'label' => __('Border Radius', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::DIMENSIONS,
+            'selectors' => [
+                '{{WRAPPER}} .gm2-category-sort' => 'border-radius: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+            ],
+        ]);
+
+        $this->add_group_control(
+            \Elementor\Group_Control_Box_Shadow::get_type(),
+            [
+                'name'     => 'widget_box_shadow',
+                'selector' => '{{WRAPPER}} .gm2-category-sort',
+            ]
+        );
+
+        $this->end_controls_section();
+
+        // Category Levels
+        for ( $i = 0; $i <= 3; $i++ ) {
+            $this->start_controls_section( 'gm2_depth_' . $i . '_section', [
+                'label' => sprintf( __( 'Category Level %d', 'gm2-category-sort' ), $i ),
+                'tab'   => \Elementor\Controls_Manager::TAB_STYLE,
+            ] );
+
+            $selector = '.gm2-category-name.depth-' . $i;
+            $syn_selector = '.gm2-category-synonym.depth-' . $i;
+
+            $this->add_group_control(
+                \Elementor\Group_Control_Typography::get_type(),
+                [
+                    'name'     => 'depth_' . $i . '_typography',
+                    'selector' => '{{WRAPPER}} ' . $selector . ', {{WRAPPER}} ' . $syn_selector,
+                ]
+            );
+
+            $this->add_control( 'depth_' . $i . '_text_color', [
+                'label' => __( 'Text Color', 'gm2-category-sort' ),
+                'type'  => \Elementor\Controls_Manager::COLOR,
+                'selectors' => [
+                    '{{WRAPPER}} ' . $selector => 'color: {{VALUE}};',
+                    '{{WRAPPER}} ' . $syn_selector => 'color: {{VALUE}};',
+                ],
+            ] );
+
+            $this->add_control( 'depth_' . $i . '_bg_color', [
+                'label' => __( 'Background', 'gm2-category-sort' ),
+                'type'  => \Elementor\Controls_Manager::COLOR,
+                'selectors' => [
+                    '{{WRAPPER}} ' . $selector => 'background-color: {{VALUE}};',
+                ],
+            ] );
+
+            $this->add_control( 'depth_' . $i . '_hover_color', [
+                'label' => __( 'Hover Text Color', 'gm2-category-sort' ),
+                'type'  => \Elementor\Controls_Manager::COLOR,
+                'selectors' => [
+                    '{{WRAPPER}} ' . $selector . ':hover' => 'color: {{VALUE}};',
+                    '{{WRAPPER}} ' . $syn_selector . ':hover' => 'color: {{VALUE}};',
+                ],
+            ] );
+
+            $this->add_control( 'depth_' . $i . '_hover_bg', [
+                'label' => __( 'Hover Background', 'gm2-category-sort' ),
+                'type'  => \Elementor\Controls_Manager::COLOR,
+                'selectors' => [
+                    '{{WRAPPER}} ' . $selector . ':hover' => 'background-color: {{VALUE}};',
+                ],
+            ] );
+
+            $this->add_control( 'depth_' . $i . '_active_color', [
+                'label' => __( 'Active Text Color', 'gm2-category-sort' ),
+                'type'  => \Elementor\Controls_Manager::COLOR,
+                'selectors' => [
+                    '{{WRAPPER}} ' . $selector . '.selected' => 'color: {{VALUE}};',
+                ],
+            ] );
+
+            $this->add_control( 'depth_' . $i . '_active_bg', [
+                'label' => __( 'Active Background', 'gm2-category-sort' ),
+                'type'  => \Elementor\Controls_Manager::COLOR,
+                'selectors' => [
+                    '{{WRAPPER}} ' . $selector . '.selected' => 'background-color: {{VALUE}};',
+                ],
+            ] );
+
+            $this->add_group_control(
+                \Elementor\Group_Control_Border::get_type(),
+                [
+                    'name'     => 'depth_' . $i . '_border',
+                    'selector' => '{{WRAPPER}} ' . $selector,
+                ]
+            );
+
+            $this->add_responsive_control( 'depth_' . $i . '_radius', [
+                'label' => __( 'Border Radius', 'gm2-category-sort' ),
+                'type'  => \Elementor\Controls_Manager::DIMENSIONS,
+                'selectors' => [
+                    '{{WRAPPER}} ' . $selector => 'border-radius: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+                ],
+            ] );
+
+            $this->add_group_control(
+                \Elementor\Group_Control_Box_Shadow::get_type(),
+                [
+                    'name'     => 'depth_' . $i . '_shadow',
+                    'selector' => '{{WRAPPER}} ' . $selector,
+                ]
+            );
+
+            $this->add_responsive_control( 'depth_' . $i . '_padding', [
+                'label' => __( 'Padding', 'gm2-category-sort' ),
+                'type'  => \Elementor\Controls_Manager::DIMENSIONS,
+                'selectors' => [
+                    '{{WRAPPER}} ' . $selector => 'padding: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+                ],
+            ] );
+
+            $this->add_responsive_control( 'depth_' . $i . '_margin', [
+                'label' => __( 'Margin', 'gm2-category-sort' ),
+                'type'  => \Elementor\Controls_Manager::DIMENSIONS,
+                'selectors' => [
+                    '{{WRAPPER}} ' . $selector => 'margin: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+                ],
+            ] );
+
+            $this->end_controls_section();
+        }
+
+        // Selected Categories
+        $this->start_controls_section('gm2_selected_section', [
+            'label' => __('Selected Categories', 'gm2-category-sort'),
+            'tab'   => \Elementor\Controls_Manager::TAB_STYLE,
+        ]);
+
+        $this->add_group_control(
+            \Elementor\Group_Control_Typography::get_type(),
+            [
+                'name'     => 'selected_typography',
+                'selector' => '{{WRAPPER}} .gm2-selected-category',
+            ]
+        );
+
+        $this->add_control('selected_bg', [
+            'label' => __('Background', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::COLOR,
+            'selectors' => [
+                '{{WRAPPER}} .gm2-selected-category' => 'background-color: {{VALUE}};',
+            ],
+        ]);
+
+        $this->add_control('selected_text', [
+            'label' => __('Text Color', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::COLOR,
+            'selectors' => [
+                '{{WRAPPER}} .gm2-selected-category' => 'color: {{VALUE}};',
+            ],
+        ]);
+
+        $this->add_control('selected_hover_bg', [
+            'label' => __('Hover Background', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::COLOR,
+            'selectors' => [
+                '{{WRAPPER}} .gm2-selected-category:hover' => 'background-color: {{VALUE}};',
+            ],
+        ]);
+
+        $this->add_control('selected_hover_color', [
+            'label' => __('Hover Color', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::COLOR,
+            'selectors' => [
+                '{{WRAPPER}} .gm2-selected-category:hover' => 'color: {{VALUE}};',
+            ],
+        ]);
+
+        $this->add_group_control(
+            \Elementor\Group_Control_Border::get_type(),
+            [
+                'name'     => 'selected_border',
+                'selector' => '{{WRAPPER}} .gm2-selected-category',
+            ]
+        );
+
+        $this->add_responsive_control('selected_radius', [
+            'label' => __('Border Radius', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::DIMENSIONS,
+            'selectors' => [
+                '{{WRAPPER}} .gm2-selected-category' => 'border-radius: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+            ],
+        ]);
+
+        $this->add_group_control(
+            \Elementor\Group_Control_Box_Shadow::get_type(),
+            [
+                'name'     => 'selected_shadow',
+                'selector' => '{{WRAPPER}} .gm2-selected-category',
+            ]
+        );
+
+        $this->add_control('remove_icon_color', [
+            'label' => __('Remove Icon Color', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::COLOR,
+            'selectors' => [
+                '{{WRAPPER}} .gm2-remove-category' => 'color: {{VALUE}};',
+            ],
+        ]);
+
+        $this->add_control('remove_icon_hover_color', [
+            'label' => __('Remove Icon Hover Color', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::COLOR,
+            'selectors' => [
+                '{{WRAPPER}} .gm2-remove-category:hover' => 'color: {{VALUE}};',
+            ],
+        ]);
+
+        $this->end_controls_section();
+
+        // Synonyms
+        $this->start_controls_section('gm2_synonyms_section', [
+            'label' => __('Synonyms', 'gm2-category-sort'),
+            'tab'   => \Elementor\Controls_Manager::TAB_STYLE,
+        ]);
+
+        $this->add_group_control(
+            \Elementor\Group_Control_Typography::get_type(),
+            [
+                'name'     => 'synonym_typography',
+                'selector' => '{{WRAPPER}} .gm2-category-synonym',
+            ]
+        );
+
+        $this->add_control('synonym_color', [
+            'label' => __('Text Color', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::COLOR,
+            'selectors' => [
+                '{{WRAPPER}} .gm2-category-synonym' => 'color: {{VALUE}};',
+            ],
+        ]);
+
+        $this->add_control('synonym_bg', [
+            'label' => __('Background', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::COLOR,
+            'selectors' => [
+                '{{WRAPPER}} .gm2-category-synonym' => 'background-color: {{VALUE}};',
+            ],
+        ]);
+
+        $this->add_control('synonym_hover_color', [
+            'label' => __('Hover Color', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::COLOR,
+            'selectors' => [
+                '{{WRAPPER}} .gm2-category-synonym:hover' => 'color: {{VALUE}};',
+            ],
+        ]);
+
+        $this->add_control('synonym_hover_bg', [
+            'label' => __('Hover Background', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::COLOR,
+            'selectors' => [
+                '{{WRAPPER}} .gm2-category-synonym:hover' => 'background-color: {{VALUE}};',
+            ],
+        ]);
+
+        $this->add_group_control(
+            \Elementor\Group_Control_Border::get_type(),
+            [
+                'name'     => 'synonym_border',
+                'selector' => '{{WRAPPER}} .gm2-category-synonym',
+            ]
+        );
+
+        $this->add_responsive_control('synonym_radius', [
+            'label' => __('Border Radius', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::DIMENSIONS,
+            'selectors' => [
+                '{{WRAPPER}} .gm2-category-synonym' => 'border-radius: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+            ],
+        ]);
+
+        $this->add_group_control(
+            \Elementor\Group_Control_Box_Shadow::get_type(),
+            [
+                'name'     => 'synonym_shadow',
+                'selector' => '{{WRAPPER}} .gm2-category-synonym',
+            ]
+        );
+
+        $this->add_responsive_control('synonym_padding', [
+            'label' => __('Padding', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::DIMENSIONS,
+            'selectors' => [
+                '{{WRAPPER}} .gm2-category-synonym' => 'padding: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+            ],
+        ]);
+
+        $this->add_responsive_control('synonym_margin', [
+            'label' => __('Margin', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::DIMENSIONS,
+            'selectors' => [
+                '{{WRAPPER}} .gm2-category-synonym' => 'margin: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+            ],
+        ]);
+
+        $this->add_control('synonym_icon', [
+            'label' => __('Icon', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::ICONS,
+            'label_block' => true,
+        ]);
+
+        $this->add_control('synonym_icon_position', [
+            'label' => __('Icon Position', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::SELECT,
+            'options' => [
+                'before' => __('Before', 'gm2-category-sort'),
+                'after'  => __('After', 'gm2-category-sort'),
+            ],
+            'default' => 'before',
+        ]);
+
+        $this->end_controls_section();
+
         if ( current_user_can( 'manage_options' ) ) {
             $this->start_controls_section( 'gm2_tools_section', [
                 'label' => __( 'Tools', 'gm2-category-sort' ),
@@ -138,10 +481,12 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
         
         // Pass settings to renderer
         $renderer = new Gm2_Category_Sort_Renderer([
-            'parent_categories' => $settings['parent_categories'],
-            'filter_type' => $settings['filter_type'],
-            'simple_operator' => $settings['simple_operator'],
-            'widget_id' => $this->get_id()
+            'parent_categories'    => $settings['parent_categories'],
+            'filter_type'          => $settings['filter_type'],
+            'simple_operator'      => $settings['simple_operator'],
+            'widget_id'            => $this->get_id(),
+            'synonym_icon'         => $settings['synonym_icon'],
+            'synonym_icon_position'=> $settings['synonym_icon_position'],
         ]);
         
         echo $renderer->generate_html();


### PR DESCRIPTION
## Summary
- add Elementor style controls for widget box, each category depth, selected categories and synonyms
- allow synonym icons in rendered output
- reference depth classes in stylesheet
- bump version constant

## Testing
- `npm run build` *(fails: babel not found)*
- `phpunit -c phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684da510eb3c8327afda36f888b1dd3d