### PR TITLE
Add branch CSV export for child categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,7 @@ A progress bar shows the export status as the plugin saves `category-tree.csv` a
 separate branch files for every category that has child terms under
 `wp-content/uploads/gm2-category-sort/categories-structure`.
 Use these files to review or modify the structure of specific sections.
-When processing completes the page also lists each branch path that was
-identified so you can quickly browse them.
+When processing completes the page also lists each generated branch along with its parent category so you can quickly browse them.
 
 ### Manual Search and Assign
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,14 @@ directory at `wp-content/uploads/gm2-category-sort/mapping-logs`. Review the
 `brands.csv`, `models.csv` and `wheel-sizes.csv` files there to verify the
 exact words being checked.
 
+## One Click Categories Assignment
+
+This tool exports the full category tree and individual branch files in one step.
+Open **Tools → One Click Categories Assignment** and click **Assign Categories**.
+The plugin saves `category-tree.csv` plus separate CSVs for each category that
+has child terms under `wp-content/uploads/gm2-category-sort/categories-structure`.
+Use these files to review or modify the structure of specific sections.
+
 ### Manual Search and Assign
 
 Below the log the page provides a search form to manually select products.

--- a/README.md
+++ b/README.md
@@ -175,8 +175,9 @@ exact words being checked.
 
 This tool exports the full category tree and individual branch files in one step.
 Open **Tools → One Click Categories Assignment** and click **Study Category Tree Structure**.
-The plugin saves `category-tree.csv` plus separate CSVs for each category that
-has child terms under `wp-content/uploads/gm2-category-sort/categories-structure`.
+A progress bar shows the export status as the plugin saves `category-tree.csv` and
+separate branch files for every category that has child terms under
+`wp-content/uploads/gm2-category-sort/categories-structure`.
 Use these files to review or modify the structure of specific sections.
 
 ### Manual Search and Assign

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ exact words being checked.
 ## One Click Categories Assignment
 
 This tool exports the full category tree and individual branch files in one step.
-Open **Tools → One Click Categories Assignment** and click **Assign Categories**.
+Open **Tools → One Click Categories Assignment** and click **Study Category Tree Structure**.
 The plugin saves `category-tree.csv` plus separate CSVs for each category that
 has child terms under `wp-content/uploads/gm2-category-sort/categories-structure`.
 Use these files to review or modify the structure of specific sections.

--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ A progress bar shows the export status as the plugin saves `category-tree.csv` a
 separate branch files for every category that has child terms under
 `wp-content/uploads/gm2-category-sort/categories-structure`.
 Use these files to review or modify the structure of specific sections.
+When processing completes the page also lists each branch path that was
+identified so you can quickly browse them.
 
 ### Manual Search and Assign
 

