### PR TITLE
Fix expand icon positioning and size

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -154,7 +154,7 @@
 .elementor-widget-gm2-category-sort.gm2-synonym-pos-below .gm2-synonyms-container {
     margin-left: 0;
     margin-top: 5px;
-    width: 100%;
+    flex-basis: 100%;
     order: 3;
 }
 
@@ -188,25 +188,33 @@
 
 /* Icon defaults */
 .gm2-expand-button i,
-.gm2-expand-button svg {
+.gm2-expand-button svg,
+.gm2-expand-button .gm2-expand-icon {
     font-size: var(--gm2-expand-icon-size, 16px);
     width: var(--gm2-expand-icon-size, 16px);
     height: var(--gm2-expand-icon-size, 16px);
     margin: var(--gm2-expand-icon-spacing, 0);
     background-color: var(--gm2-expand-icon-bg, transparent);
     transition: all 0.2s ease;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
 }
 
 .gm2-expand-button:hover i,
-.gm2-expand-button:hover svg {
+.gm2-expand-button:hover svg,
+.gm2-expand-button:hover .gm2-expand-icon {
     font-size: var(--gm2-expand-icon-hover-size, var(--gm2-expand-icon-size, 16px));
     background-color: var(--gm2-expand-icon-hover-bg, var(--gm2-expand-icon-bg, transparent));
 }
 
 .gm2-expand-button.gm2-expanded i,
 .gm2-expand-button.gm2-expanded svg,
+.gm2-expand-button.gm2-expanded .gm2-expand-icon,
 .gm2-expand-button[data-expanded="true"] i,
-.gm2-expand-button[data-expanded="true"] svg {
+.gm2-expand-button[data-expanded="true"] svg,
+.gm2-expand-button[data-expanded="true"] .gm2-expand-icon {
     font-size: var(--gm2-expand-icon-active-size, var(--gm2-expand-icon-size, 16px));
     background-color: var(--gm2-expand-icon-active-bg, var(--gm2-expand-icon-bg, transparent));
 }
@@ -218,6 +226,10 @@
     margin: var(--gm2-collapse-icon-spacing, 0);
     background-color: var(--gm2-collapse-icon-bg, transparent);
     transition: all 0.2s ease;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
 }
 
 .gm2-expand-button:hover .gm2-collapse-icon {

--- a/assets/dist/frontend.js
+++ b/assets/dist/frontend.js
@@ -112,24 +112,17 @@ jQuery(document).ready(function ($) {
     var $button = $(this);
     var $childContainer = $button.closest('.gm2-category-node').find('> .gm2-child-categories');
     var isExpanded = $button.data('expanded') === 'true';
-    var $icon = $button.find('i').first();
-    var expandClass = $button.data('expand-class');
-    var collapseClass = $button.data('collapse-class');
+    var $expandIcon = $button.find('.gm2-expand-icon').first();
+    var $collapseIcon = $button.find('.gm2-collapse-icon').first();
     if (isExpanded) {
       $childContainer.slideUp();
-      if ($icon.length && expandClass && collapseClass) {
-        $icon.removeClass(collapseClass).addClass(expandClass);
-      } else {
-        $button.text('+');
-      }
+      $expandIcon.show();
+      $collapseIcon.hide();
       $button.data('expanded', 'false').removeClass('gm2-expanded');
     } else {
       $childContainer.slideDown();
-      if ($icon.length && expandClass && collapseClass) {
-        $icon.removeClass(expandClass).addClass(collapseClass);
-      } else {
-        $button.text('-');
-      }
+      $expandIcon.hide();
+      $collapseIcon.show();
       $button.data('expanded', 'true').addClass('gm2-expanded');
     }
   });

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -101,25 +101,18 @@ jQuery(document).ready(function($) {
         const $button = $(this);
         const $childContainer = $button.closest('.gm2-category-node').find('> .gm2-child-categories');
         const isExpanded = $button.data('expanded') === 'true';
-        const $icon = $button.find('i').first();
-        const expandClass = $button.data('expand-class');
-        const collapseClass = $button.data('collapse-class');
+        const $expandIcon = $button.find('.gm2-expand-icon').first();
+        const $collapseIcon = $button.find('.gm2-collapse-icon').first();
 
         if (isExpanded) {
             $childContainer.slideUp();
-            if ($icon.length && expandClass && collapseClass) {
-                $icon.removeClass(collapseClass).addClass(expandClass);
-            } else {
-                $button.text('+');
-            }
+            $expandIcon.show();
+            $collapseIcon.hide();
             $button.data('expanded', 'false').removeClass('gm2-expanded');
         } else {
             $childContainer.slideDown();
-            if ($icon.length && expandClass && collapseClass) {
-                $icon.removeClass(expandClass).addClass(collapseClass);
-            } else {
-                $button.text('-');
-            }
+            $expandIcon.hide();
+            $collapseIcon.show();
             $button.data('expanded', 'true').addClass('gm2-expanded');
         }
     });

--- a/gm2-category-sort.php
+++ b/gm2-category-sort.php
@@ -82,6 +82,10 @@ function gm2_category_sort_init() {
 
 // Register widget callback
 function gm2_register_widget($widgets_manager) {
+    if ( ! class_exists('\\Elementor\\Widget_Base') ) {
+        return;
+    }
+
     require_once GM2_CAT_SORT_PATH . 'includes/class-widget.php';
     $widgets_manager->register(new Gm2_Category_Sort_Widget());
 }

--- a/includes/class-renderer.php
+++ b/includes/class-renderer.php
@@ -137,15 +137,23 @@ class Gm2_Category_Sort_Renderer {
             $collapse_class = ! empty( $this->settings['collapse_icon']['value'] ) ? $this->settings['collapse_icon']['value'] : '';
 
             if ( $expand_class ) {
-                $expand_html = \Elementor\Icons_Manager::render_icon( $this->settings['expand_icon'], [ 'aria-hidden' => 'true', 'class' => 'gm2-expand-icon' ] );
+                $icon_markup  = \Elementor\Icons_Manager::render_icon(
+                    $this->settings['expand_icon'],
+                    [ 'aria-hidden' => 'true' ]
+                );
+                $expand_html  = '<span class="gm2-expand-icon">' . $icon_markup . '</span>';
             } else {
-                $expand_html = '<i class="gm2-expand-icon" aria-hidden="true">+</i>';
+                $expand_html = '<span class="gm2-expand-icon" aria-hidden="true">+</span>';
             }
 
             if ( $collapse_class ) {
-                $collapse_html = \Elementor\Icons_Manager::render_icon( $this->settings['collapse_icon'], [ 'aria-hidden' => 'true', 'class' => 'gm2-collapse-icon', 'style' => 'display:none;' ] );
+                $icon_markup   = \Elementor\Icons_Manager::render_icon(
+                    $this->settings['collapse_icon'],
+                    [ 'aria-hidden' => 'true' ]
+                );
+                $collapse_html = '<span class="gm2-collapse-icon" style="display:none;">' . $icon_markup . '</span>';
             } else {
-                $collapse_html = '<i class="gm2-collapse-icon" style="display:none;" aria-hidden="true">-</i>';
+                $collapse_html = '<span class="gm2-collapse-icon" style="display:none;" aria-hidden="true">-</span>';
             }
 
             echo '<button class="gm2-expand-button" data-expanded="false" data-expand-class="' . esc_attr( $expand_class ) . '" data-collapse-class="' . esc_attr( $collapse_class ) . '">' . $expand_html . $collapse_html . '</button>';

--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -337,7 +337,7 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
             'size_units' => ['px'],
             'range' => [ 'px' => ['min' => 8, 'max' => 60] ],
             'selectors' => [
-                '{{WRAPPER}} .gm2-expand-button i, {{WRAPPER}} .gm2-expand-button svg' => 'font-size: {{SIZE}}{{UNIT}}; width: {{SIZE}}{{UNIT}}; height: {{SIZE}}{{UNIT}};',
+                '{{WRAPPER}} .gm2-expand-button i, {{WRAPPER}} .gm2-expand-button svg, {{WRAPPER}} .gm2-expand-button .gm2-expand-icon' => 'font-size: {{SIZE}}{{UNIT}}; width: {{SIZE}}{{UNIT}}; height: {{SIZE}}{{UNIT}};',
             ],
         ]);
         $this->add_responsive_control('expand_icon_hover_size', [
@@ -346,7 +346,7 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
             'size_units' => ['px'],
             'range' => [ 'px' => ['min' => 8, 'max' => 60] ],
             'selectors' => [
-                '{{WRAPPER}} .gm2-expand-button:hover i, {{WRAPPER}} .gm2-expand-button:hover svg' => 'font-size: {{SIZE}}{{UNIT}}; width: {{SIZE}}{{UNIT}}; height: {{SIZE}}{{UNIT}};',
+                '{{WRAPPER}} .gm2-expand-button:hover i, {{WRAPPER}} .gm2-expand-button:hover svg, {{WRAPPER}} .gm2-expand-button:hover .gm2-expand-icon' => 'font-size: {{SIZE}}{{UNIT}}; width: {{SIZE}}{{UNIT}}; height: {{SIZE}}{{UNIT}};',
             ],
         ]);
         $this->add_responsive_control('expand_icon_active_size', [
@@ -355,7 +355,7 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
             'size_units' => ['px'],
             'range' => [ 'px' => ['min' => 8, 'max' => 60] ],
             'selectors' => [
-                '{{WRAPPER}} .gm2-expand-button.gm2-expanded i, {{WRAPPER}} .gm2-expand-button[data-expanded="true"] i, {{WRAPPER}} .gm2-expand-button.gm2-expanded svg, {{WRAPPER}} .gm2-expand-button[data-expanded="true"] svg' => 'font-size: {{SIZE}}{{UNIT}}; width: {{SIZE}}{{UNIT}}; height: {{SIZE}}{{UNIT}};',
+                '{{WRAPPER}} .gm2-expand-button.gm2-expanded i, {{WRAPPER}} .gm2-expand-button[data-expanded="true"] i, {{WRAPPER}} .gm2-expand-button.gm2-expanded svg, {{WRAPPER}} .gm2-expand-button[data-expanded="true"] svg, {{WRAPPER}} .gm2-expand-button.gm2-expanded .gm2-expand-icon, {{WRAPPER}} .gm2-expand-button[data-expanded="true"] .gm2-expand-icon' => 'font-size: {{SIZE}}{{UNIT}}; width: {{SIZE}}{{UNIT}}; height: {{SIZE}}{{UNIT}};',
             ],
         ]);
 
@@ -363,7 +363,7 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
             'label' => __('Icon Spacing', 'gm2-category-sort'),
             'type'  => \Elementor\Controls_Manager::DIMENSIONS,
             'selectors' => [
-                '{{WRAPPER}} .gm2-expand-button i, {{WRAPPER}} .gm2-expand-button svg' => 'margin: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+                '{{WRAPPER}} .gm2-expand-button i, {{WRAPPER}} .gm2-expand-button svg, {{WRAPPER}} .gm2-expand-button .gm2-expand-icon' => 'margin: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
             ],
         ]);
 
@@ -371,21 +371,21 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
             'label' => __('Icon Background', 'gm2-category-sort'),
             'type'  => \Elementor\Controls_Manager::COLOR,
             'selectors' => [
-                '{{WRAPPER}} .gm2-expand-button i, {{WRAPPER}} .gm2-expand-button svg' => 'background-color: {{VALUE}};',
+                '{{WRAPPER}} .gm2-expand-button i, {{WRAPPER}} .gm2-expand-button svg, {{WRAPPER}} .gm2-expand-button .gm2-expand-icon' => 'background-color: {{VALUE}};',
             ],
         ]);
         $this->add_control('expand_icon_hover_bg', [
             'label' => __('Icon Hover Background', 'gm2-category-sort'),
             'type'  => \Elementor\Controls_Manager::COLOR,
             'selectors' => [
-                '{{WRAPPER}} .gm2-expand-button:hover i, {{WRAPPER}} .gm2-expand-button:hover svg' => 'background-color: {{VALUE}};',
+                '{{WRAPPER}} .gm2-expand-button:hover i, {{WRAPPER}} .gm2-expand-button:hover svg, {{WRAPPER}} .gm2-expand-button:hover .gm2-expand-icon' => 'background-color: {{VALUE}};',
             ],
         ]);
         $this->add_control('expand_icon_active_bg', [
             'label' => __('Icon Active Background', 'gm2-category-sort'),
             'type'  => \Elementor\Controls_Manager::COLOR,
             'selectors' => [
-                '{{WRAPPER}} .gm2-expand-button.gm2-expanded i, {{WRAPPER}} .gm2-expand-button[data-expanded="true"] i, {{WRAPPER}} .gm2-expand-button.gm2-expanded svg, {{WRAPPER}} .gm2-expand-button[data-expanded="true"] svg' => 'background-color: {{VALUE}};',
+                '{{WRAPPER}} .gm2-expand-button.gm2-expanded i, {{WRAPPER}} .gm2-expand-button[data-expanded="true"] i, {{WRAPPER}} .gm2-expand-button.gm2-expanded svg, {{WRAPPER}} .gm2-expand-button[data-expanded="true"] svg, {{WRAPPER}} .gm2-expand-button.gm2-expanded .gm2-expand-icon, {{WRAPPER}} .gm2-expand-button[data-expanded="true"] .gm2-expand-icon' => 'background-color: {{VALUE}};',
             ],
         ]);
 
