### PR TITLE
Add icon styling controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## [Unreleased]
+### Added
+- Icon size, spacing and background controls for expand, collapse and synonym icons.
+- CSS variables provide default styling for these icons.
+
+### Migration Notes
+- Existing pages may display slightly different icon sizes. Adjust the new controls in Elementor if needed.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ Gm2 Category Sort adds a product category sorting widget for WooCommerce shops w
 The widget's **Expand/Collapse** panel exposes design controls for the toggle
 button. You can customize the background, border, border radius and box shadow
 of the `.gm2-expand-button` element, along with responsive padding and margin.
-These settings override the defaults found in `assets/css/style.css`.
+Icon size, spacing and background colours for the expand, collapse and synonym
+icons are available as separate controls. These settings override the defaults
+found in `assets/css/style.css`.
 
 ## Sorting
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -135,6 +135,71 @@
     background: #e0e0e0;
 }
 
+/* Icon defaults */
+.gm2-expand-button i,
+.gm2-expand-button svg {
+    font-size: var(--gm2-expand-icon-size, 16px);
+    width: var(--gm2-expand-icon-size, 16px);
+    height: var(--gm2-expand-icon-size, 16px);
+    margin: var(--gm2-expand-icon-spacing, 0);
+    background-color: var(--gm2-expand-icon-bg, transparent);
+    transition: all 0.2s ease;
+}
+
+.gm2-expand-button:hover i,
+.gm2-expand-button:hover svg {
+    font-size: var(--gm2-expand-icon-hover-size, var(--gm2-expand-icon-size, 16px));
+    background-color: var(--gm2-expand-icon-hover-bg, var(--gm2-expand-icon-bg, transparent));
+}
+
+.gm2-expand-button.gm2-expanded i,
+.gm2-expand-button.gm2-expanded svg,
+.gm2-expand-button[data-expanded="true"] i,
+.gm2-expand-button[data-expanded="true"] svg {
+    font-size: var(--gm2-expand-icon-active-size, var(--gm2-expand-icon-size, 16px));
+    background-color: var(--gm2-expand-icon-active-bg, var(--gm2-expand-icon-bg, transparent));
+}
+
+.gm2-collapse-icon {
+    font-size: var(--gm2-collapse-icon-size, 16px);
+    width: var(--gm2-collapse-icon-size, 16px);
+    height: var(--gm2-collapse-icon-size, 16px);
+    margin: var(--gm2-collapse-icon-spacing, 0);
+    background-color: var(--gm2-collapse-icon-bg, transparent);
+    transition: all 0.2s ease;
+}
+
+.gm2-expand-button:hover .gm2-collapse-icon {
+    font-size: var(--gm2-collapse-icon-hover-size, var(--gm2-collapse-icon-size, 16px));
+    background-color: var(--gm2-collapse-icon-hover-bg, var(--gm2-collapse-icon-bg, transparent));
+}
+
+.gm2-expand-button.gm2-expanded .gm2-collapse-icon,
+.gm2-expand-button[data-expanded="true"] .gm2-collapse-icon {
+    font-size: var(--gm2-collapse-icon-active-size, var(--gm2-collapse-icon-size, 16px));
+    background-color: var(--gm2-collapse-icon-active-bg, var(--gm2-collapse-icon-bg, transparent));
+}
+
+.gm2-synonym-icon {
+    font-size: var(--gm2-synonym-icon-size, 16px);
+    width: var(--gm2-synonym-icon-size, 16px);
+    height: var(--gm2-synonym-icon-size, 16px);
+    margin: var(--gm2-synonym-icon-spacing, 0 4px 0 0);
+    background-color: var(--gm2-synonym-icon-bg, transparent);
+    transition: all 0.2s ease;
+}
+
+.gm2-category-synonym:hover .gm2-synonym-icon {
+    font-size: var(--gm2-synonym-icon-hover-size, var(--gm2-synonym-icon-size, 16px));
+    background-color: var(--gm2-synonym-icon-hover-bg, var(--gm2-synonym-icon-bg, transparent));
+}
+
+.gm2-category-synonym.selected .gm2-synonym-icon,
+.gm2-category-synonym.active .gm2-synonym-icon {
+    font-size: var(--gm2-synonym-icon-active-size, var(--gm2-synonym-icon-size, 16px));
+    background-color: var(--gm2-synonym-icon-active-bg, var(--gm2-synonym-icon-bg, transparent));
+}
+
 .gm2-child-categories {
     padding-left: 30px;
     border-left: 1px dashed #e0e0e0;

--- a/includes/class-renderer.php
+++ b/includes/class-renderer.php
@@ -117,7 +117,7 @@ class Gm2_Category_Sort_Renderer {
                 ]);
                 $icon_html = '';
                 if ( ! empty( $this->settings['synonym_icon']['value'] ) ) {
-                    $icon_html = \Elementor\Icons_Manager::render_icon( $this->settings['synonym_icon'], [ 'aria-hidden' => 'true' ] );
+                    $icon_html = \Elementor\Icons_Manager::render_icon( $this->settings['synonym_icon'], [ 'aria-hidden' => 'true', 'class' => 'gm2-synonym-icon' ] );
                 }
                 if ( ! empty( $icon_html ) && $this->settings['synonym_icon_position'] === 'after' ) {
                     $link_content = esc_html($syn) . $icon_html;

--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -320,6 +320,64 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
             ],
         ]);
 
