### PR TITLE
Update auto assign list styling

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -270,6 +270,18 @@
     transform: scale(1.2);
 }
 
+.gm2-remove {
+    cursor: pointer;
+    font-size: 16px;
+    line-height: 1;
+    padding: 2px;
+}
+
+.gm2-remove:hover {
+    color: red;
+    transform: scale(1.2);
+}
+
 .gm2-no-categories {
     padding: 15px;
     text-align: center;

--- a/assets/js/auto-assign.js
+++ b/assets/js/auto-assign.js
@@ -60,8 +60,9 @@ jQuery(function($){
         function renderList(){
             productList.empty();
             Object.values(products).forEach(function(p){
-                var li = $('<li>').attr('data-id', p.id).text(p.sku+' - '+p.title);
-                $('<a href="#" class="gm2-remove">&times;</a>').appendTo(li);
+                var li = $('<li>').attr('data-id', p.id);
+                $('<a href="#" class="gm2-remove" style="font-size:18px;margin-right:6px;">&times;</a>').appendTo(li);
+                $('<span>').text(p.sku + ' - ' + p.title).appendTo(li);
                 productList.append(li);
             });
         }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,5 @@
 <?php
+namespace {
 require_once __DIR__ . '/../includes/class-category-importer.php';
 require_once __DIR__ . '/../includes/class-product-category-importer.php';
 require_once __DIR__ . '/../includes/class-product-category-generator.php';
@@ -167,6 +168,8 @@ if ( ! function_exists( 'add_query_arg' ) ) {
     function add_query_arg( $params ) {
         return '?' . http_build_query( $params );
     }
+}
+
 }
 
 namespace Elementor {


### PR DESCRIPTION
## Summary
- adjust product list markup in auto-assign screen
- add styles for `.gm2-remove` links
- fix namespace in test bootstrap so PHPUnit can run

## Testing
- `npm run build`
- `vendor/bin/phpunit` *(fails: RendererTest::test_expand_button_contains_icon_markup)*

------
https://chatgpt.com/codex/tasks/task_e_684dc7f2df0c8327a909f8358eb51141