### PR TITLE
Add reset search option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Reset search button on the Auto Assign Categories page to clear previous results.
+
 ## [1.0.15] - 2025-06-15
 ### Added
 - Icon size, spacing and background controls for expand, collapse and synonym icons.

--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ Add `--overwrite` to replace existing categories instead of appending.
 Below the log the page provides a search form to manually select products.
 Choose which fields to search (title, description or attributes), enter a
 keyword and click **Search** to build a list of matching products. Additional
-products can be looked up by SKU or title in the second search box. After
+products can be looked up by SKU or title in the second search box. Use the
+**Reset Search** button to clear the results when starting a new query. After
 selecting one or more categories from the list, click **Assign** to apply them
 to all products in the list.
 

--- a/assets/js/auto-assign.js
+++ b/assets/js/auto-assign.js
@@ -81,6 +81,7 @@ jQuery(function($){
 
     // --- Manual search and assign ---
     var searchBtn = $('#gm2-search-btn');
+    var resetSearchBtn = $('#gm2-reset-search-btn');
     var searchFields = $('#gm2-search-fields');
     var searchTerms = $('#gm2-search-terms');
     var productList = $('#gm2-product-list');
@@ -154,6 +155,17 @@ jQuery(function($){
             renderList();
             searchProgress.attr('value',0).show();
             runSearch(fields, term, 0);
+        });
+
+        resetSearchBtn.on('click', function(e){
+            e.preventDefault();
+            products = {};
+            renderList();
+            searchTerms.val('');
+            productSearch.val('');
+            searchDropdown.empty().hide();
+            liveSpinner.hide();
+            searchProgress.hide();
         });
 
         var debounceTimer = null;

--- a/gm2-category-sort.php
+++ b/gm2-category-sort.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Gm2 Category Sort
  * Description: Adds a collapsible category filter widget for WooCommerce products in Elementor.
- * Version: 1.0.15
+ * Version: 1.0.16
  * Author: ProjectsGm2
  * Text Domain: gm2-category-sort
  */
@@ -10,7 +10,7 @@
 defined('ABSPATH') || exit;
 
 // Plugin version used for cache busting
-define('GM2_CAT_SORT_VERSION', '1.0.15');
+define('GM2_CAT_SORT_VERSION', '1.0.16');
 
 // Define plugin constants
 define('GM2_CAT_SORT_PATH', plugin_dir_path(__FILE__));

--- a/includes/class-auto-assign.php
+++ b/includes/class-auto-assign.php
@@ -126,6 +126,8 @@ class Gm2_Category_Sort_Auto_Assign {
                 </select>
                 <input type="text" id="gm2-search-terms" style="width:200px;" />
                 <button id="gm2-search-btn" class="button"><?php esc_html_e( 'Search', 'gm2-category-sort' ); ?></button>
+                &nbsp;
+                <button id="gm2-reset-search-btn" class="button"><?php esc_html_e( 'Reset Search', 'gm2-category-sort' ); ?></button>
             </p>
             <p><progress id="gm2-search-progress" value="0" max="100" style="display:none;width:100%;"></progress></p>
             <p style="position:relative;">


### PR DESCRIPTION
## Summary
- add Reset Search button to manual assign
- wire up jQuery handler for clearing product list and fields
- bump plugin version to 1.0.16
- document Reset Search feature in README
- note change in changelog

## Testing
- `composer install` *(fails: command not found)*
- `php ./vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685062bcd6f483278680561e143dcea0