### PR TITLE
Implement branch-based auto assignment on one-click page

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,11 @@ The plugin saves `category-tree.csv` plus separate CSVs for each category that
 has child terms under `wp-content/uploads/gm2-category-sort/categories-structure`.
 Use these files to review or modify the structure of specific sections.
 
+After generating the tree you can automatically assign categories to all
+products. Choose which product fields to analyze—title, description or
+attributes—using the multiselect next to the **Assign Categories** button and
+click the button to run the assignment.
+
 ### Manual Search and Assign
 
 Below the log the page provides a search form to manually select products.

--- a/assets/js/one-click-assign.js
+++ b/assets/js/one-click-assign.js
@@ -1,5 +1,7 @@
 jQuery(function($){
     var btn = $('#gm2-one-click-btn');
+    var assignBtn = $('#gm2-oca-assign');
+    var fieldsSel = $('#gm2-oca-fields');
     var msg = $('#gm2-one-click-message');
     var results = $('#gm2-branch-results');
     if(!btn.length) return;
@@ -33,6 +35,25 @@ jQuery(function($){
             if(resp.success){
                 msg.text(gm2OneClickAssign.completed);
                 loadBranches();
+            }else{
+                msg.text(resp.data || gm2OneClickAssign.error);
+            }
+        }).fail(function(){
+            msg.text(gm2OneClickAssign.error);
+        });
+    });
+
+    assignBtn.on('click', function(e){
+        e.preventDefault();
+        msg.text(gm2OneClickAssign.assigning);
+        var fields = fieldsSel.val() || [];
+        $.post(ajaxurl, {
+            action: 'gm2_one_click_assign_categories',
+            nonce: gm2OneClickAssign.nonce,
+            fields: fields
+        }).done(function(resp){
+            if(resp.success){
+                msg.text(gm2OneClickAssign.assignDone);
             }else{
                 msg.text(resp.data || gm2OneClickAssign.error);
             }

--- a/tests/OneClickAssignTest.php
+++ b/tests/OneClickAssignTest.php
@@ -1,0 +1,84 @@
+<?php
+namespace {
+use PHPUnit\Framework\TestCase;
+require_once __DIR__ . '/../includes/class-one-click-assign.php';
+
+// Stub WP_Query
+if ( ! class_exists( 'WP_Query' ) ) {
+    class WP_Query {
+        public $posts = [];
+        public $found_posts = 0;
+        public function __construct( $args = [] ) {
+            $ids = array_keys( $GLOBALS['gm2_product_objects'] ?? [] );
+            $this->found_posts = count( $ids );
+            $this->posts = $ids;
+        }
+    }
+}
+
+if ( ! function_exists( 'current_user_can' ) ) {
+    function current_user_can( $cap ) { return true; }
+}
+if ( ! function_exists( 'check_ajax_referer' ) ) {
+    function check_ajax_referer( $action, $name ) { return true; }
+}
+if ( ! function_exists( 'wp_send_json_success' ) ) {
+    function wp_send_json_success( $data = null ) { $GLOBALS['gm2_json_result'] = ['success'=>true,'data'=>$data]; return $GLOBALS['gm2_json_result']; }
+}
+if ( ! function_exists( 'wp_send_json_error' ) ) {
+    function wp_send_json_error( $data = null ) { $GLOBALS['gm2_json_result'] = ['success'=>false,'data'=>$data]; return $GLOBALS['gm2_json_result']; }
+}
+if ( ! function_exists( 'sanitize_key' ) ) {
+    function sanitize_key( $str ) { return $str; }
+}
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+    function sanitize_text_field( $str ) { return $str; }
+}
+if ( ! function_exists( 'wc_get_product' ) ) {
+    function wc_get_product( $id ) { return $GLOBALS['gm2_product_objects'][$id] ?? null; }
+}
+if ( ! function_exists( 'wc_get_product_terms' ) ) {
+    function wc_get_product_terms( $id, $tax, $args=[] ) { return []; }
+}
+}
+
+namespace {
+use PHPUnit\Framework\TestCase;
+
+class DummyProduct {
+    private $id; private $name; private $desc; public function __construct($id,$n,$d){$this->id=$id;$this->name=$n;$this->desc=$d;}
+    public function get_name(){return $this->name;}
+    public function get_description(){return $this->desc;}
+    public function get_short_description(){return '';}
+    public function get_attributes(){return [];}    public function get_sku(){return 'SKU'.$this->id;}
+}
+
+class OneClickAssignTest extends TestCase {
+    protected function setUp(): void {
+        gm2_test_reset_terms();
+        $GLOBALS['gm2_product_objects'] = [];
+        $GLOBALS['gm2_json_result'] = null;
+        $_POST = [];
+    }
+
+    private function create_categories(){
+        $p = wp_insert_term('Parent','product_cat');
+        update_term_meta($p['term_id'],'gm2_synonyms','Main');
+        $c = wp_insert_term('Child','product_cat',['parent'=>$p['term_id']]);
+        update_term_meta($c['term_id'],'gm2_synonyms','Alt');
+        return [$p['term_id'],$c['term_id']];
+    }
+
+    public function test_assigns_from_description(){
+        list($pid,$cid) = $this->create_categories();
+        $GLOBALS['gm2_product_objects'][1] = new DummyProduct(1,'Prod','great alt thing');
+        $_POST['nonce']='t';
+        $_POST['fields']=['description'];
+        Gm2_Category_Sort_One_Click_Assign::ajax_assign_categories();
+        $calls = $GLOBALS['gm2_set_terms_calls'];
+        $this->assertCount(1, $calls);
+        $this->assertContains($pid, $calls[0]['terms']);
+        $this->assertContains($cid, $calls[0]['terms']);
+    }
+}
+}

--- a/tests/ProductCategoryGeneratorTest.php
+++ b/tests/ProductCategoryGeneratorTest.php
@@ -17,6 +17,7 @@ if ( ! function_exists( 'sanitize_title' ) ) {
 }
 }
 
+namespace {
 use PHPUnit\Framework\TestCase;
 
 class ProductCategoryGeneratorTest extends TestCase {
@@ -607,4 +608,5 @@ class ProductCategoryGeneratorTest extends TestCase {
             $cats
         );
     }
+}
 }


### PR DESCRIPTION
## Summary
- add category assignment controls to One Click Categories Assignment page
- implement AJAX handler for assigning categories using selected product fields
- support field selection in frontend JavaScript
- fix namespace usage in ProductCategoryGeneratorTest
- test new one-click assignment behaviour
- document the Assign Categories option

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6851e8fc484883279299fa9073635cba