+        $this->add_responsive_control('expand_icon_size', [
+            'label' => __('Icon Size', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::SLIDER,
+            'size_units' => ['px'],
+            'range' => [ 'px' => ['min' => 8, 'max' => 60] ],
+            'selectors' => [
+                '{{WRAPPER}} .gm2-expand-button i, {{WRAPPER}} .gm2-expand-button svg' => 'font-size: {{SIZE}}{{UNIT}}; width: {{SIZE}}{{UNIT}}; height: {{SIZE}}{{UNIT}};',
+            ],
+        ]);
+        $this->add_responsive_control('expand_icon_hover_size', [
+            'label' => __('Icon Size (Hover)', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::SLIDER,
+            'size_units' => ['px'],
+            'range' => [ 'px' => ['min' => 8, 'max' => 60] ],
+            'selectors' => [
+                '{{WRAPPER}} .gm2-expand-button:hover i, {{WRAPPER}} .gm2-expand-button:hover svg' => 'font-size: {{SIZE}}{{UNIT}}; width: {{SIZE}}{{UNIT}}; height: {{SIZE}}{{UNIT}};',
+            ],
+        ]);
+        $this->add_responsive_control('expand_icon_active_size', [
+            'label' => __('Icon Size (Active)', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::SLIDER,
+            'size_units' => ['px'],
+            'range' => [ 'px' => ['min' => 8, 'max' => 60] ],
+            'selectors' => [
+                '{{WRAPPER}} .gm2-expand-button.gm2-expanded i, {{WRAPPER}} .gm2-expand-button[data-expanded="true"] i, {{WRAPPER}} .gm2-expand-button.gm2-expanded svg, {{WRAPPER}} .gm2-expand-button[data-expanded="true"] svg' => 'font-size: {{SIZE}}{{UNIT}}; width: {{SIZE}}{{UNIT}}; height: {{SIZE}}{{UNIT}};',
+            ],
+        ]);
+
+        $this->add_responsive_control('expand_icon_margin', [
+            'label' => __('Icon Spacing', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::DIMENSIONS,
+            'selectors' => [
+                '{{WRAPPER}} .gm2-expand-button i, {{WRAPPER}} .gm2-expand-button svg' => 'margin: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+            ],
+        ]);
+
+        $this->add_control('expand_icon_bg', [
+            'label' => __('Icon Background', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::COLOR,
+            'selectors' => [
+                '{{WRAPPER}} .gm2-expand-button i, {{WRAPPER}} .gm2-expand-button svg' => 'background-color: {{VALUE}};',
+            ],
+        ]);
+        $this->add_control('expand_icon_hover_bg', [
+            'label' => __('Icon Hover Background', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::COLOR,
+            'selectors' => [
+                '{{WRAPPER}} .gm2-expand-button:hover i, {{WRAPPER}} .gm2-expand-button:hover svg' => 'background-color: {{VALUE}};',
+            ],
+        ]);
+        $this->add_control('expand_icon_active_bg', [
+            'label' => __('Icon Active Background', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::COLOR,
+            'selectors' => [
+                '{{WRAPPER}} .gm2-expand-button.gm2-expanded i, {{WRAPPER}} .gm2-expand-button[data-expanded="true"] i, {{WRAPPER}} .gm2-expand-button.gm2-expanded svg, {{WRAPPER}} .gm2-expand-button[data-expanded="true"] svg' => 'background-color: {{VALUE}};',
+            ],
+        ]);
+
         $this->add_control('expand_icon_color', [
             'label' => __('Icon Color', 'gm2-category-sort'),
             'type'  => \Elementor\Controls_Manager::COLOR,
@@ -342,6 +400,89 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
             'selectors' => [
                 '{{WRAPPER}} .gm2-expand-button.gm2-expanded i' => 'color: {{VALUE}};',
                 '{{WRAPPER}} .gm2-expand-button[data-expanded="true"] i' => 'color: {{VALUE}};',
+            ],
+        ]);
+
+        $this->add_responsive_control('collapse_icon_size', [
+            'label' => __('Collapse Icon Size', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::SLIDER,
+            'size_units' => ['px'],
+            'range' => [ 'px' => ['min' => 8, 'max' => 60] ],
+            'selectors' => [
+                '{{WRAPPER}} .gm2-collapse-icon' => 'font-size: {{SIZE}}{{UNIT}}; width: {{SIZE}}{{UNIT}}; height: {{SIZE}}{{UNIT}};',
+            ],
+        ]);
+        $this->add_responsive_control('collapse_icon_hover_size', [
+            'label' => __('Collapse Icon Size (Hover)', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::SLIDER,
+            'size_units' => ['px'],
+            'range' => [ 'px' => ['min' => 8, 'max' => 60] ],
+            'selectors' => [
+                '{{WRAPPER}} .gm2-expand-button:hover .gm2-collapse-icon' => 'font-size: {{SIZE}}{{UNIT}}; width: {{SIZE}}{{UNIT}}; height: {{SIZE}}{{UNIT}};',
+            ],
+        ]);
+        $this->add_responsive_control('collapse_icon_active_size', [
+            'label' => __('Collapse Icon Size (Active)', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::SLIDER,
+            'size_units' => ['px'],
+            'range' => [ 'px' => ['min' => 8, 'max' => 60] ],
+            'selectors' => [
+                '{{WRAPPER}} .gm2-expand-button.gm2-expanded .gm2-collapse-icon, {{WRAPPER}} .gm2-expand-button[data-expanded="true"] .gm2-collapse-icon' => 'font-size: {{SIZE}}{{UNIT}}; width: {{SIZE}}{{UNIT}}; height: {{SIZE}}{{UNIT}};',
+            ],
+        ]);
+
+        $this->add_responsive_control('collapse_icon_margin', [
+            'label' => __('Collapse Icon Spacing', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::DIMENSIONS,
+            'selectors' => [
+                '{{WRAPPER}} .gm2-collapse-icon' => 'margin: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+            ],
+        ]);
+
+        $this->add_control('collapse_icon_bg', [
+            'label' => __('Collapse Icon Background', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::COLOR,
+            'selectors' => [
+                '{{WRAPPER}} .gm2-collapse-icon' => 'background-color: {{VALUE}};',
+            ],
+        ]);
+        $this->add_control('collapse_icon_hover_bg', [
+            'label' => __('Collapse Icon Hover Background', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::COLOR,
+            'selectors' => [
+                '{{WRAPPER}} .gm2-expand-button:hover .gm2-collapse-icon' => 'background-color: {{VALUE}};',
+            ],
+        ]);
+        $this->add_control('collapse_icon_active_bg', [
+            'label' => __('Collapse Icon Active Background', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::COLOR,
+            'selectors' => [
+                '{{WRAPPER}} .gm2-expand-button.gm2-expanded .gm2-collapse-icon, {{WRAPPER}} .gm2-expand-button[data-expanded="true"] .gm2-collapse-icon' => 'background-color: {{VALUE}};',
+            ],
+        ]);
+
+        $this->add_control('collapse_icon_color', [
+            'label' => __('Collapse Icon Color', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::COLOR,
+            'selectors' => [
+                '{{WRAPPER}} .gm2-collapse-icon' => 'color: {{VALUE}};',
+            ],
+        ]);
+
+        $this->add_control('collapse_icon_hover_color', [
+            'label' => __('Collapse Icon Hover Color', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::COLOR,
+            'selectors' => [
+                '{{WRAPPER}} .gm2-expand-button:hover .gm2-collapse-icon' => 'color: {{VALUE}};',
+            ],
+        ]);
+
+        $this->add_control('collapse_icon_active_color', [
+            'label' => __('Collapse Icon Active Color', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::COLOR,
+            'selectors' => [
+                '{{WRAPPER}} .gm2-expand-button.gm2-expanded .gm2-collapse-icon' => 'color: {{VALUE}};',
+                '{{WRAPPER}} .gm2-expand-button[data-expanded="true"] .gm2-collapse-icon' => 'color: {{VALUE}};',
             ],
         ]);
 
@@ -573,6 +714,64 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
             'label' => __('Icon', 'gm2-category-sort'),
             'type'  => \Elementor\Controls_Manager::ICONS,
             'label_block' => true,
+        ]);
+
+        $this->add_responsive_control('synonym_icon_size', [
+            'label' => __('Icon Size', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::SLIDER,
+            'size_units' => ['px'],
+            'range' => [ 'px' => ['min' => 8, 'max' => 60] ],
+            'selectors' => [
+                '{{WRAPPER}} .gm2-synonym-icon' => 'font-size: {{SIZE}}{{UNIT}}; width: {{SIZE}}{{UNIT}}; height: {{SIZE}}{{UNIT}};',
+            ],
+        ]);
+        $this->add_responsive_control('synonym_icon_hover_size', [
+            'label' => __('Icon Size (Hover)', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::SLIDER,
+            'size_units' => ['px'],
+            'range' => [ 'px' => ['min' => 8, 'max' => 60] ],
+            'selectors' => [
+                '{{WRAPPER}} .gm2-category-synonym:hover .gm2-synonym-icon' => 'font-size: {{SIZE}}{{UNIT}}; width: {{SIZE}}{{UNIT}}; height: {{SIZE}}{{UNIT}};',
+            ],
+        ]);
+        $this->add_responsive_control('synonym_icon_active_size', [
+            'label' => __('Icon Size (Active)', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::SLIDER,
+            'size_units' => ['px'],
+            'range' => [ 'px' => ['min' => 8, 'max' => 60] ],
+            'selectors' => [
+                '{{WRAPPER}} .gm2-category-synonym.selected .gm2-synonym-icon, {{WRAPPER}} .gm2-category-synonym.active .gm2-synonym-icon' => 'font-size: {{SIZE}}{{UNIT}}; width: {{SIZE}}{{UNIT}}; height: {{SIZE}}{{UNIT}};',
+            ],
+        ]);
+
+        $this->add_responsive_control('synonym_icon_margin', [
+            'label' => __('Icon Spacing', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::DIMENSIONS,
+            'selectors' => [
+                '{{WRAPPER}} .gm2-synonym-icon' => 'margin: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+            ],
+        ]);
+
+        $this->add_control('synonym_icon_bg', [
+            'label' => __('Icon Background', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::COLOR,
+            'selectors' => [
+                '{{WRAPPER}} .gm2-synonym-icon' => 'background-color: {{VALUE}};',
+            ],
+        ]);
+        $this->add_control('synonym_icon_hover_bg', [
+            'label' => __('Icon Hover Background', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::COLOR,
+            'selectors' => [
+                '{{WRAPPER}} .gm2-category-synonym:hover .gm2-synonym-icon' => 'background-color: {{VALUE}};',
+            ],
+        ]);
+        $this->add_control('synonym_icon_active_bg', [
+            'label' => __('Icon Active Background', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::COLOR,
+            'selectors' => [
+                '{{WRAPPER}} .gm2-category-synonym.selected .gm2-synonym-icon, {{WRAPPER}} .gm2-category-synonym.active .gm2-synonym-icon' => 'background-color: {{VALUE}};',
+            ],
         ]);
 
         $this->add_control('synonym_icon_position', [


### PR DESCRIPTION
## Summary
- support custom icon size, margin and background colours
- add CSS variables and default styling for icon states
- document icon styling options
- add migration notes

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dc545d35c832798a678cf1183d273