### PR TITLE
Add icon support for category toggles

### DIFF
--- a/assets/dist/frontend.js
+++ b/assets/dist/frontend.js
@@ -112,14 +112,25 @@ jQuery(document).ready(function ($) {
     var $button = $(this);
     var $childContainer = $button.closest('.gm2-category-node').find('> .gm2-child-categories');
     var isExpanded = $button.data('expanded') === 'true';
+    var $icon = $button.find('i').first();
+    var expandClass = $button.data('expand-class');
+    var collapseClass = $button.data('collapse-class');
     if (isExpanded) {
       $childContainer.slideUp();
-      $button.text('+');
-      $button.data('expanded', 'false');
+      if ($icon.length && expandClass && collapseClass) {
+        $icon.removeClass(collapseClass).addClass(expandClass);
+      } else {
+        $button.text('+');
+      }
+      $button.data('expanded', 'false').removeClass('gm2-expanded');
     } else {
       $childContainer.slideDown();
-      $button.text('-');
-      $button.data('expanded', 'true');
+      if ($icon.length && expandClass && collapseClass) {
+        $icon.removeClass(expandClass).addClass(collapseClass);
+      } else {
+        $button.text('-');
+      }
+      $button.data('expanded', 'true').addClass('gm2-expanded');
     }
   });
   function gm2HandleCategoryClick(e) {

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -101,15 +101,26 @@ jQuery(document).ready(function($) {
         const $button = $(this);
         const $childContainer = $button.closest('.gm2-category-node').find('> .gm2-child-categories');
         const isExpanded = $button.data('expanded') === 'true';
-        
+        const $icon = $button.find('i').first();
+        const expandClass = $button.data('expand-class');
+        const collapseClass = $button.data('collapse-class');
+
         if (isExpanded) {
             $childContainer.slideUp();
-            $button.text('+');
-            $button.data('expanded', 'false');
+            if ($icon.length && expandClass && collapseClass) {
+                $icon.removeClass(collapseClass).addClass(expandClass);
+            } else {
+                $button.text('+');
+            }
+            $button.data('expanded', 'false').removeClass('gm2-expanded');
         } else {
             $childContainer.slideDown();
-            $button.text('-');
-            $button.data('expanded', 'true');
+            if ($icon.length && expandClass && collapseClass) {
+                $icon.removeClass(expandClass).addClass(collapseClass);
+            } else {
+                $button.text('-');
+            }
+            $button.data('expanded', 'true').addClass('gm2-expanded');
         }
     });
 

--- a/includes/class-renderer.php
+++ b/includes/class-renderer.php
@@ -133,7 +133,11 @@ class Gm2_Category_Sort_Renderer {
         }
         
         if ($has_children) {
-            echo '<button class="gm2-expand-button" data-expanded="false">+</button>';
+            $expand_class   = ! empty( $this->settings['expand_icon']['value'] ) ? $this->settings['expand_icon']['value'] : '';
+            $collapse_class = ! empty( $this->settings['collapse_icon']['value'] ) ? $this->settings['collapse_icon']['value'] : '';
+            $expand_html    = $expand_class ? '<i class="' . esc_attr( $expand_class ) . '"></i>' : '<i>+</i>';
+
+            echo '<button class="gm2-expand-button" data-expanded="false" data-expand-class="' . esc_attr( $expand_class ) . '" data-collapse-class="' . esc_attr( $collapse_class ) . '">' . $expand_html . '</button>';
         }
         echo '</div>';
         echo '</div>';

--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -245,6 +245,57 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
             $this->end_controls_section();
         }
 
+        // Expand/Collapse Icons
+        $this->start_controls_section('gm2_expand_section', [
+            'label' => __('Expand/Collapse', 'gm2-category-sort'),
+            'tab'   => \Elementor\Controls_Manager::TAB_STYLE,
+        ]);
+
+        $this->add_control('expand_icon', [
+            'label'   => __('Expand Icon', 'gm2-category-sort'),
+            'type'    => \Elementor\Controls_Manager::ICONS,
+            'default' => [
+                'value'   => 'fas fa-plus',
+                'library' => 'fa-solid',
+            ],
+        ]);
+
+        $this->add_control('collapse_icon', [
+            'label'   => __('Collapse Icon', 'gm2-category-sort'),
+            'type'    => \Elementor\Controls_Manager::ICONS,
+            'default' => [
+                'value'   => 'fas fa-minus',
+                'library' => 'fa-solid',
+            ],
+        ]);
+
+        $this->add_control('expand_icon_color', [
+            'label' => __('Icon Color', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::COLOR,
+            'selectors' => [
+                '{{WRAPPER}} .gm2-expand-button i' => 'color: {{VALUE}};',
+            ],
+        ]);
+
+        $this->add_control('expand_icon_hover_color', [
+            'label' => __('Icon Hover Color', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::COLOR,
+            'selectors' => [
+                '{{WRAPPER}} .gm2-expand-button:hover i' => 'color: {{VALUE}};',
+            ],
+        ]);
+
+        $this->add_control('expand_icon_active_color', [
+            'label' => __('Icon Active Color', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::COLOR,
+            'selectors' => [
+                '{{WRAPPER}} .gm2-expand-button.gm2-expanded i' => 'color: {{VALUE}};',
+                '{{WRAPPER}} .gm2-expand-button[data-expanded="true"] i' => 'color: {{VALUE}};',
+            ],
+        ]);
+
+        $this->end_controls_section();
+
         // Selected Categories
         $this->start_controls_section('gm2_selected_section', [
             'label' => __('Selected Categories', 'gm2-category-sort'),
@@ -487,6 +538,8 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
             'widget_id'            => $this->get_id(),
             'synonym_icon'         => $settings['synonym_icon'],
             'synonym_icon_position'=> $settings['synonym_icon_position'],
+            'expand_icon'          => $settings['expand_icon'],
+            'collapse_icon'        => $settings['collapse_icon'],
         ]);
         
         echo $renderer->generate_html();


### PR DESCRIPTION
## Summary
- add expand/collapse icon controls to widget options
- output chosen icons in renderer
- toggle icon classes on expand/collapse via JS
- compile frontend assets

## Testing
- `npm run build`
- `./vendor/bin/phpunit -c phpunit.xml` *(fails: `/usr/bin/env: ‘php’: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_684da7e01e048327a3397050114e050b