### PR TITLE
Load icon fonts during scripts enqueue

### DIFF
--- a/gm2-category-sort.php
+++ b/gm2-category-sort.php
@@ -59,6 +59,7 @@ function gm2_category_sort_init() {
     require_once GM2_CAT_SORT_PATH . 'includes/class-product-category-generator.php';
     require_once GM2_CAT_SORT_PATH . 'includes/class-product-category-importer.php';
     require_once GM2_CAT_SORT_PATH . 'includes/class-auto-assign.php';
+    require_once GM2_CAT_SORT_PATH . 'includes/class-widget.php';
     
     // Initialize components
     Gm2_Category_Sort_Enqueuer::init();
@@ -73,6 +74,18 @@ function gm2_category_sort_init() {
     
     add_filter('pre_get_document_title', 'gm2_category_sort_modify_title');
     add_action('wp_head', 'gm2_category_sort_meta_description');
+
+    // Enqueue icon styles early when widget is used on the page.
+    add_action(
+        'elementor/frontend/widget/before_render',
+        function( $widget ) {
+            if ( $widget instanceof Gm2_Category_Sort_Widget ) {
+                add_action( 'wp_enqueue_scripts', [ $widget, 'enqueue_icon_styles' ] );
+            }
+        },
+        10,
+        1
+    );
     
     // Register widget for both modern and legacy Elementor hooks
     add_action('elementor/widgets/register', 'gm2_register_widget');

--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -838,16 +838,22 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
         }
         return $options;
     }
+
+    /**
+     * Enqueue icon libraries used by this widget.
+     */
+    public function enqueue_icon_styles() {
+        $settings = $this->get_settings_for_display();
+
+        foreach ( [ 'expand_icon', 'collapse_icon', 'synonym_icon' ] as $key ) {
+            if ( ! empty( $settings[ $key ] ) ) {
+                \Elementor\Icons_Manager::enqueue_shim( $settings[ $key ] );
+            }
+        }
+    }
     
     protected function render() {
         $settings = $this->get_settings_for_display();
-
-        if ( ! empty( $settings['expand_icon'] ) ) {
-            \Elementor\Icons_Manager::enqueue_shim( $settings['expand_icon'] );
-        }
-        if ( ! empty( $settings['collapse_icon'] ) ) {
-            \Elementor\Icons_Manager::enqueue_shim( $settings['collapse_icon'] );
-        }
 
         // Only render on WooCommerce pages
         if (!is_shop() && !is_product_category() && !is_product_taxonomy() && !is_search()) {


### PR DESCRIPTION
## Summary
- enqueue icon fonts ahead of render in widget
- hook to enqueue_icon_styles on wp_enqueue_scripts
- remove late enqueue_shim calls

## Testing
- `phpunit -c phpunit.xml --colors=never`

------
https://chatgpt.com/codex/tasks/task_e_684ddb4181cc8327bd2c4c06275fd734