### PR TITLE
Add styling controls for expand button

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ Gm2 Category Sort adds a product category sorting widget for WooCommerce shops w
    After each filter update, the page automatically scrolls back to the selected
    categories list so it's easy to refine choices.
 
+## Styling
+
+The widget's **Expand/Collapse** panel exposes design controls for the toggle
+button. You can customize the background, border, border radius and box shadow
+of the `.gm2-expand-button` element, along with responsive padding and margin.
+These settings override the defaults found in `assets/css/style.css`.
+
 ## Sorting
 
 The widget honors the WooCommerce sorting dropdown. Values like `price`,

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -113,19 +113,22 @@
 }
 
 
+/* Expand/collapse toggle */
 .gm2-expand-button {
     background: #f5f5f5;
     border: 1px solid #ddd;
     border-radius: 3px;
     width: 24px;
     height: 24px;
+    padding: 0;
+    margin: 0 0 0 10px;
     cursor: pointer;
     font-size: 16px;
     display: flex;
     align-items: center;
     justify-content: center;
     transition: all 0.2s ease;
-    margin-left: 10px;
+    box-shadow: none;
 }
 
 .gm2-expand-button:hover {

--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -345,6 +345,54 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
             ],
         ]);
 
+        $this->add_group_control(
+            \Elementor\Group_Control_Background::get_type(),
+            [
+                'name'     => 'expand_button_bg',
+                'selector' => '{{WRAPPER}} .gm2-expand-button',
+            ]
+        );
+
+        $this->add_group_control(
+            \Elementor\Group_Control_Border::get_type(),
+            [
+                'name'     => 'expand_button_border',
+                'selector' => '{{WRAPPER}} .gm2-expand-button',
+            ]
+        );
+
+        $this->add_responsive_control('expand_button_radius', [
+            'label' => __('Border Radius', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::DIMENSIONS,
+            'selectors' => [
+                '{{WRAPPER}} .gm2-expand-button' => 'border-radius: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+            ],
+        ]);
+
+        $this->add_group_control(
+            \Elementor\Group_Control_Box_Shadow::get_type(),
+            [
+                'name'     => 'expand_button_shadow',
+                'selector' => '{{WRAPPER}} .gm2-expand-button',
+            ]
+        );
+
+        $this->add_responsive_control('expand_button_padding', [
+            'label' => __('Padding', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::DIMENSIONS,
+            'selectors' => [
+                '{{WRAPPER}} .gm2-expand-button' => 'padding: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+            ],
+        ]);
+
+        $this->add_responsive_control('expand_button_margin', [
+            'label' => __('Margin', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::DIMENSIONS,
+            'selectors' => [
+                '{{WRAPPER}} .gm2-expand-button' => 'margin: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+            ],
+        ]);
+
         $this->end_controls_section();
 
         // Selected Categories


### PR DESCRIPTION
## Summary
- style gm2-expand-button via Elementor controls
- provide default expand button CSS
- document new styling options

## Testing
- `vendor/bin/phpunit` *(fails: Namespace declaration statement has to be the very first statement or after any declare call in the script)*

------
https://chatgpt.com/codex/tasks/task_e_684dc3358be88327898f7cfcad6721b8