### PR TITLE
Add Elementor icon rendering support

### DIFF
--- a/includes/class-renderer.php
+++ b/includes/class-renderer.php
@@ -135,9 +135,20 @@ class Gm2_Category_Sort_Renderer {
         if ($has_children) {
             $expand_class   = ! empty( $this->settings['expand_icon']['value'] ) ? $this->settings['expand_icon']['value'] : '';
             $collapse_class = ! empty( $this->settings['collapse_icon']['value'] ) ? $this->settings['collapse_icon']['value'] : '';
-            $expand_html    = $expand_class ? '<i class="' . esc_attr( $expand_class ) . '"></i>' : '<i>+</i>';
 
-            echo '<button class="gm2-expand-button" data-expanded="false" data-expand-class="' . esc_attr( $expand_class ) . '" data-collapse-class="' . esc_attr( $collapse_class ) . '">' . $expand_html . '</button>';
+            if ( $expand_class ) {
+                $expand_html = \Elementor\Icons_Manager::render_icon( $this->settings['expand_icon'], [ 'aria-hidden' => 'true', 'class' => 'gm2-expand-icon' ] );
+            } else {
+                $expand_html = '<i class="gm2-expand-icon" aria-hidden="true">+</i>';
+            }
+
+            if ( $collapse_class ) {
+                $collapse_html = \Elementor\Icons_Manager::render_icon( $this->settings['collapse_icon'], [ 'aria-hidden' => 'true', 'class' => 'gm2-collapse-icon', 'style' => 'display:none;' ] );
+            } else {
+                $collapse_html = '<i class="gm2-collapse-icon" style="display:none;" aria-hidden="true">-</i>';
+            }
+
+            echo '<button class="gm2-expand-button" data-expanded="false" data-expand-class="' . esc_attr( $expand_class ) . '" data-collapse-class="' . esc_attr( $collapse_class ) . '">' . $expand_html . $collapse_html . '</button>';
         }
         echo '</div>';
         echo '</div>';

--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -583,7 +583,14 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
     
     protected function render() {
         $settings = $this->get_settings_for_display();
-        
+
+        if ( ! empty( $settings['expand_icon'] ) ) {
+            \Elementor\Icons_Manager::enqueue_shim( $settings['expand_icon'] );
+        }
+        if ( ! empty( $settings['collapse_icon'] ) ) {
+            \Elementor\Icons_Manager::enqueue_shim( $settings['collapse_icon'] );
+        }
+
         // Only render on WooCommerce pages
         if (!is_shop() && !is_product_category() && !is_product_taxonomy() && !is_search()) {
             echo '<div class="elementor-alert elementor-alert-info">';

--- a/tests/RendererTest.php
+++ b/tests/RendererTest.php
@@ -25,4 +25,27 @@ class RendererTest extends TestCase {
         $this->assertStringContainsString( 'gm2-category-name depth-0', $html );
         $this->assertStringContainsString( 'depth-1', $html );
     }
+
+    public function test_expand_button_contains_icon_markup() {
+        $root = wp_insert_term( 'Root', 'product_cat' );
+
+        $renderer = new Gm2_Category_Sort_Renderer([
+            'filter_type'   => 'simple',
+            'widget_id'     => '1',
+            'expand_icon'   => [ 'value' => 'fas fa-plus', 'library' => 'fa-solid' ],
+            'collapse_icon' => [ 'value' => 'fas fa-minus', 'library' => 'fa-solid' ],
+        ]);
+
+        $ref = new ReflectionClass( $renderer );
+        $method = $ref->getMethod( 'render_category_node' );
+        $method->setAccessible( true );
+
+        ob_start();
+        $term = (object) [ 'term_id' => $root['term_id'], 'name' => 'Root', 'gm2_synonyms' => [] ];
+        $method->invoke( $renderer, $term, 0 );
+        $html = ob_get_clean();
+
+        $this->assertMatchesRegularExpression( '/<(?:i|span)[^>]*fas fa-plus/', $html );
+        $this->assertMatchesRegularExpression( '/<(?:i|span)[^>]*fas fa-minus/', $html );
+    }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -169,3 +169,17 @@ if ( ! function_exists( 'add_query_arg' ) ) {
     }
 }
 
+namespace Elementor {
+    class Icons_Manager {
+        public static function render_icon( $icon, $attrs = [] ) {
+            $value = $icon['value'] ?? '';
+            $attr_str = '';
+            foreach ( $attrs as $k => $v ) {
+                $attr_str .= ' ' . $k . '="' . $v . '"';
+            }
+            return '<i class="' . $value . '"' . $attr_str . '></i>';
+        }
+        public static function enqueue_shim( $icon ) {}
+    }
+}
+


### PR DESCRIPTION
## Summary
- render expand/collapse icons with Elementor Icons Manager
- enqueue Elementor icon libraries on widget render
- stub Icons_Manager in tests and verify icon markup

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684dc1440690832786ae95744baf60dd