### PR TITLE
Fix synonym row layout

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -42,7 +42,8 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    width: 100%;
+    flex: 1;
+    width: auto;
 }
 
 .gm2-indent {
@@ -95,13 +96,15 @@
 }
 
 .elementor-widget-gm2-category-sort.gm2-synonym-pos-below .gm2-category-name-container {
-    flex-direction: column;
-    align-items: flex-start;
+    flex-wrap: wrap;
+    align-items: center;
 }
 
 .elementor-widget-gm2-category-sort.gm2-synonym-pos-below .gm2-synonyms-container {
     margin-left: 0;
     margin-top: 5px;
+    width: 100%;
+    order: 3;
 }
 
 .gm2-category-synonym {


### PR DESCRIPTION
## Summary
- keep category name container flexible without forcing a fixed width
- move only the synonyms below the main row

## Testing
- `npm run build`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dc2604d788327ad5cee3a4709f08e