### PR TITLE
Improve wheel size mapping for simulators

### DIFF
--- a/includes/class-product-category-generator.php
+++ b/includes/class-product-category-generator.php
@@ -246,7 +246,17 @@ class Gm2_Category_Sort_Product_Category_Generator {
     public static function assign_categories( $text, array $mapping, $fuzzy = false, $threshold = 85, $csv_dir = null ) {
         $lower = self::normalize_text( $text );
         $cats  = [];
-        $words = preg_split( '/\s+/', $lower );
+        $words          = preg_split( '/\s+/', $lower );
+        $wheel_size_num = null;
+        $wheel_size     = null;
+        if ( preg_match(
+            '/^\s*(\d{1,2}(?:\.\d+)?)(?=[\s"\'\x{201C}\x{201D}\x{2019}\x{2032}\x{2033}xX]|$)/u',
+            $text,
+            $m
+        ) ) {
+            $wheel_size_num = $m[1];
+            $wheel_size     = $wheel_size_num . '"';
+        }
         $word_count = count( $words );
         $lug_hole_candidates = [];
         $brands        = [];
@@ -455,7 +465,8 @@ class Gm2_Category_Sort_Product_Category_Generator {
             }
         }
 
-      $brand_terms = [ 'wheel simulator', 'rim liner', 'hubcap', 'wheel cover' ];
+        $brand_terms  = [ 'wheel simulator', 'rim liner', 'hubcap', 'wheel cover' ];
+        $brand_found  = false;
         foreach ( $brand_terms as $term ) {
             if ( preg_match( '/(?<!\w)' . preg_quote( $term, '/' ) . '(?!\w)/', $lower ) ) {
                 $neg = false;
@@ -472,7 +483,36 @@ class Gm2_Category_Sort_Product_Category_Generator {
                             $cats[] = $cat;
                         }
                     }
+                    $brand_found = true;
                     break;
+                }
+            }
+        }
+
+        if ( $brand_found && $wheel_size_num ) {
+            $found_child = false;
+            $candidates  = [
+                $wheel_size_num . '"',
+                $wheel_size_num . "\xE2\x80\xB3",
+                $wheel_size_num,
+            ];
+            foreach ( $candidates as $cand ) {
+                $key = self::normalize_text( $cand );
+                if ( isset( $mapping[ $key ] ) ) {
+                    foreach ( $mapping[ $key ] as $cat ) {
+                        if ( ! in_array( $cat, $cats, true ) ) {
+                            $cats[] = $cat;
+                        }
+                    }
+                    $found_child = true;
+                    break;
+                }
+            }
+            if ( ! $found_child ) {
+                foreach ( [ 'By Wheel Size', $wheel_size ] as $cat ) {
+                    if ( ! in_array( $cat, $cats, true ) ) {
+                        $cats[] = $cat;
+                    }
                 }
             }
         }

--- a/tests/ProductCategoryGeneratorTest.php
+++ b/tests/ProductCategoryGeneratorTest.php
@@ -147,9 +147,81 @@ class ProductCategoryGeneratorTest extends TestCase {
                 'Wheel Simulators',
                 'Brands',
                 'Eagle Flight Wheel Simulators',
+                'By Wheel Size',
+                '19.5"',
             ],
             $cats
         );
+    }
+
+    public function test_wheel_size_prefix_category() {
+        $root = wp_insert_term( 'By Wheel Size', 'product_cat' );
+        wp_insert_term( '19.5"', 'product_cat', [ 'parent' => $root['term_id'] ] );
+
+        $mapping = Gm2_Category_Sort_Product_Category_Generator::build_mapping_from_globals();
+        $text    = '19.5" wheel simulator for trucks';
+
+        $cats = Gm2_Category_Sort_Product_Category_Generator::assign_categories( $text, $mapping );
+
+        $this->assertContains( 'By Wheel Size', $cats );
+        $this->assertContains( '19.5"', $cats );
+    }
+
+    public function test_wheel_size_prefix_single_quote() {
+        $root = wp_insert_term( 'By Wheel Size', 'product_cat' );
+        wp_insert_term( '19.5"', 'product_cat', [ 'parent' => $root['term_id'] ] );
+
+        $mapping = Gm2_Category_Sort_Product_Category_Generator::build_mapping_from_globals();
+        $text    = "19.5' rim liner kit";
+
+        $cats = Gm2_Category_Sort_Product_Category_Generator::assign_categories( $text, $mapping );
+
+        $this->assertContains( 'By Wheel Size', $cats );
+        $this->assertContains( '19.5"', $cats );
+    }
+
+    public function test_wheel_size_prefix_no_symbol() {
+        $root = wp_insert_term( 'By Wheel Size', 'product_cat' );
+        wp_insert_term( '19.5"', 'product_cat', [ 'parent' => $root['term_id'] ] );
+
+        $mapping = Gm2_Category_Sort_Product_Category_Generator::build_mapping_from_globals();
+        $text    = '19.5 wheel cover';
+
+        $cats = Gm2_Category_Sort_Product_Category_Generator::assign_categories( $text, $mapping );
+
+        $this->assertContains( 'By Wheel Size', $cats );
+        $this->assertContains( '19.5"', $cats );
+    }
+
+    public function test_wheel_size_prefix_various_sizes() {
+        $root  = wp_insert_term( 'By Wheel Size', 'product_cat' );
+        $sizes = [ '15', '16', '16.5', '17', '17.5', '22.5', '24.5' ];
+        foreach ( $sizes as $s ) {
+            wp_insert_term( $s . '"', 'product_cat', [ 'parent' => $root['term_id'] ] );
+        }
+
+        $mapping = Gm2_Category_Sort_Product_Category_Generator::build_mapping_from_globals();
+
+        foreach ( $sizes as $s ) {
+            foreach ( [ $s . '" wheel cover', $s . "' wheel cover" ] as $text ) {
+                $cats = Gm2_Category_Sort_Product_Category_Generator::assign_categories( $text, $mapping );
+                $this->assertContains( 'By Wheel Size', $cats );
+                $this->assertContains( $s . '"', $cats );
+            }
+        }
+    }
+
+    public function test_wheel_size_category_curly_quote() {
+        $root = wp_insert_term( 'By Wheel Size', 'product_cat' );
+        wp_insert_term( "19.5\xE2\x80\xB3", 'product_cat', [ 'parent' => $root['term_id'] ] );
+
+        $mapping = Gm2_Category_Sort_Product_Category_Generator::build_mapping_from_globals();
+        $text    = '19.5" rim liner kit';
+
+        $cats = Gm2_Category_Sort_Product_Category_Generator::assign_categories( $text, $mapping );
+
+        $this->assertContains( 'By Wheel Size', $cats );
+        $this->assertContains( "19.5\xE2\x80\xB3", $cats );
     }
 
     public function test_eagle_flight_brand_rule() {
@@ -190,6 +262,8 @@ class ProductCategoryGeneratorTest extends TestCase {
                 'Ram 5500',
                 'Brands',
                 'Eagle Flight Wheel Simulators',
+                'By Wheel Size',
+                '19.5"',
             ],
             $cats
         );


### PR DESCRIPTION
## Summary
- match wheel-size child categories with multiple quote variants
- fall back to generic wheel-size when child not found
- cover curly-quote category in tests

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6850d0f680c08327a00e967000bfae70