### PR TITLE
Rename button label to 'Study Category Tree'

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ exact words being checked.
 ## One Click Categories Assignment
 
 This tool exports the full category tree and individual branch files in one step.
-Open **Tools → One Click Categories Assignment** and click **Assign Categories**.
+Open **Tools → One Click Categories Assignment** and click **Study Category Tree**.
 The plugin saves `category-tree.csv` plus separate CSVs for each category that
 has child terms under `wp-content/uploads/gm2-category-sort/categories-structure`.
 Use these files to review or modify the structure of specific sections.

--- a/includes/class-one-click-assign.php
+++ b/includes/class-one-click-assign.php
@@ -66,7 +66,7 @@ class Gm2_Category_Sort_One_Click_Assign {
             <h1><?php esc_html_e( 'One Click Categories Assignment', 'gm2-category-sort' ); ?></h1>
             <p>
                 <button id="gm2-one-click-btn" class="button button-primary">
-                    <?php esc_html_e( 'Assign Categories', 'gm2-category-sort' ); ?>
+                    <?php esc_html_e( 'Study Category Tree', 'gm2-category-sort' ); ?>
                 </button>
             </p>
             <div id="gm2-one-click-message"></div>


### PR DESCRIPTION
## Summary
- rename the one-click assignment page button label to "Study Category Tree"
- update docs to match

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6851e01cc2e08327a62906afd11d8fee