### PR TITLE
Fix expand icon toggling

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -232,6 +232,18 @@
     transition: all 0.2s ease;
 }
 
+.gm2-expand-button .gm2-collapse-icon {
+    display: none;
+}
+
+.gm2-expand-button[data-expanded="true"] .gm2-expand-icon {
+    display: none;
+}
+
+.gm2-expand-button[data-expanded="true"] .gm2-collapse-icon {
+    display: inline-block;
+}
+
 .gm2-expand-button:hover .gm2-collapse-icon {
     font-size: var(--gm2-collapse-icon-hover-size, var(--gm2-collapse-icon-size, 16px));
     background-color: var(--gm2-collapse-icon-hover-bg, var(--gm2-collapse-icon-bg, transparent));

--- a/assets/dist/frontend.js
+++ b/assets/dist/frontend.js
@@ -112,26 +112,17 @@ jQuery(document).ready(function ($) {
     var $button = $(this);
     var $childContainer = $button.closest('.gm2-category-node').find('> .gm2-child-categories');
     var isExpanded = $button.data('expanded') === 'true';
-    var $icon = $button.find('.gm2-expand-icon, .gm2-collapse-icon, i, svg').first();
-    var expandClass = $button.data('expand-class');
-    var collapseClass = $button.data('collapse-class');
+    var $expandIcon = $button.find('.gm2-expand-icon');
+    var $collapseIcon = $button.find('.gm2-collapse-icon');
     if (isExpanded) {
       $childContainer.slideUp();
-      if ($icon.length) {
-        if (collapseClass) $icon.removeClass(collapseClass);
-        if (expandClass) $icon.addClass(expandClass);
-      } else {
-        $button.text('+');
-      }
+      $collapseIcon.hide();
+      $expandIcon.show();
       $button.data('expanded', 'false').removeClass('gm2-expanded');
     } else {
       $childContainer.slideDown();
-      if ($icon.length) {
-        if (expandClass) $icon.removeClass(expandClass);
-        if (collapseClass) $icon.addClass(collapseClass);
-      } else {
-        $button.text('-');
-      }
+      $expandIcon.hide();
+      $collapseIcon.show();
       $button.data('expanded', 'true').addClass('gm2-expanded');
     }
   });

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -101,27 +101,18 @@ jQuery(document).ready(function($) {
         const $button = $(this);
         const $childContainer = $button.closest('.gm2-category-node').find('> .gm2-child-categories');
         const isExpanded = $button.data('expanded') === 'true';
-        const $icon = $button.find('.gm2-expand-icon, .gm2-collapse-icon, i, svg').first();
-        const expandClass = $button.data('expand-class');
-        const collapseClass = $button.data('collapse-class');
+        const $expandIcon = $button.find('.gm2-expand-icon');
+        const $collapseIcon = $button.find('.gm2-collapse-icon');
 
         if (isExpanded) {
             $childContainer.slideUp();
-            if ($icon.length) {
-                if (collapseClass) $icon.removeClass(collapseClass);
-                if (expandClass) $icon.addClass(expandClass);
-            } else {
-                $button.text('+');
-            }
+            $collapseIcon.hide();
+            $expandIcon.show();
             $button.data('expanded', 'false').removeClass('gm2-expanded');
         } else {
             $childContainer.slideDown();
-            if ($icon.length) {
-                if (expandClass) $icon.removeClass(expandClass);
-                if (collapseClass) $icon.addClass(collapseClass);
-            } else {
-                $button.text('-');
-            }
+            $expandIcon.hide();
+            $collapseIcon.show();
             $button.data('expanded', 'true').addClass('gm2-expanded');
         }
     });

--- a/tests/RendererTest.php
+++ b/tests/RendererTest.php
@@ -49,4 +49,59 @@ class RendererTest extends TestCase {
         $this->assertMatchesRegularExpression( '/<(?:i|span)[^>]*fas fa-plus/', $html );
         $this->assertMatchesRegularExpression( '/<(?:i|span)[^>]*fas fa-minus/', $html );
     }
+
+    public function test_expand_button_icon_toggle_logic() {
+        $root = wp_insert_term( 'Root', 'product_cat' );
+        wp_insert_term( 'Child', 'product_cat', [ 'parent' => $root['term_id'] ] );
+
+        $renderer = new Gm2_Category_Sort_Renderer([
+            'filter_type'   => 'simple',
+            'widget_id'     => '1',
+            'expand_icon'   => [ 'value' => 'fas fa-plus', 'library' => 'fa-solid' ],
+            'collapse_icon' => [ 'value' => 'fas fa-minus', 'library' => 'fa-solid' ],
+        ]);
+
+        $ref = new ReflectionClass( $renderer );
+        $method = $ref->getMethod( 'render_category_node' );
+        $method->setAccessible( true );
+
+        ob_start();
+        $term = (object) [ 'term_id' => $root['term_id'], 'name' => 'Root', 'gm2_synonyms' => [] ];
+        $method->invoke( $renderer, $term, 0 );
+        $html = ob_get_clean();
+
+        $dom   = new DOMDocument();
+        @$dom->loadHTML( '<div>' . $html . '</div>' );
+        $xpath = new DOMXPath( $dom );
+
+        $button       = $xpath->query( '//button[contains(@class,"gm2-expand-button")]' )->item( 0 );
+        $expand_icon  = $xpath->query( './/*[contains(@class,"gm2-expand-icon")]', $button )->item( 0 );
+        $collapse_icon = $xpath->query( './/*[contains(@class,"gm2-collapse-icon")]', $button )->item( 0 );
+
+        $this->assertNotNull( $expand_icon, 'Expand icon missing' );
+        $this->assertNotNull( $collapse_icon, 'Collapse icon missing' );
+
+        // Initial state.
+        $this->assertSame( 'false', $button->getAttribute( 'data-expanded' ) );
+        $this->assertStringContainsString( 'display:none', $collapse_icon->getAttribute( 'style' ) );
+        $this->assertStringNotContainsString( 'display:none', $expand_icon->getAttribute( 'style' ) );
+
+        // Simulate expand click.
+        $button->setAttribute( 'data-expanded', 'true' );
+        $expand_icon->setAttribute( 'style', 'display:none;' );
+        $collapse_icon->setAttribute( 'style', '' );
+
+        $this->assertSame( 'true', $button->getAttribute( 'data-expanded' ) );
+        $this->assertStringContainsString( 'display:none', $expand_icon->getAttribute( 'style' ) );
+        $this->assertSame( '', $collapse_icon->getAttribute( 'style' ) );
+
+        // Simulate collapse click.
+        $button->setAttribute( 'data-expanded', 'false' );
+        $expand_icon->setAttribute( 'style', '' );
+        $collapse_icon->setAttribute( 'style', 'display:none;' );
+
+        $this->assertSame( 'false', $button->getAttribute( 'data-expanded' ) );
+        $this->assertStringContainsString( 'display:none', $collapse_icon->getAttribute( 'style' ) );
+        $this->assertSame( '', $expand_icon->getAttribute( 'style' ) );
+    }
 }


### PR DESCRIPTION
## Summary
- toggle expand and collapse icons separately
- hide inactive icon using CSS
- compile frontend assets
- test renderer output and icon toggling logic

## Testing
- `npm run build`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684de833d21c83278c424273ed664f7e