### PR TITLE
Add layout controls and styling options

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -19,6 +19,18 @@
     list-style: none;
 }
 
+.elementor-widget-gm2-category-sort.gm2-display-inline .gm2-category-node {
+    display: inline-block;
+    width: auto;
+    margin-right: 5px;
+}
+
+.elementor-widget-gm2-category-sort.gm2-display-inline .gm2-parent-categories-container,
+.elementor-widget-gm2-category-sort.gm2-display-inline .gm2-child-categories {
+    display: flex;
+    flex-wrap: wrap;
+}
+
 .gm2-category-header {
     display: flex;
     align-items: center;

--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -134,6 +134,57 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
 
         $this->end_controls_section();
 
+        // Layout
+        $this->start_controls_section('gm2_layout_section', [
+            'label' => __('Layout', 'gm2-category-sort'),
+            'tab'   => \Elementor\Controls_Manager::TAB_STYLE,
+        ]);
+
+        $this->add_control('display_mode', [
+            'label' => __('Display Mode', 'gm2-category-sort'),
+            'type' => \Elementor\Controls_Manager::SELECT,
+            'options' => [
+                'block'  => __('Block', 'gm2-category-sort'),
+                'inline' => __('Inline', 'gm2-category-sort'),
+            ],
+            'default' => 'block',
+            'prefix_class' => 'gm2-display-'
+        ]);
+
+        $this->add_responsive_control('vertical_spacing', [
+            'label' => __('Vertical Spacing', 'gm2-category-sort'),
+            'type' => \Elementor\Controls_Manager::SLIDER,
+            'size_units' => ['px'],
+            'range' => [
+                'px' => ['min' => 0, 'max' => 50],
+            ],
+            'default' => [
+                'size' => 5,
+                'unit' => 'px',
+            ],
+            'selectors' => [
+                '{{WRAPPER}} .gm2-category-node' => 'margin-bottom: {{SIZE}}{{UNIT}};'
+            ],
+        ]);
+
+        $this->add_responsive_control('horizontal_spacing', [
+            'label' => __('Horizontal Spacing', 'gm2-category-sort'),
+            'type' => \Elementor\Controls_Manager::SLIDER,
+            'size_units' => ['px'],
+            'range' => [
+                'px' => ['min' => 0, 'max' => 50],
+            ],
+            'default' => [
+                'size' => 5,
+                'unit' => 'px',
+            ],
+            'selectors' => [
+                '{{WRAPPER}}.gm2-display-inline .gm2-category-node' => 'margin-right: {{SIZE}}{{UNIT}};'
+            ],
+        ]);
+
+        $this->end_controls_section();
+
         // Category Levels
         for ( $i = 0; $i <= 3; $i++ ) {
             $this->start_controls_section( 'gm2_depth_' . $i . '_section', [


### PR DESCRIPTION
## Summary
- add layout controls for display mode, vertical spacing and horizontal spacing
- style inline display of category nodes
- keep spacing customizable via Elementor

## Testing
- `bash bin/install-phpunit.sh`
- `vendor/bin/phpunit`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684db476b59083278b8e51be9f2b593c