### PR TITLE
Persist branch list in One Click page

### DIFF
--- a/assets/js/one-click-assign.js
+++ b/assets/js/one-click-assign.js
@@ -20,6 +20,9 @@ jQuery(function($){
         });
     }
 
+    // Display existing branch list on initial page load if CSV files exist
+    loadBranches();
+
     btn.on('click', function(e){
         e.preventDefault();
         msg.text(gm2OneClickAssign.running);


### PR DESCRIPTION
## Summary
- load existing branch list on admin page load

The branch list shown on Tools → One Click Categories Assignment was only visible after the CSV generation ran. Refreshing the page cleared it. Now the script automatically loads the list on page load so the existing category tree remains visible until the button is clicked again to regenerate.

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6851e7858fc48327852f9f027cd43131