### PR TITLE
Fix expand icon CSS selectors

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -188,7 +188,8 @@
 
 /* Icon defaults */
 .gm2-expand-button i,
-.gm2-expand-button svg {
+.gm2-expand-button svg,
+.gm2-expand-button .gm2-expand-icon {
     font-size: var(--gm2-expand-icon-size, 16px);
     width: var(--gm2-expand-icon-size, 16px);
     height: var(--gm2-expand-icon-size, 16px);
@@ -198,15 +199,18 @@
 }
 
 .gm2-expand-button:hover i,
-.gm2-expand-button:hover svg {
+.gm2-expand-button:hover svg,
+.gm2-expand-button:hover .gm2-expand-icon {
     font-size: var(--gm2-expand-icon-hover-size, var(--gm2-expand-icon-size, 16px));
     background-color: var(--gm2-expand-icon-hover-bg, var(--gm2-expand-icon-bg, transparent));
 }
 
 .gm2-expand-button.gm2-expanded i,
 .gm2-expand-button.gm2-expanded svg,
+.gm2-expand-button.gm2-expanded .gm2-expand-icon,
 .gm2-expand-button[data-expanded="true"] i,
-.gm2-expand-button[data-expanded="true"] svg {
+.gm2-expand-button[data-expanded="true"] svg,
+.gm2-expand-button[data-expanded="true"] .gm2-expand-icon {
     font-size: var(--gm2-expand-icon-active-size, var(--gm2-expand-icon-size, 16px));
     background-color: var(--gm2-expand-icon-active-bg, var(--gm2-expand-icon-bg, transparent));
 }

--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -337,7 +337,7 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
             'size_units' => ['px'],
             'range' => [ 'px' => ['min' => 8, 'max' => 60] ],
             'selectors' => [
-                '{{WRAPPER}} .gm2-expand-button i, {{WRAPPER}} .gm2-expand-button svg' => 'font-size: {{SIZE}}{{UNIT}}; width: {{SIZE}}{{UNIT}}; height: {{SIZE}}{{UNIT}};',
+                '{{WRAPPER}} .gm2-expand-button i, {{WRAPPER}} .gm2-expand-button svg, {{WRAPPER}} .gm2-expand-button .gm2-expand-icon' => 'font-size: {{SIZE}}{{UNIT}}; width: {{SIZE}}{{UNIT}}; height: {{SIZE}}{{UNIT}};',
             ],
         ]);
         $this->add_responsive_control('expand_icon_hover_size', [
@@ -346,7 +346,7 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
             'size_units' => ['px'],
             'range' => [ 'px' => ['min' => 8, 'max' => 60] ],
             'selectors' => [
-                '{{WRAPPER}} .gm2-expand-button:hover i, {{WRAPPER}} .gm2-expand-button:hover svg' => 'font-size: {{SIZE}}{{UNIT}}; width: {{SIZE}}{{UNIT}}; height: {{SIZE}}{{UNIT}};',
+                '{{WRAPPER}} .gm2-expand-button:hover i, {{WRAPPER}} .gm2-expand-button:hover svg, {{WRAPPER}} .gm2-expand-button:hover .gm2-expand-icon' => 'font-size: {{SIZE}}{{UNIT}}; width: {{SIZE}}{{UNIT}}; height: {{SIZE}}{{UNIT}};',
             ],
         ]);
         $this->add_responsive_control('expand_icon_active_size', [
@@ -355,7 +355,7 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
             'size_units' => ['px'],
             'range' => [ 'px' => ['min' => 8, 'max' => 60] ],
             'selectors' => [
-                '{{WRAPPER}} .gm2-expand-button.gm2-expanded i, {{WRAPPER}} .gm2-expand-button[data-expanded="true"] i, {{WRAPPER}} .gm2-expand-button.gm2-expanded svg, {{WRAPPER}} .gm2-expand-button[data-expanded="true"] svg' => 'font-size: {{SIZE}}{{UNIT}}; width: {{SIZE}}{{UNIT}}; height: {{SIZE}}{{UNIT}};',
+                '{{WRAPPER}} .gm2-expand-button.gm2-expanded i, {{WRAPPER}} .gm2-expand-button[data-expanded="true"] i, {{WRAPPER}} .gm2-expand-button.gm2-expanded svg, {{WRAPPER}} .gm2-expand-button[data-expanded="true"] svg, {{WRAPPER}} .gm2-expand-button.gm2-expanded .gm2-expand-icon, {{WRAPPER}} .gm2-expand-button[data-expanded="true"] .gm2-expand-icon' => 'font-size: {{SIZE}}{{UNIT}}; width: {{SIZE}}{{UNIT}}; height: {{SIZE}}{{UNIT}};',
             ],
         ]);
 
@@ -363,7 +363,7 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
             'label' => __('Icon Spacing', 'gm2-category-sort'),
             'type'  => \Elementor\Controls_Manager::DIMENSIONS,
             'selectors' => [
-                '{{WRAPPER}} .gm2-expand-button i, {{WRAPPER}} .gm2-expand-button svg' => 'margin: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+                '{{WRAPPER}} .gm2-expand-button i, {{WRAPPER}} .gm2-expand-button svg, {{WRAPPER}} .gm2-expand-button .gm2-expand-icon' => 'margin: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
             ],
         ]);
 