@@ -393,7 +393,7 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
             'label' => __('Icon Color', 'gm2-category-sort'),
             'type'  => \Elementor\Controls_Manager::COLOR,
             'selectors' => [
-                '{{WRAPPER}} .gm2-expand-button i' => 'color: {{VALUE}};',
+                '{{WRAPPER}} .gm2-expand-button i, {{WRAPPER}} .gm2-expand-button .gm2-expand-icon' => 'color: {{VALUE}};',
             ],
         ]);
 
@@ -401,7 +401,7 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
             'label' => __('Icon Hover Color', 'gm2-category-sort'),
             'type'  => \Elementor\Controls_Manager::COLOR,
             'selectors' => [
-                '{{WRAPPER}} .gm2-expand-button:hover i' => 'color: {{VALUE}};',
+                '{{WRAPPER}} .gm2-expand-button:hover i, {{WRAPPER}} .gm2-expand-button:hover .gm2-expand-icon' => 'color: {{VALUE}};',
             ],
         ]);
 
@@ -409,8 +409,8 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
             'label' => __('Icon Active Color', 'gm2-category-sort'),
             'type'  => \Elementor\Controls_Manager::COLOR,
             'selectors' => [
-                '{{WRAPPER}} .gm2-expand-button.gm2-expanded i' => 'color: {{VALUE}};',
-                '{{WRAPPER}} .gm2-expand-button[data-expanded="true"] i' => 'color: {{VALUE}};',
+                '{{WRAPPER}} .gm2-expand-button.gm2-expanded i, {{WRAPPER}} .gm2-expand-button.gm2-expanded .gm2-expand-icon' => 'color: {{VALUE}};',
+                '{{WRAPPER}} .gm2-expand-button[data-expanded="true"] i, {{WRAPPER}} .gm2-expand-button[data-expanded="true"] .gm2-expand-icon' => 'color: {{VALUE}};',
             ],
         ]);
 
@@ -847,6 +847,9 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
         }
         if ( ! empty( $settings['collapse_icon'] ) ) {
             \Elementor\Icons_Manager::enqueue_shim( $settings['collapse_icon'] );
+        }
+        if ( ! empty( $settings['synonym_icon'] ) ) {
+            \Elementor\Icons_Manager::enqueue_shim( $settings['synonym_icon'] );
         }
 
         // Only render on WooCommerce pages


### PR DESCRIPTION
## Summary
- ensure expand/collapse icons are wrapped in span elements
- add inline-flex and pointer-event rules so icons don't block clicks

## Testing
- `npm install`
- `npm run build`
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684da06f29e483279a99a2637d05609d