### PR TITLE
Implement single lug/hole category rule

### DIFF
--- a/includes/class-product-category-generator.php
+++ b/includes/class-product-category-generator.php
@@ -116,6 +116,7 @@ class Gm2_Category_Sort_Product_Category_Generator {
         $cats  = [];
         $words = preg_split( '/\s+/', $lower );
         $word_count = count( $words );
+        $lug_hole_candidates = [];
         foreach ( $mapping as $term => $path ) {
             $matched = false;
             if ( preg_match( '/(?<!\\w)' . preg_quote( $term, '/' ) . '(?!\\w)/', $lower ) ) {
@@ -145,13 +146,34 @@ class Gm2_Category_Sort_Product_Category_Generator {
                 if ( $neg ) {
                     continue;
                 }
-                foreach ( $path as $cat ) {
-                    if ( ! in_array( $cat, $cats, true ) ) {
-                        $cats[] = $cat;
+                if ( in_array( 'By Lug/Hole Configuration', $path, true ) ) {
+                    if ( ! isset( $lug_hole_candidates[ $term ] ) ) {
+                        $lug_hole_candidates[ $term ] = $path;
+                    }
+                } else {
+                    foreach ( $path as $cat ) {
+                        if ( ! in_array( $cat, $cats, true ) ) {
+                            $cats[] = $cat;
+                        }
                     }
                 }
             }
         }
+        if ( $lug_hole_candidates ) {
+            uksort(
+                $lug_hole_candidates,
+                static function ( $a, $b ) {
+                    return strlen( $b ) <=> strlen( $a );
+                }
+            );
+            $path = reset( $lug_hole_candidates );
+            foreach ( $path as $cat ) {
+                if ( ! in_array( $cat, $cats, true ) ) {
+                    $cats[] = $cat;
+                }
+            }
+        }
+
         return $cats;
     }
 }

--- a/tests/ProductCategoryGeneratorTest.php
+++ b/tests/ProductCategoryGeneratorTest.php
@@ -124,4 +124,19 @@ class ProductCategoryGeneratorTest extends TestCase {
 
         $this->assertSame( [ 'Wheel' ], $cats );
     }
+
+    public function test_only_one_lug_hole_category_matches() {
+        $root = wp_insert_term( 'By Lug/Hole Configuration', 'product_cat' );
+        wp_insert_term( '10 Lug', 'product_cat', [ 'parent' => $root['term_id'] ] );
+        wp_insert_term( '10 Lug 2 Hole', 'product_cat', [ 'parent' => $root['term_id'] ] );
+        wp_insert_term( '10 Lug 4 Hole', 'product_cat', [ 'parent' => $root['term_id'] ] );
+        wp_insert_term( '10 Lug 5 Hole', 'product_cat', [ 'parent' => $root['term_id'] ] );
+
+        $mapping = Gm2_Category_Sort_Product_Category_Generator::build_mapping_from_globals();
+        $text    = '19.5" Dodge Ram 4500 5500 2008 Wheel Rim Liner Hubcap Covers 10 Lug 5 Hole';
+
+        $cats = Gm2_Category_Sort_Product_Category_Generator::assign_categories( $text, $mapping );
+
+        $this->assertSame( [ 'By Lug/Hole Configuration', '10 Lug 5 Hole' ], $cats );
+    }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -174,7 +174,7 @@ if ( ! function_exists( 'add_query_arg' ) ) {
 
 namespace Elementor {
     class Icons_Manager {
-          public static function try_get_icon_html( $icon, $attrs = [], $tag = null ) {
+        public static function try_get_icon_html( $icon, $attrs = [], $tag = null, $echo = false ) {
             $value     = $icon['value'] ?? '';
             $attr_str  = '';
             foreach ( $attrs as $k => $v ) {


### PR DESCRIPTION
## Summary
- prefer only one category under **By Lug/Hole Configuration** when auto assigning
- adjust Elementor icon stub
- add unit test for new rule

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68506812c1048327a9112cfcf0516d7f