@@ -371,21 +371,21 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
             'label' => __('Icon Background', 'gm2-category-sort'),
             'type'  => \Elementor\Controls_Manager::COLOR,
             'selectors' => [
-                '{{WRAPPER}} .gm2-expand-button i, {{WRAPPER}} .gm2-expand-button svg' => 'background-color: {{VALUE}};',
+                '{{WRAPPER}} .gm2-expand-button i, {{WRAPPER}} .gm2-expand-button svg, {{WRAPPER}} .gm2-expand-button .gm2-expand-icon' => 'background-color: {{VALUE}};',
             ],
         ]);
         $this->add_control('expand_icon_hover_bg', [
             'label' => __('Icon Hover Background', 'gm2-category-sort'),
             'type'  => \Elementor\Controls_Manager::COLOR,
             'selectors' => [
-                '{{WRAPPER}} .gm2-expand-button:hover i, {{WRAPPER}} .gm2-expand-button:hover svg' => 'background-color: {{VALUE}};',
+                '{{WRAPPER}} .gm2-expand-button:hover i, {{WRAPPER}} .gm2-expand-button:hover svg, {{WRAPPER}} .gm2-expand-button:hover .gm2-expand-icon' => 'background-color: {{VALUE}};',
             ],
         ]);
         $this->add_control('expand_icon_active_bg', [
             'label' => __('Icon Active Background', 'gm2-category-sort'),
             'type'  => \Elementor\Controls_Manager::COLOR,
             'selectors' => [
-                '{{WRAPPER}} .gm2-expand-button.gm2-expanded i, {{WRAPPER}} .gm2-expand-button[data-expanded="true"] i, {{WRAPPER}} .gm2-expand-button.gm2-expanded svg, {{WRAPPER}} .gm2-expand-button[data-expanded="true"] svg' => 'background-color: {{VALUE}};',
+                '{{WRAPPER}} .gm2-expand-button.gm2-expanded i, {{WRAPPER}} .gm2-expand-button[data-expanded="true"] i, {{WRAPPER}} .gm2-expand-button.gm2-expanded svg, {{WRAPPER}} .gm2-expand-button[data-expanded="true"] svg, {{WRAPPER}} .gm2-expand-button.gm2-expanded .gm2-expand-icon, {{WRAPPER}} .gm2-expand-button[data-expanded="true"] .gm2-expand-icon' => 'background-color: {{VALUE}};',
             ],
         ]);
 
@@ -393,7 +393,7 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
             'label' => __('Icon Color', 'gm2-category-sort'),
             'type'  => \Elementor\Controls_Manager::COLOR,
             'selectors' => [
-                '{{WRAPPER}} .gm2-expand-button i' => 'color: {{VALUE}};',
+                '{{WRAPPER}} .gm2-expand-button i, {{WRAPPER}} .gm2-expand-button .gm2-expand-icon' => 'color: {{VALUE}};',
             ],
         ]);
 
@@ -401,7 +401,7 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
             'label' => __('Icon Hover Color', 'gm2-category-sort'),
             'type'  => \Elementor\Controls_Manager::COLOR,
             'selectors' => [
-                '{{WRAPPER}} .gm2-expand-button:hover i' => 'color: {{VALUE}};',
+                '{{WRAPPER}} .gm2-expand-button:hover i, {{WRAPPER}} .gm2-expand-button:hover .gm2-expand-icon' => 'color: {{VALUE}};',
             ],
         ]);
 
@@ -409,8 +409,8 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
             'label' => __('Icon Active Color', 'gm2-category-sort'),
             'type'  => \Elementor\Controls_Manager::COLOR,
             'selectors' => [
-                '{{WRAPPER}} .gm2-expand-button.gm2-expanded i' => 'color: {{VALUE}};',
-                '{{WRAPPER}} .gm2-expand-button[data-expanded="true"] i' => 'color: {{VALUE}};',
+                '{{WRAPPER}} .gm2-expand-button.gm2-expanded i, {{WRAPPER}} .gm2-expand-button.gm2-expanded .gm2-expand-icon' => 'color: {{VALUE}};',
+                '{{WRAPPER}} .gm2-expand-button[data-expanded="true"] i, {{WRAPPER}} .gm2-expand-button[data-expanded="true"] .gm2-expand-icon' => 'color: {{VALUE}};',
             ],
         ]);
 


### PR DESCRIPTION
## Summary
- target `.gm2-expand-icon` elements so icon sizes and colors can be styled
- rebuild front-end assets

## Testing
- `npm install`
- `npm run build`
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684da06f29e483279a99a2637d05609d