### PR TITLE
Add reset product categories tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,10 @@ The plugin can analyze existing products and automatically assign categories
 based on their titles, descriptions and attribute values. Run the tool from
 **Tools → Auto Assign Categories** in the admin area and choose whether to
 **Add categories** or **Overwrite categories** before clicking **Start Auto
-Assign**. As each product is processed it appears in the log window:
+Assign**. Use the **Reset All Categories** button to remove every product's
+assigned categories before starting a fresh assignment. A progress bar shows
+the status while products are being cleared. As each product is processed it
+appears in the log window:
 
 ```
 SKU123 - Sample Product => Accessories, Wheel Covers


### PR DESCRIPTION
## Summary
- add admin button and progress bar to reset all product categories
- support AJAX handler and JS functions for resetting categories
- document the new feature in the README

## Testing
- `npm install`
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68505f6a2b108327a886d1ae69b50571