### PR TITLE
Fix expand icon echo issue

### DIFF
--- a/includes/class-renderer.php
+++ b/includes/class-renderer.php
@@ -117,7 +117,13 @@ class Gm2_Category_Sort_Renderer {
                 ]);
                 $icon_html = '';
                 if ( ! empty( $this->settings['synonym_icon']['value'] ) ) {
-                    $icon_html = \Elementor\Icons_Manager::render_icon( $this->settings['synonym_icon'], [ 'aria-hidden' => 'true', 'class' => 'gm2-synonym-icon' ] );
+                    $icon_html = \Elementor\Icons_Manager::render_icon(
+                        $this->settings['synonym_icon'],
+                        [ 'aria-hidden' => 'true', 'class' => 'gm2-synonym-icon' ],
+                        null,
+                        null,
+                        false
+                    );
                 }
                 if ( ! empty( $icon_html ) && $this->settings['synonym_icon_position'] === 'after' ) {
                     $link_content = esc_html($syn) . $icon_html;
@@ -139,7 +145,10 @@ class Gm2_Category_Sort_Renderer {
             if ( $expand_class ) {
                 $icon_markup  = \Elementor\Icons_Manager::render_icon(
                     $this->settings['expand_icon'],
-                    [ 'aria-hidden' => 'true' ]
+                    [ 'aria-hidden' => 'true' ],
+                    null,
+                    null,
+                    false
                 );
                 $expand_html  = '<span class="gm2-expand-icon">' . $icon_markup . '</span>';
             } else {
@@ -149,7 +158,10 @@ class Gm2_Category_Sort_Renderer {
             if ( $collapse_class ) {
                 $icon_markup   = \Elementor\Icons_Manager::render_icon(
                     $this->settings['collapse_icon'],
-                    [ 'aria-hidden' => 'true' ]
+                    [ 'aria-hidden' => 'true' ],
+                    null,
+                    null,
+                    false
                 );
                 $collapse_html = '<span class="gm2-collapse-icon" style="display:none;">' . $icon_markup . '</span>';
             } else {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -174,16 +174,22 @@ if ( ! function_exists( 'add_query_arg' ) ) {
 
 namespace Elementor {
     class Icons_Manager {
-        public static function render_icon( $icon, $attrs = [] ) {
-            $value = $icon['value'] ?? '';
-            $attr_str = '';
+        public static function render_icon( $icon, $attrs = [], $tag = null, $is_new = null, $echo = false ) {
+            $value     = $icon['value'] ?? '';
+            $attr_str  = '';
             foreach ( $attrs as $k => $v ) {
                 $attr_str .= ' ' . $k . '="' . $v . '"';
             }
             if ( isset( $icon['library'] ) && $icon['library'] === 'svg' ) {
-                return '<svg' . $attr_str . '><path d="' . $value . '"></path></svg>';
+                $markup = '<svg' . $attr_str . '><path d="' . $value . '"></path></svg>';
+            } else {
+                $markup = '<i class="' . $value . '"' . $attr_str . '></i>';
             }
-            return '<i class="' . $value . '"' . $attr_str . '></i>';
+            if ( $echo ) {
+                echo $markup;
+                return null;
+            }
+            return $markup;
         }
         public static function enqueue_shim( $icon ) {}
     }


### PR DESCRIPTION
## Summary
- avoid premature echoing when rendering icons
- update test bootstrap Icons_Manager stub to match new call signature

## Testing
- `npm run build` *(fails: babel not found)*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68503c1d077c83279f74a9398a908b46