### PR TITLE
Fix Elementor crash by delaying widget include

### DIFF
--- a/gm2-category-sort.php
+++ b/gm2-category-sort.php
@@ -59,7 +59,6 @@ function gm2_category_sort_init() {
     require_once GM2_CAT_SORT_PATH . 'includes/class-product-category-generator.php';
     require_once GM2_CAT_SORT_PATH . 'includes/class-product-category-importer.php';
     require_once GM2_CAT_SORT_PATH . 'includes/class-auto-assign.php';
-    require_once GM2_CAT_SORT_PATH . 'includes/class-widget.php';
     
     // Initialize components
     Gm2_Category_Sort_Enqueuer::init();


### PR DESCRIPTION
## Summary
- avoid loading `class-widget.php` before Elementor

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dee026d7c8327ad9fbf0bae001a58