### PR TITLE
Add 'over the lug' synonym

### DIFF
--- a/Research/Category Tree With Synonyms-Auto Enhance-13 JUN - Category Tree With Synonyms-Auto Enhance-13 JUN.csv
+++ b/Research/Category Tree With Synonyms-Auto Enhance-13 JUN - Category Tree With Synonyms-Auto Enhance-13 JUN.csv
@@ -143,7 +143,7 @@
 "Wheel Simulators (Rim Liners,Hubcaps,Wheel Covers)",By Fit Type,"Clip-On Wheel Simulators (Clip-On Rim Liners,Clip-On Hubcaps,Clip-On Wheel Covers)",
 "Wheel Simulators (Rim Liners,Hubcaps,Wheel Covers)",By Fit Type,"Screw-On Wheel Simulators (Screw-On Rim Liners,Screw-On Hubcaps,Screw-On Wheel Covers)",
 "Wheel Simulators (Rim Liners,Hubcaps,Wheel Covers)",By Fit Type,"Lug-Nut Mount Wheel Simulators (Lug-Nut Mount Rim Liners,Lug-Nut Mount Hubcaps,Lug-Nut Mount Wheel Covers)",
-"Wheel Simulators (Rim Liners,Hubcaps,Wheel Covers)",By Fit Type,"Over-Lug Mount Wheel Simulators (Over-Lug Mount Rim Liners,Over-Lug Mount Hubcaps,Over-Lug Mount Wheel Covers)",
+"Wheel Simulators (Rim Liners,Hubcaps,Wheel Covers)",By Fit Type,"Over-Lug Mount Wheel Simulators (Over-Lug Mount Rim Liners,Over-Lug Mount Hubcaps,Over-Lug Mount Wheel Covers,Over Lug Mount Wheel Simulators,Over Lug Mount Rim Liners,Over Lug Mount Hubcaps,Over Lug Mount Wheel Covers,Over the Lug Mount Wheel Simulators,Over the Lug Mount Rim Liners,Over the Lug Mount Hubcaps,Over the Lug Mount Wheel Covers,Over Lug,Over the Lug)",
 "Wheel Simulators (Rim Liners,Hubcaps,Wheel Covers)",By Fit Type,"Ring Mount Wheel Simulators (Ring Mount Rim Liners,Ring Mount Hubcaps,Ring Mount Wheel Covers)",
 "Wheel Simulators (Rim Liners,Hubcaps,Wheel Covers)",By Material,"Stainless Steel Wheel Simulators (Stainless Steel Rim Liners,Stainless Steel Hubcaps,Stainless Steel Wheel Covers)",
 "Wheel Simulators (Rim Liners,Hubcaps,Wheel Covers)",By Vehicle Type,"Truck Wheel Simulators (Truck Rim Liners,Truck Hubcaps,Truck Wheel Covers)",

--- a/includes/class-product-category-generator.php
+++ b/includes/class-product-category-generator.php
@@ -15,6 +15,7 @@ class Gm2_Category_Sort_Product_Category_Generator {
         'wheelcover'      => 'wheel cover',
         'wheel-simulator' => 'wheel simulator',
         'wheel-simulators'=> 'wheel simulator',
+        'over-lug'        => 'over lug',
     ];
 
     /** @var string[] */

--- a/scripts/generate_product_categories.py
+++ b/scripts/generate_product_categories.py
@@ -18,6 +18,7 @@ REPLACEMENTS = {
     "wheelcover": "wheel cover",
     "wheel-simulator": "wheel simulator",
     "wheel-simulators": "wheel simulator",
+    "over-lug": "over lug",
 }
 
 NEGATION_PATTERNS = [

--- a/tests/AutoAssignTest.php
+++ b/tests/AutoAssignTest.php
@@ -236,5 +236,18 @@ class AutoAssignTest extends TestCase {
         $this->assertFalse( $calls[0]['append'] );
         $this->assertFalse( $calls[1]['append'] );
     }
+
+    public function test_cli_recognizes_over_the_lug_synonym() {
+        $term = wp_insert_term( 'Over-Lug', 'product_cat' );
+        update_term_meta( $term['term_id'], 'gm2_synonyms', 'Over Lug,Over the Lug' );
+
+        $GLOBALS['gm2_product_objects'][1] = new TestProduct( 1, 'Prod X', 'Works over the lug', 'S3' );
+
+        Gm2_Category_Sort_Auto_Assign::cli_run( [], [] );
+
+        $calls = $GLOBALS['gm2_set_terms_calls'];
+        $this->assertCount( 1, $calls );
+        $this->assertSame( [ $term['term_id'] ], $calls[0]['terms'] );
+    }
 }
 }

--- a/tests/ProductCategoryGeneratorTest.php
+++ b/tests/ProductCategoryGeneratorTest.php
@@ -101,4 +101,16 @@ class ProductCategoryGeneratorTest extends TestCase {
             $this->assertSame( [], $cats, $phrase );
         }
     }
+
+    public function test_over_the_lug_synonym() {
+        $cat = wp_insert_term( 'Over-Lug', 'product_cat' );
+        update_term_meta( $cat['term_id'], 'gm2_synonyms', 'Over Lug,Over the Lug' );
+
+        $mapping = Gm2_Category_Sort_Product_Category_Generator::build_mapping_from_globals();
+        $text    = 'Works with over the lug wheels';
+
+        $cats = Gm2_Category_Sort_Product_Category_Generator::assign_categories( $text, $mapping );
+
+        $this->assertSame( [ 'Over-Lug' ], $cats );
+    }
 }


### PR DESCRIPTION
## Summary
- normalize "over-lug" tokens in both PHP and Python generators
- expand Over-Lug synonyms in category CSV
- verify Over-Lug synonyms in category generation and auto assign tests

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_684db13a3f0c832784bdf50ce0e95366