### PR TITLE
Fix branch rule keyword handling

### DIFF
--- a/includes/class-branch-rules.php
+++ b/includes/class-branch-rules.php
@@ -109,8 +109,8 @@ class Gm2_Category_Sort_Branch_Rules {
         foreach ( $data as $slug => $rule ) {
             $slug          = sanitize_key( $slug );
             $rules[ $slug ] = [
-                'include' => sanitize_text_field( $rule['include'] ?? '' ),
-                'exclude' => sanitize_text_field( $rule['exclude'] ?? '' ),
+                'include' => sanitize_textarea_field( $rule['include'] ?? '' ),
+                'exclude' => sanitize_textarea_field( $rule['exclude'] ?? '' ),
             ];
         }
         update_option( 'gm2_branch_rules', $rules );

--- a/tests/AutoAssignTest.php
+++ b/tests/AutoAssignTest.php
@@ -80,6 +80,9 @@ if ( ! function_exists( 'update_option' ) ) {
 if ( ! function_exists( 'sanitize_text_field' ) ) {
     function sanitize_text_field( $str ) { return $str; }
 }
+if ( ! function_exists( 'sanitize_textarea_field' ) ) {
+    function sanitize_textarea_field( $str ) { return $str; }
+}
 if ( ! function_exists( 'sanitize_key' ) ) {
     function sanitize_key( $str ) { return $str; }
 }

--- a/tests/OneClickAssignTest.php
+++ b/tests/OneClickAssignTest.php
@@ -34,6 +34,9 @@ if ( ! function_exists( 'sanitize_key' ) ) {
 if ( ! function_exists( 'sanitize_text_field' ) ) {
     function sanitize_text_field( $str ) { return $str; }
 }
+if ( ! function_exists( 'sanitize_textarea_field' ) ) {
+    function sanitize_textarea_field( $str ) { return $str; }
+}
 if ( ! function_exists( 'wc_get_product' ) ) {
     function wc_get_product( $id ) { return $GLOBALS['gm2_product_objects'][$id] ?? null; }
 }

--- a/tests/ProductCategoryGeneratorTest.php
+++ b/tests/ProductCategoryGeneratorTest.php
@@ -9,6 +9,9 @@ if ( ! function_exists( 'update_option' ) ) {
 if ( ! function_exists( 'sanitize_text_field' ) ) {
     function sanitize_text_field( $str ) { return $str; }
 }
+if ( ! function_exists( 'sanitize_textarea_field' ) ) {
+    function sanitize_textarea_field( $str ) { return $str; }
+}
 if ( ! function_exists( 'sanitize_key' ) ) {
     function sanitize_key( $str ) { return $str; }
 }


### PR DESCRIPTION
## Summary
- preserve quotes when saving branch rule keywords
- stub `sanitize_textarea_field` for tests

## Testing
- `vendor/bin/phpunit` *(fails: `/usr/bin/env: ‘php’: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6852106d7a50832780bd1334a648c527