### PR TITLE
Update README with PHP requirement and composer config

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,8 +201,13 @@ This project is licensed under the MIT License. See [LICENSE](LICENSE) for detai
 
 To run the test suite:
 
-1. Ensure PHP 7.3 or newer is installed and available in your `$PATH` (required by PHPUnit 9). On local setups you can install it with `apt-get install php` or your package manager.
-2. Execute `bin/install-phpunit.sh` to download PHPUnit (Composer will be used if present).
+1. Install PHP 7.3 or newer and ensure it is available in your `$PATH`. The
+   `bin/install-phpunit.sh` script requires PHP, so it **must** be installed
+   before running the script. On local setups you can install PHP with
+   `apt-get install php` or your package manager.
+2. Execute `bin/install-phpunit.sh` to download PHPUnit. If you have Composer
+   installed you may alternatively run `composer install` which will fetch
+   PHPUnit automatically using the provided `composer.json`.
 3. From the project root run:
 
 ```bash

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,8 @@
+{
+    "name": "gm2/category-sort",
+    "description": "Gm2 Category Sort plugin",
+    "type": "project",
+    "require-dev": {
+        "phpunit/phpunit": "^9"
+    }
+}


### PR DESCRIPTION
## Summary
- clarify that PHP must be installed before running `bin/install-phpunit.sh`
- mention `composer install` alternative for fetching PHPUnit
- add `composer.json` containing phpunit as a dev dependency

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_684db4980c0083278a48febcdc44c397