### PR TITLE
Implement single lug/hole category rule

### DIFF
--- a/includes/class-product-category-generator.php
+++ b/includes/class-product-category-generator.php
@@ -16,6 +16,9 @@ class Gm2_Category_Sort_Product_Category_Generator {
         'wheel-simulator' => 'wheel simulator',
         'wheel-simulators'=> 'wheel simulator',
         'over-lug'        => 'over lug',
+        'rimliner'        => 'rim liner',
+        'rim-liner'       => 'rim liner',
+        'rim liners'      => 'rim liner',
     ];
 
     /** @var string[] */
@@ -100,7 +103,6 @@ class Gm2_Category_Sort_Product_Category_Generator {
                 }
             }
         }
-
         return $mapping;
     }
 
@@ -116,9 +118,48 @@ class Gm2_Category_Sort_Product_Category_Generator {
         $cats  = [];
         $words = preg_split( '/\s+/', $lower );
         $word_count = count( $words );
+        $lug_hole_candidates = [];
+        $brands        = [];
+        $brand_models  = [];
+        $other_mapping = [];
+
         foreach ( $mapping as $term => $path ) {
+            $brand_idx = array_search( 'By Brand & Model', $path, true );
+            if ( $brand_idx !== false ) {
+                if ( isset( $path[ $brand_idx + 1 ] ) && ! isset( $path[ $brand_idx + 2 ] ) ) {
+                    $brand = $path[ $brand_idx + 1 ];
+                    if ( ! isset( $brands[ $brand ] ) ) {
+                        $brands[ $brand ] = [];
+                    }
+                    $brands[ $brand ][] = [ 'term' => $term, 'path' => $path ];
+                    continue;
+                }
+                if ( isset( $path[ $brand_idx + 2 ] ) ) {
+                    $brand       = $path[ $brand_idx + 1 ];
+                    $model_name  = self::normalize_text( $path[ $brand_idx + 2 ] );
+                    $m_words     = preg_split( '/\s+/', $model_name );
+                    $m_words     = array_values( array_filter( $m_words, static function ( $w ) {
+                        return ! in_array( $w, [ 'wheel', 'wheels', 'simulator', 'simulators', 'rim', 'liner', 'cover', 'covers', 'hubcap', 'hubcaps' ], true );
+                    } ) );
+                    if ( ! isset( $brand_models[ $brand ] ) ) {
+                        $brand_models[ $brand ] = [];
+                    }
+                    $brand_models[ $brand ][] = [
+                        'term'        => $term,
+                        'path'        => $path,
+                        'model_words' => $m_words,
+                    ];
+                    continue;
+                }
+            }
+
+            $other_mapping[ $term ] = $path;
+        }
+
+        $brand_matches = [];
+        foreach ( $other_mapping as $term => $path ) {
             $matched = false;
-            if ( preg_match( '/(?<!\\w)' . preg_quote( $term, '/' ) . '(?!\\w)/', $lower ) ) {
+            if ( preg_match( '/(?<!\w)' . preg_quote( $term, '/' ) . '(?!\w)/', $lower ) ) {
                 $matched = true;
             } elseif ( $fuzzy ) {
                 $term_words = preg_split( '/\s+/', $term );
@@ -132,8 +173,66 @@ class Gm2_Category_Sort_Product_Category_Generator {
                     }
                 }
             }
+            if ( ! $matched ) {
+                continue;
+            }
+            $neg = false;
+            foreach ( self::$negation_patterns as $pattern ) {
+                $regex = '/' . sprintf( $pattern, preg_quote( $term, '/' ) ) . '/';
+                if ( preg_match( $regex, $lower ) ) {
+                    $neg = true;
+                    break;
+                }
+            }
+            if ( $neg ) {
+                continue;
+            }
+            if ( in_array( 'By Lug/Hole Configuration', $path, true ) ) {
+                if ( ! isset( $lug_hole_candidates[ $term ] ) ) {
+                    $lug_hole_candidates[ $term ] = $path;
+                }
+            } else {
+                foreach ( $path as $cat ) {
+                    if ( ! in_array( $cat, $cats, true ) ) {
+                        $cats[] = $cat;
+                    }
+                }
+            }
+        }
 
-            if ( $matched ) {
+        if ( $lug_hole_candidates ) {
+            uksort( $lug_hole_candidates, static function ( $a, $b ) {
+                return strlen( $b ) <=> strlen( $a );
+            } );
+            $path = reset( $lug_hole_candidates );
+            foreach ( $path as $cat ) {
+                if ( ! in_array( $cat, $cats, true ) ) {
+                    $cats[] = $cat;
+                }
+            }
+        }
+
+        foreach ( $brands as $brand => $entries ) {
+            foreach ( $entries as $entry ) {
+                $term    = $entry['term'];
+                $matched = false;
+                if ( preg_match( '/(?<!\w)' . preg_quote( $term, '/' ) . '(?!\w)/', $lower ) ) {
+                    $matched = true;
+                } elseif ( $fuzzy ) {
+                    $term_words = preg_split( '/\s+/', $term );
+                    $n = count( $term_words );
+                    for ( $i = 0; $i <= $word_count - $n; $i++ ) {
+                        $segment = implode( ' ', array_slice( $words, $i, $n ) );
+                        similar_text( $term, $segment, $percent );
+                        if ( $percent >= $threshold ) {
+                            $matched = true;
+                            break;
+                        }
+                    }
+                }
+                if ( ! $matched ) {
+                    continue;
+                }
                 $neg = false;
                 foreach ( self::$negation_patterns as $pattern ) {
                     $regex = '/' . sprintf( $pattern, preg_quote( $term, '/' ) ) . '/';
@@ -145,13 +244,68 @@ class Gm2_Category_Sort_Product_Category_Generator {
                 if ( $neg ) {
                     continue;
                 }
-                foreach ( $path as $cat ) {
+                $brand_matches[ $brand ] = $term;
+                foreach ( $entry['path'] as $cat ) {
+                    if ( ! in_array( $cat, $cats, true ) ) {
+                        $cats[] = $cat;
+                    }
+                }
+                break;
+            }
+        }
+
+        foreach ( $brand_matches as $brand => $brand_term ) {
+            if ( empty( $brand_models[ $brand ] ) ) {
+                continue;
+            }
+            foreach ( $brand_models[ $brand ] as $model ) {
+                $all_present = true;
+                foreach ( $model['model_words'] as $word ) {
+                    if ( strpos( $lower, $word ) === false ) {
+                        $all_present = false;
+                        break;
+                    }
+                }
+                if ( ! $all_present ) {
+                    continue;
+                }
+                $brand_norm     = self::normalize_text( $brand_term );
+                $first_word     = $model['model_words'][0] ?? '';
+                $close_pattern  = '/\b' . preg_quote( $brand_norm, '/' ) . '\b.{0,40}\b' . preg_quote( $first_word, '/' ) . '/';
+                $reverse_pattern = '/\b' . preg_quote( $first_word, '/' ) . '\b.{0,40}\b' . preg_quote( $brand_norm, '/' ) . '/';
+                if ( ! preg_match( $close_pattern, $lower ) && ! preg_match( $reverse_pattern, $lower ) ) {
+                    continue;
+                }
+                foreach ( $model['path'] as $cat ) {
                     if ( ! in_array( $cat, $cats, true ) ) {
                         $cats[] = $cat;
                     }
                 }
             }
         }
+
+        $brand_terms = [ 'wheel simulator', 'rim liner', 'hubcap', 'wheel cover' ];
+        foreach ( $brand_terms as $term ) {
+            if ( preg_match( '/(?<!\w)' . preg_quote( $term, '/' ) . '(?!\w)/', $lower ) ) {
+                $neg = false;
+                foreach ( self::$negation_patterns as $pattern ) {
+                    $regex = '/' . sprintf( $pattern, preg_quote( $term, '/' ) ) . '/';
+                    if ( preg_match( $regex, $lower ) ) {
+                        $neg = true;
+                        break;
+                    }
+                }
+                if ( ! $neg ) {
+                    foreach ( [ 'Wheel Simulators', 'Brands', 'Eagle Flight Wheel Simulators' ] as $cat ) {
+                        if ( ! in_array( $cat, $cats, true ) ) {
+                            $cats[] = $cat;
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+
         return $cats;
     }
 }

--- a/tests/ProductCategoryGeneratorTest.php
+++ b/tests/ProductCategoryGeneratorTest.php
@@ -83,7 +83,10 @@ class ProductCategoryGeneratorTest extends TestCase {
 
         $cats = Gm2_Category_Sort_Product_Category_Generator::assign_categories( $text, $mapping );
 
-        $this->assertSame( [ 'Hubcap' ], $cats );
+        $this->assertSame(
+            [ 'Hubcap', 'Wheel Simulators', 'Brands', 'Eagle Flight Wheel Simulators' ],
+            $cats
+        );
     }
 
     public function test_ignores_additional_negation_patterns() {
@@ -123,5 +126,86 @@ class ProductCategoryGeneratorTest extends TestCase {
         $cats = Gm2_Category_Sort_Product_Category_Generator::assign_categories( $text, $mapping, true );
 
         $this->assertSame( [ 'Wheel' ], $cats );
+    }
+
+    public function test_only_one_lug_hole_category_matches() {
+        $root = wp_insert_term( 'By Lug/Hole Configuration', 'product_cat' );
+        wp_insert_term( '10 Lug', 'product_cat', [ 'parent' => $root['term_id'] ] );
+        wp_insert_term( '10 Lug 2 Hole', 'product_cat', [ 'parent' => $root['term_id'] ] );
+        wp_insert_term( '10 Lug 4 Hole', 'product_cat', [ 'parent' => $root['term_id'] ] );
+        wp_insert_term( '10 Lug 5 Hole', 'product_cat', [ 'parent' => $root['term_id'] ] );
+
+        $mapping = Gm2_Category_Sort_Product_Category_Generator::build_mapping_from_globals();
+        $text    = '19.5" Dodge Ram 4500 5500 2008 Wheel Rim Liner Hubcap Covers 10 Lug 5 Hole';
+
+        $cats = Gm2_Category_Sort_Product_Category_Generator::assign_categories( $text, $mapping );
+
+        $this->assertSame(
+            [
+                'By Lug/Hole Configuration',
+                '10 Lug 5 Hole',
+                'Wheel Simulators',
+                'Brands',
+                'Eagle Flight Wheel Simulators',
+            ],
+            $cats
+        );
+    }
+
+    public function test_eagle_flight_brand_rule() {
+        $wheel  = wp_insert_term( 'Wheel Simulators', 'product_cat' );
+        $brands = wp_insert_term( 'Brands', 'product_cat', [ 'parent' => $wheel['term_id'] ] );
+        wp_insert_term( 'Eagle Flight Wheel Simulators', 'product_cat', [ 'parent' => $brands['term_id'] ] );
+
+        $mapping = Gm2_Category_Sort_Product_Category_Generator::build_mapping_from_globals();
+        $text    = 'Premium rim liner kit for trucks';
+
+        $cats = Gm2_Category_Sort_Product_Category_Generator::assign_categories( $text, $mapping );
+
+        $this->assertSame( [ 'Wheel Simulators', 'Brands', 'Eagle Flight Wheel Simulators' ], $cats );
+    }
+
+    public function test_brand_model_requires_brand_word() {
+        $wheel  = wp_insert_term( 'Wheel Simulators', 'product_cat' );
+        $branch = wp_insert_term( 'By Brand & Model', 'product_cat', [ 'parent' => $wheel['term_id'] ] );
+
+        $dodge = wp_insert_term( 'Dodge', 'product_cat', [ 'parent' => $branch['term_id'] ] );
+        wp_insert_term( 'Ram 4500', 'product_cat', [ 'parent' => $dodge['term_id'] ] );
+        wp_insert_term( 'Ram 5500', 'product_cat', [ 'parent' => $dodge['term_id'] ] );
+
+        $gmc = wp_insert_term( 'GMC', 'product_cat', [ 'parent' => $branch['term_id'] ] );
+        wp_insert_term( '4500', 'product_cat', [ 'parent' => $gmc['term_id'] ] );
+
+        $mapping = Gm2_Category_Sort_Product_Category_Generator::build_mapping_from_globals();
+        $text    = '19.5" Dodge Ram 4500 5500 2008 Wheel Rim Liner Hubcap Covers';
+
+        $cats = Gm2_Category_Sort_Product_Category_Generator::assign_categories( $text, $mapping );
+
+        $this->assertSame(
+            [
+                'Wheel Simulators',
+                'By Brand & Model',
+                'Dodge',
+                'Ram 4500',
+                'Ram 5500',
+                'Brands',
+                'Eagle Flight Wheel Simulators',
+            ],
+            $cats
+        );
+    }
+
+    public function test_model_not_assigned_when_brand_far_apart() {
+        $wheel  = wp_insert_term( 'Wheel Simulators', 'product_cat' );
+        $branch = wp_insert_term( 'By Brand & Model', 'product_cat', [ 'parent' => $wheel['term_id'] ] );
+        $dodge  = wp_insert_term( 'Dodge', 'product_cat', [ 'parent' => $branch['term_id'] ] );
+        wp_insert_term( 'Ram 4500', 'product_cat', [ 'parent' => $dodge['term_id'] ] );
+
+        $mapping = Gm2_Category_Sort_Product_Category_Generator::build_mapping_from_globals();
+        $text    = 'Dodge ... ' . str_repeat( 'x ', 30 ) . 'Ram 4500 truck';
+
+        $cats = Gm2_Category_Sort_Product_Category_Generator::assign_categories( $text, $mapping );
+
+        $this->assertSame( [ 'Wheel Simulators', 'By Brand & Model', 'Dodge' ], $cats );
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -174,7 +174,7 @@ if ( ! function_exists( 'add_query_arg' ) ) {
 
 namespace Elementor {
     class Icons_Manager {
-          public static function try_get_icon_html( $icon, $attrs = [], $tag = null ) {
+        public static function try_get_icon_html( $icon, $attrs = [], $tag = null, $echo = false ) {
             $value     = $icon['value'] ?? '';
             $attr_str  = '';
             foreach ( $attrs as $k => $v ) {


### PR DESCRIPTION
## Summary
- prefer only one category under **By Lug/Hole Configuration** when auto assigning
- add Eagle Flight brand rule for wheel simulator-related products
- adjust Elementor icon stub
- add rule so model categories under **By Brand & Model** require matching brand words
- ensure brand and model words appear near each other
- filter generic words from model names for reliable matches
- refine brand/model matching order to check brands first

## Testing
- `./bin/install-phpunit.sh`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68506812c1048327a9112cfcf0516d7f