### PR TITLE
Add manual search and assign functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,15 @@ Success: Auto assign complete.
 ```
 Add `--overwrite` to replace existing categories instead of appending.
 
+### Manual Search and Assign
+
+Below the log the page provides a search form to manually select products.
+Choose which fields to search (title, description or attributes), enter a
+keyword and click **Search** to build a list of matching products. Additional
+products can be looked up by SKU or title in the second search box. After
+selecting one or more categories from the list, click **Assign** to apply them
+to all products in the list.
+
 During analysis common negative phrases such as `not for`, `does not fit` or
 `without` are detected and prevent category matches. The tool also performs
 basic stemming so minor wording differences like `lugs` vs `lug`,

--- a/assets/js/auto-assign.js
+++ b/assets/js/auto-assign.js
@@ -41,4 +41,93 @@ jQuery(function($){
         var fuzzy = $('#gm2_fuzzy').is(':checked');
         step(0, true, overwrite, fuzzy);
     });
+
+    // --- Manual search and assign ---
+    var searchBtn = $('#gm2-search-btn');
+    var searchFields = $('#gm2-search-fields');
+    var searchTerms = $('#gm2-search-terms');
+    var productList = $('#gm2-product-list');
+    var productSearch = $('#gm2-product-search');
+    var assignBtn = $('#gm2-assign-btn');
+    var catSelect = $('#gm2-category-select');
+
+    if(searchBtn.length){
+        var products = {};
+
+        function renderList(){
+            productList.empty();
+            Object.values(products).forEach(function(p){
+                var li = $('<li>').attr('data-id', p.id).text(p.sku+' - '+p.title);
+                $('<a href="#" class="gm2-remove">&times;</a>').appendTo(li);
+                productList.append(li);
+            });
+        }
+
+        function addItems(items){
+            items.forEach(function(p){
+                if(!products[p.id]) products[p.id] = p;
+            });
+            renderList();
+        }
+
+        productList.on('click','.gm2-remove', function(e){
+            e.preventDefault();
+            var id = $(this).parent().data('id');
+            delete products[id];
+            renderList();
+        });
+
+        searchBtn.on('click', function(e){
+            e.preventDefault();
+            var fields = searchFields.val() || [];
+            var term = searchTerms.val();
+            $.post(ajaxurl, {
+                action: 'gm2_auto_assign_search',
+                nonce: gm2AutoAssign.nonce,
+                fields: fields,
+                search: term
+            }).done(function(resp){
+                if(resp.success){
+                    addItems(resp.data.items);
+                }
+            });
+        });
+
+        productSearch.on('keypress', function(e){
+            if(e.which === 13){
+                e.preventDefault();
+                var q = $(this).val();
+                $.post(ajaxurl, {
+                    action: 'gm2_auto_assign_search',
+                    nonce: gm2AutoAssign.nonce,
+                    fields: ['title','description','attributes'],
+                    search: q
+                }).done(function(resp){
+                    if(resp.success){
+                        addItems(resp.data.items);
+                    }
+                });
+            }
+        });
+
+        assignBtn.on('click', function(e){
+            e.preventDefault();
+            var ids = Object.keys(products);
+            var cats = catSelect.val() || [];
+            if(!ids.length || !cats.length) return;
+            var overwrite = $('input[name="gm2_overwrite"]:checked').val();
+            $.post(ajaxurl, {
+                action: 'gm2_auto_assign_selected',
+                nonce: gm2AutoAssign.nonce,
+                products: ids,
+                categories: cats,
+                overwrite: overwrite
+            }).done(function(resp){
+                if(resp.success){
+                    products = {};
+                    renderList();
+                }
+            });
+        });
+    }
 });

--- a/tests/AutoAssignTest.php
+++ b/tests/AutoAssignTest.php
@@ -80,6 +80,9 @@ if ( ! function_exists( 'update_option' ) ) {
 if ( ! function_exists( 'sanitize_text_field' ) ) {
     function sanitize_text_field( $str ) { return $str; }
 }
+if ( ! function_exists( 'sanitize_key' ) ) {
+    function sanitize_key( $str ) { return $str; }
+}
 
 if ( ! function_exists( 'wc_get_product' ) ) {
     function wc_get_product( $id ) {
@@ -134,6 +137,7 @@ class AutoAssignTest extends TestCase {
         $GLOBALS['gm2_product_objects'] = [];
         $GLOBALS['gm2_json_result'] = null;
         \WP_CLI::$success_messages = [];
+        $_POST = [];
     }
 
     private function create_categories() {
@@ -260,6 +264,37 @@ class AutoAssignTest extends TestCase {
         $calls = $GLOBALS['gm2_set_terms_calls'];
         $this->assertCount( 1, $calls );
         $this->assertSame( [ $wheel['term_id'] ], $calls[0]['terms'] );
+    }
+
+    public function test_ajax_search_products() {
+        $this->create_products();
+
+        $_POST['nonce'] = 't';
+        $_POST['fields'] = [ 'title' ];
+        $_POST['search'] = 'Prod One';
+
+        Gm2_Category_Sort_Auto_Assign::ajax_search_products();
+
+        $result = $GLOBALS['gm2_json_result'];
+        $this->assertTrue( $result['success'] );
+        $this->assertCount( 1, $result['data']['items'] );
+        $this->assertSame( 'SKU1', $result['data']['items'][0]['sku'] );
+    }
+
+    public function test_ajax_assign_selected() {
+        $term = wp_insert_term( 'NewCat', 'product_cat' );
+        $this->create_products();
+
+        $_POST['nonce'] = 't';
+        $_POST['products'] = [1];
+        $_POST['categories'] = [ $term['term_id'] ];
+
+        Gm2_Category_Sort_Auto_Assign::ajax_assign_selected();
+
+        $calls = $GLOBALS['gm2_set_terms_calls'];
+        $this->assertCount( 1, $calls );
+        $this->assertSame( [ $term['term_id'] ], $calls[0]['terms'] );
+        $this->assertTrue( $calls[0]['append'] );
     }
 }
 }


### PR DESCRIPTION
## Summary
- extend auto-assign admin page with search tools
- implement AJAX handlers for searching products and assigning categories
- update frontend JS for search/assign interface
- document manual search feature in README
- add tests for new handlers

## Testing
- `bash bin/install-phpunit.sh`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_684cafc94c8883278508c5f146d15423