--- a/assets/js/one-click-assign.js
+++ b/assets/js/one-click-assign.js
@@ -2,6 +2,7 @@ jQuery(function($){
     var btn = $('#gm2-one-click-btn');
     var msg = $('#gm2-one-click-message');
     var progress = $('#gm2-one-click-progress');
+    var branches = $('#gm2-one-click-branches');
     if(!btn.length) return;
 
     function step(offset, reset){
@@ -25,6 +26,15 @@ jQuery(function($){
             }else{
                 progress.hide();
                 msg.text(gm2OneClickAssign.completed);
+                branches.empty();
+                if(resp.data.branches && resp.data.branches.length){
+                    branches.append('<h2>'+gm2OneClickAssign.branchesTitle+'</h2>');
+                    var ul = $('<ul></ul>');
+                    resp.data.branches.forEach(function(path){
+                        ul.append($('<li></li>').text(path));
+                    });
+                    branches.append(ul);
+                }
             }
         }).fail(function(){
             progress.hide();
@@ -36,6 +46,7 @@ jQuery(function($){
         e.preventDefault();
         msg.text(gm2OneClickAssign.running);
         progress.attr('value',0).show();
+        branches.empty();
         step(0, true);
     });
 });

--- a/assets/js/one-click-assign.js
+++ b/assets/js/one-click-assign.js
@@ -1,0 +1,22 @@
+jQuery(function($){
+    var btn = $('#gm2-one-click-btn');
+    var msg = $('#gm2-one-click-message');
+    if(!btn.length) return;
+
+    btn.on('click', function(e){
+        e.preventDefault();
+        msg.text(gm2OneClickAssign.running);
+        $.post(ajaxurl, {
+            action: 'gm2_one_click_assign',
+            nonce: gm2OneClickAssign.nonce
+        }).done(function(resp){
+            if(resp.success){
+                msg.text(gm2OneClickAssign.completed);
+            }else{
+                msg.text(resp.data || gm2OneClickAssign.error);
+            }
+        }).fail(function(){
+            msg.text(gm2OneClickAssign.error);
+        });
+    });
+});

--- a/assets/js/one-click-assign.js
+++ b/assets/js/one-click-assign.js
@@ -4,6 +4,7 @@ jQuery(function($){
     var progress = $('#gm2-one-click-progress');
     var branches = $('#gm2-one-click-branches');
     if(!btn.length) return;
+    btn.text(gm2OneClickAssign.buttonLabel);
 
     function step(offset, reset){
         $.post(ajaxurl, {

--- a/assets/js/one-click-assign.js
+++ b/assets/js/one-click-assign.js
@@ -30,8 +30,12 @@ jQuery(function($){
                 if(resp.data.branches && resp.data.branches.length){
                     branches.append('<h2>'+gm2OneClickAssign.branchesTitle+'</h2>');
                     var ul = $('<ul></ul>');
-                    resp.data.branches.forEach(function(path){
-                        ul.append($('<li></li>').text(path));
+                    resp.data.branches.forEach(function(item){
+                        var text = item.path;
+                        if(item.parent){
+                            text += ' ('+gm2OneClickAssign.parentLabel+': '+item.parent+')';
+                        }
+                        ul.append($('<li></li>').text(text));
                     });
                     branches.append(ul);
                 }

--- a/assets/js/one-click-assign.js
+++ b/assets/js/one-click-assign.js
@@ -1,22 +1,41 @@
 jQuery(function($){
     var btn = $('#gm2-one-click-btn');
     var msg = $('#gm2-one-click-message');
+    var progress = $('#gm2-one-click-progress');
     if(!btn.length) return;
+
+    function step(offset, reset){
+        $.post(ajaxurl, {
+            action: 'gm2_one_click_assign',
+            nonce: gm2OneClickAssign.nonce,
+            offset: offset,
+            reset: reset ? 1 : 0
+        }).done(function(resp){
+            if(!resp.success){
+                progress.hide();
+                msg.text(resp.data || gm2OneClickAssign.error);
+                return;
+            }
+            if(resp.data.total){
+                var percent = Math.round((resp.data.offset/resp.data.total)*100);
+                progress.attr('value', percent).show();
+            }
+            if(!resp.data.done){
+                step(resp.data.offset, false);
+            }else{
+                progress.hide();
+                msg.text(gm2OneClickAssign.completed);
+            }
+        }).fail(function(){
+            progress.hide();
+            msg.text(gm2OneClickAssign.error);
+        });
+    }
 
     btn.on('click', function(e){
         e.preventDefault();
         msg.text(gm2OneClickAssign.running);
-        $.post(ajaxurl, {
-            action: 'gm2_one_click_assign',
-            nonce: gm2OneClickAssign.nonce
-        }).done(function(resp){
-            if(resp.success){
-                msg.text(gm2OneClickAssign.completed);
-            }else{
-                msg.text(resp.data || gm2OneClickAssign.error);
-            }
-        }).fail(function(){
-            msg.text(gm2OneClickAssign.error);
-        });
+        progress.attr('value',0).show();
+        step(0, true);
     });
 });

--- a/gm2-category-sort.php
+++ b/gm2-category-sort.php
@@ -16,6 +16,7 @@ define('GM2_CAT_SORT_VERSION', '1.0.16');
 define('GM2_CAT_SORT_PATH', plugin_dir_path(__FILE__));
 define('GM2_CAT_SORT_URL', plugin_dir_url(__FILE__));
 define('GM2_CAT_SORT_CRON_HOOK', 'gm2_category_sort_generate_sitemap');
+define('GM2_ONE_CLICK_LABEL', 'Study Category Tree Structure');
 
 register_activation_hook( __FILE__, 'gm2_category_sort_activate' );
 register_deactivation_hook( __FILE__, 'gm2_category_sort_deactivate' );

--- a/gm2-category-sort.php
+++ b/gm2-category-sort.php
@@ -60,6 +60,7 @@ function gm2_category_sort_init() {
     require_once GM2_CAT_SORT_PATH . 'includes/class-product-category-importer.php';
     require_once GM2_CAT_SORT_PATH . 'includes/class-attribute-fixer.php';
     require_once GM2_CAT_SORT_PATH . 'includes/class-auto-assign.php';
+    require_once GM2_CAT_SORT_PATH . 'includes/class-one-click-assign.php';
     
     // Initialize components
     Gm2_Category_Sort_Enqueuer::init();
@@ -72,6 +73,7 @@ function gm2_category_sort_init() {
     Gm2_Category_Sort_Product_Category_Importer::init();
     Gm2_Category_Sort_Attribute_Fixer::init();
     Gm2_Category_Sort_Auto_Assign::init();
+    Gm2_Category_Sort_One_Click_Assign::init();
     
     add_filter('pre_get_document_title', 'gm2_category_sort_modify_title');
     add_action('wp_head', 'gm2_category_sort_meta_description');

--- a/includes/class-one-click-assign.php
+++ b/includes/class-one-click-assign.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * One Click Categories Assignment admin page.
+ */
+class Gm2_Category_Sort_One_Click_Assign {
+
+    /**
+     * Initialize hooks.
+     */
+    public static function init() {
+        add_action( 'admin_menu', [ __CLASS__, 'register_admin_page' ] );
+        add_action( 'admin_enqueue_scripts', [ __CLASS__, 'enqueue_admin_assets' ] );
+        add_action( 'wp_ajax_gm2_one_click_assign', [ __CLASS__, 'ajax_assign' ] );
+    }
+
+    /**
+     * Register the Tools page.
+     */
+    public static function register_admin_page() {
+        add_management_page(
+            __( 'One Click Categories Assignment', 'gm2-category-sort' ),
+            __( 'One Click Categories Assignment', 'gm2-category-sort' ),
+            'manage_options',
+            'gm2-one-click-assign',
+            [ __CLASS__, 'admin_page' ]
+        );
+    }
+
+    /**
+     * Enqueue admin JavaScript.
+     *
+     * @param string $hook Current admin page hook.
+     */
+    public static function enqueue_admin_assets( $hook ) {
+        if ( $hook !== 'tools_page_gm2-one-click-assign' ) {
+            return;
+        }
+
+        $ver = file_exists( GM2_CAT_SORT_PATH . 'assets/js/one-click-assign.js' ) ? filemtime( GM2_CAT_SORT_PATH . 'assets/js/one-click-assign.js' ) : GM2_CAT_SORT_VERSION;
+        wp_enqueue_script(
+            'gm2-one-click-assign',
+            GM2_CAT_SORT_URL . 'assets/js/one-click-assign.js',
+            [ 'jquery' ],
+            $ver,
+            true
+        );
+
+        wp_localize_script(
+            'gm2-one-click-assign',
+            'gm2OneClickAssign',
+            [
+                'nonce'     => wp_create_nonce( 'gm2_one_click_assign' ),
+                'running'   => __( 'Processing...', 'gm2-category-sort' ),
+                'completed' => __( 'Category CSV files generated.', 'gm2-category-sort' ),
+                'error'     => __( 'Error generating files.', 'gm2-category-sort' ),
+            ]
+        );
+    }
+
+    /**
+     * Render the admin page.
+     */
+    public static function admin_page() {
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e( 'One Click Categories Assignment', 'gm2-category-sort' ); ?></h1>
+            <p>
+                <button id="gm2-one-click-btn" class="button button-primary">
+                    <?php esc_html_e( 'Assign Categories', 'gm2-category-sort' ); ?>
+                </button>
+            </p>
+            <div id="gm2-one-click-message"></div>
+        </div>
+        <?php
+    }
+
+    /**
+     * Handle AJAX request to generate category CSV files.
+     */
+    public static function ajax_assign() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( 'unauthorized' );
+        }
+
+        check_ajax_referer( 'gm2_one_click_assign', 'nonce' );
+
+        $upload = wp_upload_dir();
+        $dir    = trailingslashit( $upload['basedir'] ) . 'gm2-category-sort/categories-structure';
+
+        Gm2_Category_Sort_Product_Category_Generator::export_category_tree_csv( $dir );
+        self::export_branch_csvs( $dir );
+
+        wp_send_json_success();
+    }
+
+    /**
+     * Split category-tree.csv into separate branch files for every level.
+     *
+     * Each category path prefix gets its own CSV containing all rows under
+     * that branch, ensuring child categories receive branch files too.
+     *
+     * @param string $dir Directory containing category-tree.csv.
+     * @return void
+     */
+    protected static function export_branch_csvs( $dir ) {
+        $tree_file = rtrim( $dir, '/' ) . '/category-tree.csv';
+        if ( ! file_exists( $tree_file ) ) {
+            return;
+        }
+
+        $rows    = array_map( 'str_getcsv', file( $tree_file ) );
+
+        // Determine which category path prefixes have children.
+        $has_children = [];
+        foreach ( $rows as $row ) {
+            if ( empty( $row ) ) {
+                continue;
+            }
+
+            $path_slugs = [];
+            $last_index = count( $row ) - 1;
+            foreach ( $row as $index => $segment ) {
+                $segment = trim( $segment );
+                if ( $segment === '' ) {
+                    continue;
+                }
+
+                $path_slugs[] = sanitize_title( $segment );
+                $slug         = implode( '-', $path_slugs );
+
+                // Only mark a slug if this row has a deeper level underneath it.
+                if ( $index < $last_index ) {
+                    $has_children[ $slug ] = true;
+                }
+            }
+        }
+
+        $handles = [];
+        foreach ( $rows as $row ) {
+            if ( empty( $row ) ) {
+                continue;
+            }
+
+            $path_slugs = [];
+            foreach ( $row as $segment ) {
+                $segment = trim( $segment );
+                if ( $segment === '' ) {
+                    continue;
+                }
+
+                $path_slugs[] = sanitize_title( $segment );
+                $slug         = implode( '-', $path_slugs );
+
+                // Skip if this slug has no children in the overall tree.
+                if ( ! isset( $has_children[ $slug ] ) ) {
+                    continue;
+                }
+
+                $file = rtrim( $dir, '/' ) . '/' . $slug . '.csv';
+
+                if ( ! isset( $handles[ $slug ] ) ) {
+                    $handles[ $slug ] = fopen( $file, 'w' );
+                    if ( ! $handles[ $slug ] ) {
+                        unset( $handles[ $slug ] );
+                        continue;
+                    }
+                }
+
+                fputcsv( $handles[ $slug ], $row );
+            }
+        }
+
+        foreach ( $handles as $fh ) {
+            fclose( $fh );
+        }
+    }
+}

--- a/includes/class-one-click-assign.php
+++ b/includes/class-one-click-assign.php
@@ -55,6 +55,7 @@ class Gm2_Category_Sort_One_Click_Assign {
                 'error'     => __( 'Error generating files.', 'gm2-category-sort' ),
                 'branchesTitle' => __( 'Identified Branches', 'gm2-category-sort' ),
                 'parentLabel'   => __( 'Parent', 'gm2-category-sort' ),
+                'buttonLabel'   => GM2_ONE_CLICK_LABEL,
             ]
         );
     }
@@ -68,7 +69,7 @@ class Gm2_Category_Sort_One_Click_Assign {
             <h1><?php esc_html_e( 'One Click Categories Assignment', 'gm2-category-sort' ); ?></h1>
             <p>
                 <button id="gm2-one-click-btn" class="button button-primary">
-                    <?php esc_html_e( 'Study Category Tree Structure', 'gm2-category-sort' ); ?>
+                    <?php echo esc_html( GM2_ONE_CLICK_LABEL ); ?>
                 </button>
             </p>
             <p><progress id="gm2-one-click-progress" value="0" max="100" style="display:none;width:100%;"></progress></p>

--- a/includes/class-one-click-assign.php
+++ b/includes/class-one-click-assign.php
@@ -54,6 +54,7 @@ class Gm2_Category_Sort_One_Click_Assign {
                 'completed' => __( 'Category CSV files generated.', 'gm2-category-sort' ),
                 'error'     => __( 'Error generating files.', 'gm2-category-sort' ),
                 'branchesTitle' => __( 'Identified Branches', 'gm2-category-sort' ),
+                'parentLabel'   => __( 'Parent', 'gm2-category-sort' ),
             ]
         );
     }
@@ -201,7 +202,7 @@ class Gm2_Category_Sort_One_Click_Assign {
      * Retrieve readable branch paths from the category-tree.csv file.
      *
      * @param string $dir Directory containing category-tree.csv.
-     * @return string[] List of branch paths.
+     * @return array[] List of branch info arrays with path and parent name.
      */
     protected static function get_branch_paths( $dir ) {
         $tree_file = rtrim( $dir, '/' ) . '/category-tree.csv';
@@ -231,6 +232,18 @@ class Gm2_Category_Sort_One_Click_Assign {
             }
         }
 
-        return array_values( $paths );
+        $branches = [];
+        foreach ( $paths as $slug => $path ) {
+            $parts = explode( '-', $slug );
+            array_pop( $parts );
+            $parent_slug = implode( '-', $parts );
+            $parent      = isset( $paths[ $parent_slug ] ) ? $paths[ $parent_slug ] : '';
+            $branches[]  = [
+                'path'   => $path,
+                'parent' => $parent,
+            ];
+        }
+
+        return $branches;
     }
 }

--- a/includes/class-one-click-assign.php
+++ b/includes/class-one-click-assign.php
@@ -66,7 +66,7 @@ class Gm2_Category_Sort_One_Click_Assign {
             <h1><?php esc_html_e( 'One Click Categories Assignment', 'gm2-category-sort' ); ?></h1>
             <p>
                 <button id="gm2-one-click-btn" class="button button-primary">
-                    <?php esc_html_e( 'Assign Categories', 'gm2-category-sort' ); ?>
+                    <?php esc_html_e( 'Study Category Tree Structure', 'gm2-category-sort' ); ?>
                 </button>
             </p>
             <div id="gm2-one-click-message"></div>


### PR DESCRIPTION
## Summary
- add new One Click Categories Assignment tool with AJAX
- split the category tree into branch CSV files only for categories that have children
- document the new admin page and CSV location

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6851c3b3537c8327a8652f357f02aaeb