### PR TITLE
Improve auto-assign with flexible wheel size detection

### DIFF
--- a/includes/class-product-category-generator.php
+++ b/includes/class-product-category-generator.php
@@ -247,6 +247,14 @@ class Gm2_Category_Sort_Product_Category_Generator {
         $lower = self::normalize_text( $text );
         $cats  = [];
         $words = preg_split( '/\s+/', $lower );
+        $wheel_size = null;
+        if ( preg_match(
+            '/^\s*(\d{1,2}(?:\.\d+)?)(?=[\s"\'\xE2\x80\x9C\xE2\x80\x9D\xE2\x80\x99\xE2\x80\xB2\xE2\x80\xB3xX]|$)/u',
+            $text,
+            $m
+        ) ) {
+            $wheel_size = $m[1] . '"';
+        }
         $word_count = count( $words );
         $lug_hole_candidates = [];
         $brands        = [];
@@ -455,7 +463,8 @@ class Gm2_Category_Sort_Product_Category_Generator {
             }
         }
 
-      $brand_terms = [ 'wheel simulator', 'rim liner', 'hubcap', 'wheel cover' ];
+        $brand_terms  = [ 'wheel simulator', 'rim liner', 'hubcap', 'wheel cover' ];
+        $brand_found  = false;
         foreach ( $brand_terms as $term ) {
             if ( preg_match( '/(?<!\w)' . preg_quote( $term, '/' ) . '(?!\w)/', $lower ) ) {
                 $neg = false;
@@ -472,7 +481,16 @@ class Gm2_Category_Sort_Product_Category_Generator {
                             $cats[] = $cat;
                         }
                     }
+                    $brand_found = true;
                     break;
+                }
+            }
+        }
+
+        if ( $brand_found && $wheel_size ) {
+            foreach ( [ 'By Wheel Size', $wheel_size ] as $cat ) {
+                if ( ! in_array( $cat, $cats, true ) ) {
+                    $cats[] = $cat;
                 }
             }
         }

--- a/tests/ProductCategoryGeneratorTest.php
+++ b/tests/ProductCategoryGeneratorTest.php
@@ -147,9 +147,50 @@ class ProductCategoryGeneratorTest extends TestCase {
                 'Wheel Simulators',
                 'Brands',
                 'Eagle Flight Wheel Simulators',
+                'By Wheel Size',
+                '19.5"',
             ],
             $cats
         );
+    }
+
+    public function test_wheel_size_prefix_category() {
+        $root = wp_insert_term( 'By Wheel Size', 'product_cat' );
+        wp_insert_term( '19.5"', 'product_cat', [ 'parent' => $root['term_id'] ] );
+
+        $mapping = Gm2_Category_Sort_Product_Category_Generator::build_mapping_from_globals();
+        $text    = '19.5" wheel simulator for trucks';
+
+        $cats = Gm2_Category_Sort_Product_Category_Generator::assign_categories( $text, $mapping );
+
+        $this->assertContains( 'By Wheel Size', $cats );
+        $this->assertContains( '19.5"', $cats );
+    }
+
+    public function test_wheel_size_prefix_single_quote() {
+        $root = wp_insert_term( 'By Wheel Size', 'product_cat' );
+        wp_insert_term( '19.5"', 'product_cat', [ 'parent' => $root['term_id'] ] );
+
+        $mapping = Gm2_Category_Sort_Product_Category_Generator::build_mapping_from_globals();
+        $text    = "19.5' rim liner kit";
+
+        $cats = Gm2_Category_Sort_Product_Category_Generator::assign_categories( $text, $mapping );
+
+        $this->assertContains( 'By Wheel Size', $cats );
+        $this->assertContains( '19.5"', $cats );
+    }
+
+    public function test_wheel_size_prefix_no_symbol() {
+        $root = wp_insert_term( 'By Wheel Size', 'product_cat' );
+        wp_insert_term( '19.5"', 'product_cat', [ 'parent' => $root['term_id'] ] );
+
+        $mapping = Gm2_Category_Sort_Product_Category_Generator::build_mapping_from_globals();
+        $text    = '19.5 wheel cover';
+
+        $cats = Gm2_Category_Sort_Product_Category_Generator::assign_categories( $text, $mapping );
+
+        $this->assertContains( 'By Wheel Size', $cats );
+        $this->assertContains( '19.5"', $cats );
     }
 
     public function test_eagle_flight_brand_rule() {
@@ -190,6 +231,8 @@ class ProductCategoryGeneratorTest extends TestCase {
                 'Ram 5500',
                 'Brands',
                 'Eagle Flight Wheel Simulators',
+                'By Wheel Size',
+                '19.5"',
             ],
             $cats
         );


### PR DESCRIPTION
## Summary
- broaden regex for wheel size detection
- add unit tests for single quote and no symbol cases

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6850d0f680c08327a00e967000bfae70