### PR TITLE
Dynamic wheel size lookup

### DIFF
--- a/includes/class-product-category-generator.php
+++ b/includes/class-product-category-generator.php
@@ -177,6 +177,27 @@ class Gm2_Category_Sort_Product_Category_Generator {
     }
 
     /**
+     * Extract mapping entries that belong to the "By Wheel Size" branch.
+     *
+     * This scans the full term mapping and returns a new array containing only
+     * the entries whose category path includes the "By Wheel Size" segment. It
+     * allows wheel size categories to be discovered regardless of where the
+     * branch sits in the overall hierarchy.
+     *
+     * @param array<string,array> $mapping Full term mapping.
+     * @return array<string,array> Filtered mapping for wheel size terms.
+     */
+    protected static function extract_wheel_size_map( array $mapping ) {
+        $result = [];
+        foreach ( $mapping as $term => $path ) {
+            if ( in_array( 'By Wheel Size', $path, true ) ) {
+                $result[ $term ] = $path;
+            }
+        }
+        return $result;
+    }
+
+    /**
      * Build a mapping of category and synonym terms to their full hierarchy.
      *
      * This uses the globals populated by the test stubs.
@@ -268,6 +289,9 @@ class Gm2_Category_Sort_Product_Category_Generator {
             foreach ( $mapping as $term => $path ) {
                 $brand_idx = self::find_brand_index( $path );
                 if ( $brand_idx === false ) {
+                    if ( in_array( 'By Wheel Size', $path, true ) ) {
+                        continue;
+                    }
                     $other_mapping[ $term ] = $path;
                     continue;
                 }
@@ -333,6 +357,9 @@ class Gm2_Category_Sort_Product_Category_Generator {
                     }
                 }
 
+                if ( in_array( 'By Wheel Size', $path, true ) ) {
+                    continue;
+                }
                 $other_mapping[ $term ] = $path;
             }
         }
@@ -489,17 +516,18 @@ class Gm2_Category_Sort_Product_Category_Generator {
             }
         }
 
-      if ( $brand_found && $wheel_size_num ) {
-            $found_child = false;
-            $candidates  = [
+        if ( $brand_found && $wheel_size_num ) {
+            $found_child    = false;
+            $wheel_size_map = self::extract_wheel_size_map( $mapping );
+            $candidates     = [
                 $wheel_size_num . '"',
                 $wheel_size_num . "\xE2\x80\xB3",
                 $wheel_size_num,
             ];
             foreach ( $candidates as $cand ) {
                 $key = self::normalize_text( $cand );
-                if ( isset( $mapping[ $key ] ) ) {
-                    foreach ( $mapping[ $key ] as $cat ) {
+                if ( isset( $wheel_size_map[ $key ] ) ) {
+                    foreach ( $wheel_size_map[ $key ] as $cat ) {
                         if ( ! in_array( $cat, $cats, true ) ) {
                             $cats[] = $cat;
                         }

--- a/tests/ProductCategoryGeneratorTest.php
+++ b/tests/ProductCategoryGeneratorTest.php
@@ -223,6 +223,33 @@ class ProductCategoryGeneratorTest extends TestCase {
         $this->assertContains( 'By Wheel Size', $cats );
         $this->assertContains( "19.5\xE2\x80\xB3", $cats );
     }
+
+    public function test_wheel_size_category_in_subtree() {
+        $wheel  = wp_insert_term( 'Wheel Simulators', 'product_cat' );
+        $brands = wp_insert_term( 'Brands', 'product_cat', [ 'parent' => $wheel['term_id'] ] );
+        wp_insert_term( 'Eagle Flight Wheel Simulators', 'product_cat', [ 'parent' => $brands['term_id'] ] );
+
+        $acc   = wp_insert_term( 'Accessories', 'product_cat' );
+        $root  = wp_insert_term( 'By Wheel Size', 'product_cat', [ 'parent' => $acc['term_id'] ] );
+        wp_insert_term( '19.5"', 'product_cat', [ 'parent' => $root['term_id'] ] );
+
+        $mapping = Gm2_Category_Sort_Product_Category_Generator::build_mapping_from_globals();
+        $text    = '19.5" wheel simulator cover';
+
+        $cats = Gm2_Category_Sort_Product_Category_Generator::assign_categories( $text, $mapping );
+
+        $this->assertSame(
+            [
+                'Wheel Simulators',
+                'Brands',
+                'Eagle Flight Wheel Simulators',
+                'Accessories',
+                'By Wheel Size',
+                '19.5"',
+            ],
+            $cats
+        );
+    }
   
     public function test_eagle_flight_brand_rule() {
         $wheel  = wp_insert_term( 'Wheel Simulators', 'product_cat' );


### PR DESCRIPTION
## Summary
- add `extract_wheel_size_map` helper to detect wheel size categories anywhere in the tree
- ignore wheel-size nodes when building the general mapping
- use dynamic wheel size lookup when assigning categories
- test wheel size matching when the branch is nested elsewhere

## Testing
- `phpunit -c phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68519ec8ca948327a6cc010db685fa9c