### PR TITLE
Fix branch rule keyword handling

### DIFF
--- a/includes/class-branch-rules.php
+++ b/includes/class-branch-rules.php
@@ -104,13 +104,13 @@ class Gm2_Category_Sort_Branch_Rules {
             wp_send_json_error( 'unauthorized' );
         }
         check_ajax_referer( 'gm2_branch_rules', 'nonce' );
-        $data = isset( $_POST['rules'] ) && is_array( $_POST['rules'] ) ? $_POST['rules'] : [];
+        $data = isset( $_POST['rules'] ) && is_array( $_POST['rules'] ) ? wp_unslash( $_POST['rules'] ) : [];
         $rules = [];
         foreach ( $data as $slug => $rule ) {
             $slug          = sanitize_key( $slug );
             $rules[ $slug ] = [
-                'include' => sanitize_text_field( $rule['include'] ?? '' ),
-                'exclude' => sanitize_text_field( $rule['exclude'] ?? '' ),
+                'include' => sanitize_textarea_field( $rule['include'] ?? '' ),
+                'exclude' => sanitize_textarea_field( $rule['exclude'] ?? '' ),
             ];
         }
         update_option( 'gm2_branch_rules', $rules );

--- a/includes/class-product-category-generator.php
+++ b/includes/class-product-category-generator.php
@@ -39,6 +39,14 @@ class Gm2_Category_Sort_Product_Category_Generator {
      * @return string Normalized text.
      */
     public static function normalize_text( $text ) {
+        $text = strtr( $text, [
+            '′' => "'",
+            '″' => '"',
+            '‘' => "'",
+            '’' => "'",
+            '“' => '"',
+            '”' => '"',
+        ] );
         $text = strtolower( $text );
         foreach ( self::$replacements as $key => $val ) {
             $text = preg_replace( '/\b' . preg_quote( $key, '/' ) . '\b/', $val, $text );

--- a/tests/AutoAssignTest.php
+++ b/tests/AutoAssignTest.php
@@ -80,6 +80,15 @@ if ( ! function_exists( 'update_option' ) ) {
 if ( ! function_exists( 'sanitize_text_field' ) ) {
     function sanitize_text_field( $str ) { return $str; }
 }
+if ( ! function_exists( 'sanitize_textarea_field' ) ) {
+    function sanitize_textarea_field( $str ) { return $str; }
+}
+if ( ! function_exists( 'wp_unslash' ) ) {
+    function wp_unslash( $value ) {
+        if ( is_array( $value ) ) { return array_map( 'wp_unslash', $value ); }
+        return stripslashes( $value );
+    }
+}
 if ( ! function_exists( 'sanitize_key' ) ) {
     function sanitize_key( $str ) { return $str; }
 }

--- a/tests/BranchRulesTest.php
+++ b/tests/BranchRulesTest.php
@@ -1,0 +1,54 @@
+<?php
+use PHPUnit\Framework\TestCase;
+require_once __DIR__ . '/../includes/class-branch-rules.php';
+
+if ( ! function_exists( 'current_user_can' ) ) {
+    function current_user_can( $cap ) { return true; }
+}
+if ( ! function_exists( 'check_ajax_referer' ) ) {
+    function check_ajax_referer( $action, $name ) { return true; }
+}
+if ( ! function_exists( 'wp_unslash' ) ) {
+    function wp_unslash( $value ) {
+        if ( is_array( $value ) ) { return array_map( 'wp_unslash', $value ); }
+        return stripslashes( $value );
+    }
+}
+if ( ! function_exists( 'sanitize_textarea_field' ) ) {
+    function sanitize_textarea_field( $str ) { return $str; }
+}
+if ( ! function_exists( 'sanitize_key' ) ) {
+    function sanitize_key( $str ) { return $str; }
+}
+if ( ! function_exists( 'update_option' ) ) {
+    function update_option( $name, $value ) { $GLOBALS['gm2_options'][$name] = $value; return true; }
+}
+if ( ! function_exists( 'get_option' ) ) {
+    function get_option( $name, $default = false ) { return $GLOBALS['gm2_options'][$name] ?? $default; }
+}
+if ( ! function_exists( 'wp_send_json_success' ) ) {
+    function wp_send_json_success( $data = null ) { $GLOBALS['gm2_json_result'] = ['success'=>true,'data'=>$data]; return $GLOBALS['gm2_json_result']; }
+}
+if ( ! function_exists( 'wp_send_json_error' ) ) {
+    function wp_send_json_error( $data = null ) { $GLOBALS['gm2_json_result'] = ['success'=>false,'data'=>$data]; return $GLOBALS['gm2_json_result']; }
+}
+
+class BranchRulesTest extends TestCase {
+    protected function setUp(): void {
+        $GLOBALS['gm2_options'] = [];
+        $_POST = [];
+        $GLOBALS['gm2_json_result'] = null;
+    }
+
+    public function test_ajax_save_rules_preserves_quotes() {
+        $_POST['nonce'] = 't';
+        $_POST['rules'] = [ 'branch-leaf' => [ 'include' => '19\\"', 'exclude' => "19\\'" ] ];
+
+        Gm2_Category_Sort_Branch_Rules::ajax_save_rules();
+        $result = $GLOBALS['gm2_json_result'];
+        $this->assertTrue( $result['success'] );
+        $saved = get_option( 'gm2_branch_rules' );
+        $this->assertSame( '19"', $saved['branch-leaf']['include'] );
+        $this->assertSame( "19'", $saved['branch-leaf']['exclude'] );
+    }
+}

--- a/tests/OneClickAssignTest.php
+++ b/tests/OneClickAssignTest.php
@@ -34,6 +34,15 @@ if ( ! function_exists( 'sanitize_key' ) ) {
 if ( ! function_exists( 'sanitize_text_field' ) ) {
     function sanitize_text_field( $str ) { return $str; }
 }
+if ( ! function_exists( 'sanitize_textarea_field' ) ) {
+    function sanitize_textarea_field( $str ) { return $str; }
+}
+if ( ! function_exists( 'wp_unslash' ) ) {
+    function wp_unslash( $value ) {
+        if ( is_array( $value ) ) { return array_map( 'wp_unslash', $value ); }
+        return stripslashes( $value );
+    }
+}
 if ( ! function_exists( 'wc_get_product' ) ) {
     function wc_get_product( $id ) { return $GLOBALS['gm2_product_objects'][$id] ?? null; }
 }

--- a/tests/ProductCategoryGeneratorTest.php
+++ b/tests/ProductCategoryGeneratorTest.php
@@ -9,6 +9,15 @@ if ( ! function_exists( 'update_option' ) ) {
 if ( ! function_exists( 'sanitize_text_field' ) ) {
     function sanitize_text_field( $str ) { return $str; }
 }
+if ( ! function_exists( 'sanitize_textarea_field' ) ) {
+    function sanitize_textarea_field( $str ) { return $str; }
+}
+if ( ! function_exists( 'wp_unslash' ) ) {
+    function wp_unslash( $value ) {
+        if ( is_array( $value ) ) { return array_map( 'wp_unslash', $value ); }
+        return stripslashes( $value );
+    }
+}
 if ( ! function_exists( 'sanitize_key' ) ) {
     function sanitize_key( $str ) { return $str; }
 }
@@ -607,6 +616,11 @@ class ProductCategoryGeneratorTest extends TestCase {
             [ 'Wheel Simulators', 'Brands', 'Eagle Flight Wheel Simulators', 'By Brand & Model', 'Dodge', 'Ram 4500', 'By Wheel Size', '19.5"' ],
             $cats
         );
+    }
+
+    public function test_normalize_text_converts_primes() {
+        $norm = Gm2_Category_Sort_Product_Category_Generator::normalize_text( "Size 19\xE2\x80\xB3 x 8\xE2\x80\xB2" );
+        $this->assertSame( 'size 19" x 8\'', $norm );
     }
 }
 }


### PR DESCRIPTION
## Summary
- preserve quotes when saving branch rule keywords
- unslash POST data before sanitization
- stub `wp_unslash` in tests and add unit test for quote handling
- convert prime quotes to ASCII in text normalization
- add test covering prime handling

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6852106d7a50832780bd1334a648c527