### PR TITLE
Add per-depth display mode options

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ Icon size, spacing and background colours for the expand, collapse and synonym
 icons are available as separate controls. These settings override the defaults
 found in `assets/css/style.css`.
 
+Each **Category Level** section also includes a **Display Mode** control. This
+mirrors the global layout options but applies only to that depth. Choosing
+`Inline` adds a `gm2-depth-#-display-inline` class to the widget so categories at
+the selected level render side-by-side.
+
 ## Sorting
 
 The widget honors the WooCommerce sorting dropdown. Values like `price`,

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -31,6 +31,34 @@
     flex-wrap: wrap;
 }
 
+.elementor-widget-gm2-category-sort.gm2-depth-0-display-inline .gm2-category-name.depth-0,
+.elementor-widget-gm2-category-sort.gm2-depth-0-display-inline .gm2-category-node.depth-0 {
+    display: inline-block;
+    width: auto;
+    margin-right: 5px;
+}
+
+.elementor-widget-gm2-category-sort.gm2-depth-1-display-inline .gm2-category-name.depth-1,
+.elementor-widget-gm2-category-sort.gm2-depth-1-display-inline .gm2-category-node.depth-1 {
+    display: inline-block;
+    width: auto;
+    margin-right: 5px;
+}
+
+.elementor-widget-gm2-category-sort.gm2-depth-2-display-inline .gm2-category-name.depth-2,
+.elementor-widget-gm2-category-sort.gm2-depth-2-display-inline .gm2-category-node.depth-2 {
+    display: inline-block;
+    width: auto;
+    margin-right: 5px;
+}
+
+.elementor-widget-gm2-category-sort.gm2-depth-3-display-inline .gm2-category-name.depth-3,
+.elementor-widget-gm2-category-sort.gm2-depth-3-display-inline .gm2-category-node.depth-3 {
+    display: inline-block;
+    width: auto;
+    margin-right: 5px;
+}
+
 .gm2-category-header {
     display: flex;
     align-items: center;

--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -192,6 +192,17 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
                 'tab'   => \Elementor\Controls_Manager::TAB_STYLE,
             ] );
 
+            $this->add_control( 'display_mode_depth_' . $i, [
+                'label' => __( 'Display Mode', 'gm2-category-sort' ),
+                'type' => \Elementor\Controls_Manager::SELECT,
+                'options' => [
+                    'block'  => __( 'Block', 'gm2-category-sort' ),
+                    'inline' => __( 'Inline', 'gm2-category-sort' ),
+                ],
+                'default' => 'block',
+                'prefix_class' => 'gm2-depth-' . $i . '-display-'
+            ] );
+
             $selector = '.gm2-category-name.depth-' . $i;
             $syn_selector = '.gm2-category-synonym.depth-' . $i;
 

--- a/tests/RendererTest.php
+++ b/tests/RendererTest.php
@@ -28,6 +28,7 @@ class RendererTest extends TestCase {
 
     public function test_expand_button_contains_icon_markup() {
         $root = wp_insert_term( 'Root', 'product_cat' );
+        wp_insert_term( 'Child', 'product_cat', [ 'parent' => $root['term_id'] ] );
 
         $renderer = new Gm2_Category_Sort_Renderer([
             'filter_type'   => 'simple',

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,5 @@
 <?php
+namespace {
 require_once __DIR__ . '/../includes/class-category-importer.php';
 require_once __DIR__ . '/../includes/class-product-category-importer.php';
 require_once __DIR__ . '/../includes/class-product-category-generator.php';
@@ -169,6 +170,7 @@ if ( ! function_exists( 'add_query_arg' ) ) {
     }
 }
 
+}
 namespace Elementor {
     class Icons_Manager {
         public static function render_icon( $icon, $attrs = [] ) {


### PR DESCRIPTION
## Summary
- allow choosing display mode for each category depth
- style inline display at each level
- document the new depth display controls
- update tests for PHP 8 compatibility

## Testing
- `./bin/install-phpunit.sh`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_684dc6c22a648327b01964b1dffa0f4f