### PR TITLE
Add composer test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,11 +239,9 @@ To run the test suite:
 2. Execute `bin/install-phpunit.sh` to download PHPUnit. If you have Composer
    installed you may alternatively run `composer install` which will fetch
    PHPUnit automatically using the provided `composer.json`.
-3. From the project root run:
-
-```bash
-vendor/bin/phpunit
-```
+3. From the project root run `composer test` to execute the suite. This command
+   uses `vendor/bin/phpunit` under the hood after you have run
+   `bin/install-phpunit.sh` to install PHPUnit.
 
 The tests use stubbed WordPress functions so no WordPress installation is required.
 

--- a/composer.json
+++ b/composer.json
@@ -4,5 +4,8 @@
     "type": "project",
     "require-dev": {
         "phpunit/phpunit": "^9"
+    },
+    "scripts": {
+        "test": "php ./vendor/bin/phpunit"
     }
 }


### PR DESCRIPTION
## Summary
- add a `test` entry to composer.json so the PHPUnit suite can be run with Composer
- update the Testing docs to use `composer test`

## Testing
- `php vendor/bin/phpunit` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684debae951c83278a5c17054bedbbba