### PR TITLE
Fix CSV parsing for long descriptions

### DIFF
--- a/scripts/generate_product_categories.py
+++ b/scripts/generate_product_categories.py
@@ -5,6 +5,7 @@ import argparse
 import csv
 import os
 import re
+import sys
 from typing import Dict, List
 
 # Common replacements for token normalization
@@ -125,6 +126,9 @@ def main():
     args = parser.parse_args()
 
     mapping = load_category_mapping(args.categories)
+
+    # Allow extremely large fields for product descriptions
+    csv.field_size_limit(sys.maxsize)
 
     with open(args.products, newline='', encoding='utf-8-sig') as pf, open(args.output, 'w', newline='', encoding='utf-8') as out:
         reader = csv.DictReader(pf)


### PR DESCRIPTION
## Summary
- ensure CSV parser handles long product descriptions

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_684db2b1e3c883279126bbf85e19a6aa