### PR TITLE
Add optional fuzzy match with tests

### DIFF
--- a/assets/js/auto-assign.js
+++ b/assets/js/auto-assign.js
@@ -10,13 +10,14 @@ jQuery(function($){
         });
     }
 
-    function step(offset, reset, overwrite){
+    function step(offset, reset, overwrite, fuzzy){
         $.post(ajaxurl, {
             action: 'gm2_auto_assign_step',
             nonce: gm2AutoAssign.nonce,
             offset: offset,
             reset: reset ? 1 : 0,
-            overwrite: overwrite ? 1 : 0
+            overwrite: overwrite ? 1 : 0,
+            fuzzy: fuzzy ? 1 : 0
         }).done(function(resp){
             if(!resp.success){
                 log.append('<div class="error">'+ (resp.data || gm2AutoAssign.error) +'</div>');
@@ -24,7 +25,7 @@ jQuery(function($){
             }
             append(resp.data.items);
             if(!resp.data.done){
-                step(resp.data.offset, false, overwrite);
+                step(resp.data.offset, false, overwrite, fuzzy);
             }else{
                 log.append('<div>'+ gm2AutoAssign.completed +'</div>');
             }
@@ -37,6 +38,7 @@ jQuery(function($){
         e.preventDefault();
         log.empty();
         var overwrite = $('input[name="gm2_overwrite"]:checked').val();
-        step(0, true, overwrite);
+        var fuzzy = $('#gm2_fuzzy').is(':checked');
+        step(0, true, overwrite, fuzzy);
     });
 });

--- a/includes/class-auto-assign.php
+++ b/includes/class-auto-assign.php
@@ -90,6 +90,12 @@ class Gm2_Category_Sort_Auto_Assign {
                     <?php esc_html_e( 'Overwrite categories', 'gm2-category-sort' ); ?>
                 </label>
             </p>
+            <p>
+                <label>
+                    <input type="checkbox" id="gm2_fuzzy" value="1">
+                    <?php esc_html_e( 'Use fuzzy matching', 'gm2-category-sort' ); ?>
+                </label>
+            </p>
             <p><button id="gm2-auto-assign-start" class="button button-primary"><?php esc_html_e( 'Start Auto Assign', 'gm2-category-sort' ); ?></button></p>
             <div id="gm2-auto-assign-log" style="background:#fff;border:1px solid #ccc;padding:10px;max-height:400px;overflow:auto;">
                 <?php foreach ( $log as $line ) : ?>
@@ -173,6 +179,7 @@ class Gm2_Category_Sort_Auto_Assign {
 
         $reset     = ! empty( $_POST['reset'] );
         $overwrite = ! empty( $_POST['overwrite'] );
+        $fuzzy     = ! empty( $_POST['fuzzy'] );
         $progress = get_option( 'gm2_auto_assign_progress', [ 'offset' => 0, 'log' => [] ] );
         if ( $reset ) {
             $progress = [ 'offset' => 0, 'log' => [] ];
@@ -209,7 +216,7 @@ class Gm2_Category_Sort_Auto_Assign {
                 }
             }
 
-            $cats      = Gm2_Category_Sort_Product_Category_Generator::assign_categories( $text, $mapping );
+            $cats      = Gm2_Category_Sort_Product_Category_Generator::assign_categories( $text, $mapping, $fuzzy );
             $term_ids  = [];
             foreach ( $cats as $name ) {
                 $term = get_term_by( 'name', $name, 'product_cat' );
@@ -259,6 +266,7 @@ class Gm2_Category_Sort_Auto_Assign {
      */
     public static function cli_run( $args, $assoc_args ) {
         $overwrite = ! empty( $assoc_args['overwrite'] );
+        $fuzzy     = ! empty( $assoc_args['fuzzy'] );
         $mapping   = self::build_mapping();
 
         $total    = wp_count_posts( 'product' )->publish;
@@ -306,7 +314,7 @@ class Gm2_Category_Sort_Auto_Assign {
                     }
                 }
 
-                $cats     = Gm2_Category_Sort_Product_Category_Generator::assign_categories( $text, $mapping );
+                $cats     = Gm2_Category_Sort_Product_Category_Generator::assign_categories( $text, $mapping, $fuzzy );
                 $term_ids = [];
                 foreach ( $cats as $name ) {
                     $term = get_term_by( 'name', $name, 'product_cat' );

--- a/tests/AutoAssignTest.php
+++ b/tests/AutoAssignTest.php
@@ -249,5 +249,17 @@ class AutoAssignTest extends TestCase {
         $this->assertCount( 1, $calls );
         $this->assertSame( [ $term['term_id'] ], $calls[0]['terms'] );
     }
+
+    public function test_cli_fuzzy_matching() {
+        $wheel = wp_insert_term( 'Wheel', 'product_cat' );
+
+        $GLOBALS['gm2_product_objects'][1] = new TestProduct( 1, 'Prod F', 'Stylish wheell kit', 'S1' );
+
+        Gm2_Category_Sort_Auto_Assign::cli_run( [], [ 'fuzzy' => 1 ] );
+
+        $calls = $GLOBALS['gm2_set_terms_calls'];
+        $this->assertCount( 1, $calls );
+        $this->assertSame( [ $wheel['term_id'] ], $calls[0]['terms'] );
+    }
 }
 }

--- a/tests/ProductCategoryGeneratorTest.php
+++ b/tests/ProductCategoryGeneratorTest.php
@@ -113,4 +113,15 @@ class ProductCategoryGeneratorTest extends TestCase {
 
         $this->assertSame( [ 'Over-Lug' ], $cats );
     }
+
+    public function test_fuzzy_matches_misspelling() {
+        $wheel = wp_insert_term( 'Wheel', 'product_cat' );
+
+        $mapping = Gm2_Category_Sort_Product_Category_Generator::build_mapping_from_globals();
+        $text    = 'Heavy duty wheell cover';
+
+        $cats = Gm2_Category_Sort_Product_Category_Generator::assign_categories( $text, $mapping, true );
+
+        $this->assertSame( [ 'Wheel' ], $cats );
+    }
 }


### PR DESCRIPTION
## Summary
- support optional fuzzy search in product category generator
- expose fuzzy option in auto assign UI, CLI, and helper script
- update JS helper to send fuzzy flag
- test fuzzy behaviour on misspellings

## Testing
- `vendor/bin/phpunit -c phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_684db349fe248327bc466302e3164d05