### PR TITLE
Add synonym position style control

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -62,10 +62,34 @@
 }
 
 .gm2-synonyms {
-    margin-left: 5px;
     font-style: italic;
     color: #666;
     font-size: 0.9em;
+}
+
+.gm2-synonyms-container {
+    display: flex;
+    flex-wrap: wrap;
+}
+
+.elementor-widget-gm2-category-sort.gm2-synonym-pos-inline .gm2-category-name-container {
+    flex-direction: row;
+    align-items: center;
+}
+
+.elementor-widget-gm2-category-sort.gm2-synonym-pos-inline .gm2-synonyms-container {
+    margin-left: 5px;
+    margin-top: 0;
+}
+
+.elementor-widget-gm2-category-sort.gm2-synonym-pos-below .gm2-category-name-container {
+    flex-direction: column;
+    align-items: flex-start;
+}
+
+.elementor-widget-gm2-category-sort.gm2-synonym-pos-below .gm2-synonyms-container {
+    margin-left: 0;
+    margin-top: 5px;
 }
 
 .gm2-category-synonym {

--- a/includes/class-renderer.php
+++ b/includes/class-renderer.php
@@ -103,7 +103,7 @@ class Gm2_Category_Sort_Renderer {
 
         $synonyms = isset($term->gm2_synonyms) ? $term->gm2_synonyms : array_filter(array_map('trim', explode(',', (string) get_term_meta($term->term_id, 'gm2_synonyms', true))));
         if (!empty($synonyms)) {
-            echo ' <span class="gm2-synonyms">(';
+            echo '<div class="gm2-synonyms-container"><span class="gm2-synonyms">(';
             $first = true;
             foreach ($synonyms as $syn) {
                 if (!$syn) continue;
@@ -129,7 +129,7 @@ class Gm2_Category_Sort_Renderer {
                 echo '<a class="gm2-category-synonym depth-' . intval( $depth ) . '" data-term-id="' . esc_attr($term->term_id) . '" href="' . esc_url($href) . '">' . $link_content . '</a>';
                 $first = false;
             }
-            echo ')</span>';
+            echo ')</span></div>';
         }
         
         if ($has_children) {

--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -486,6 +486,17 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
             'default' => 'before',
         ]);
 
+        $this->add_control('synonym_position', [
+            'label' => __('Synonym Position', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::SELECT,
+            'options' => [
+                'inline' => __('Inline', 'gm2-category-sort'),
+                'below'  => __('Below', 'gm2-category-sort'),
+            ],
+            'default' => 'inline',
+            'prefix_class' => 'gm2-synonym-pos-'
+        ]);
+
         $this->end_controls_section();
 
         if ( current_user_can( 'manage_options' ) ) {


### PR DESCRIPTION
## Summary
- introduce synonym_position style control
- wrap synonym links in a container
- style synonyms inline or below via new class selectors

## Testing
- `phpunit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684db2c9b8288327b6e4888e3679398e