### PR TITLE
Add CSV export for category tree

### DIFF
--- a/includes/class-auto-assign.php
+++ b/includes/class-auto-assign.php
@@ -263,6 +263,7 @@ class Gm2_Category_Sort_Auto_Assign {
         $upload = function_exists( 'wp_upload_dir' ) ? wp_upload_dir() : [ 'basedir' => dirname( __DIR__ ) ];
         $export_dir = trailingslashit( $upload['basedir'] ) . 'gm2-category-sort/mapping-logs';
         Gm2_Category_Sort_Product_Category_Generator::export_brand_model_csv( $mapping, $export_dir );
+        Gm2_Category_Sort_Product_Category_Generator::export_category_tree_csv( $export_dir );
 
         $query = new WP_Query( [
             'post_type'      => 'product',
@@ -504,6 +505,7 @@ class Gm2_Category_Sort_Auto_Assign {
         $upload    = function_exists( 'wp_upload_dir' ) ? wp_upload_dir() : [ 'basedir' => dirname( __DIR__ ) ];
         $export_dir = trailingslashit( $upload['basedir'] ) . 'gm2-category-sort/mapping-logs';
         Gm2_Category_Sort_Product_Category_Generator::export_brand_model_csv( $mapping, $export_dir );
+        Gm2_Category_Sort_Product_Category_Generator::export_category_tree_csv( $export_dir );
 
         $total    = wp_count_posts( 'product' )->publish;
         $progress = null;


### PR DESCRIPTION
## Summary
- export full category tree to a CSV file
- invoke category tree export from admin/CLI auto assign
- test that the tree is exported with synonyms

## Testing
- `bash bin/install-phpunit.sh`
- `apt-get install -y php php-xml php-mbstring`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6850c08902648327b58d21952cbfac8e