### PR TITLE
Update negation patterns

### DIFF
--- a/includes/class-product-category-generator.php
+++ b/includes/class-product-category-generator.php
@@ -23,6 +23,9 @@ class Gm2_Category_Sort_Product_Category_Generator {
         'does\s+not\s+fit\s+%s',
         'without\s+%s',
         'except\s+for\s+%s',
+        'not\s+compatible\s+with\s+%s',
+        'not\s+recommended\s+for\s+%s',
+        'not\s+intended\s+for\s+%s',
     ];
 
     /**

--- a/scripts/generate_product_categories.py
+++ b/scripts/generate_product_categories.py
@@ -25,6 +25,9 @@ NEGATION_PATTERNS = [
     r"does\s+not\s+fit\s+{}",
     r"without\s+{}",
     r"except\s+for\s+{}",
+    r"not\s+compatible\s+with\s+{}",
+    r"not\s+recommended\s+for\s+{}",
+    r"not\s+intended\s+for\s+{}",
 ]
 
 

--- a/tests/ProductCategoryGeneratorTest.php
+++ b/tests/ProductCategoryGeneratorTest.php
@@ -85,4 +85,20 @@ class ProductCategoryGeneratorTest extends TestCase {
 
         $this->assertSame( [ 'Hubcap' ], $cats );
     }
+
+    public function test_ignores_additional_negation_patterns() {
+        $this->create_categories();
+
+        $mapping = Gm2_Category_Sort_Product_Category_Generator::build_mapping_from_globals();
+        $phrases = [
+            'This is not compatible with alt parts',
+            'Item not recommended for alt equipment',
+            'Package not intended for alt usage',
+        ];
+
+        foreach ( $phrases as $phrase ) {
+            $cats = Gm2_Category_Sort_Product_Category_Generator::assign_categories( $phrase, $mapping );
+            $this->assertSame( [], $cats, $phrase );
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- expand negation patterns in PHP and Python implementations
- test the new phrases

## Testing
- `vendor/bin/phpunit` *(fails: `/usr/bin/env: ‘php’: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_684da81888748327984440b0bf43983b