### PR TITLE
Fix branch rule keyword handling

### DIFF
--- a/includes/class-branch-rules.php
+++ b/includes/class-branch-rules.php
@@ -104,13 +104,13 @@ class Gm2_Category_Sort_Branch_Rules {
             wp_send_json_error( 'unauthorized' );
         }
         check_ajax_referer( 'gm2_branch_rules', 'nonce' );
-        $data = isset( $_POST['rules'] ) && is_array( $_POST['rules'] ) ? $_POST['rules'] : [];
+        $data = isset( $_POST['rules'] ) && is_array( $_POST['rules'] ) ? wp_unslash( $_POST['rules'] ) : [];
         $rules = [];
         foreach ( $data as $slug => $rule ) {
             $slug          = sanitize_key( $slug );
             $rules[ $slug ] = [
-                'include' => sanitize_text_field( $rule['include'] ?? '' ),
-                'exclude' => sanitize_text_field( $rule['exclude'] ?? '' ),
+                'include' => wp_kses_post( $rule['include'] ?? '' ),
+                'exclude' => wp_kses_post( $rule['exclude'] ?? '' ),
             ];
         }
         update_option( 'gm2_branch_rules', $rules );

--- a/tests/AutoAssignTest.php
+++ b/tests/AutoAssignTest.php
@@ -80,6 +80,18 @@ if ( ! function_exists( 'update_option' ) ) {
 if ( ! function_exists( 'sanitize_text_field' ) ) {
     function sanitize_text_field( $str ) { return $str; }
 }
+if ( ! function_exists( 'sanitize_textarea_field' ) ) {
+    function sanitize_textarea_field( $str ) { return $str; }
+}
+if ( ! function_exists( 'wp_kses_post' ) ) {
+    function wp_kses_post( $str ) { return $str; }
+}
+if ( ! function_exists( 'wp_unslash' ) ) {
+    function wp_unslash( $value ) {
+        if ( is_array( $value ) ) { return array_map( 'wp_unslash', $value ); }
+        return stripslashes( $value );
+    }
+}
 if ( ! function_exists( 'sanitize_key' ) ) {
     function sanitize_key( $str ) { return $str; }
 }

--- a/tests/BranchRulesTest.php
+++ b/tests/BranchRulesTest.php
@@ -1,0 +1,57 @@
+<?php
+use PHPUnit\Framework\TestCase;
+require_once __DIR__ . '/../includes/class-branch-rules.php';
+
+if ( ! function_exists( 'current_user_can' ) ) {
+    function current_user_can( $cap ) { return true; }
+}
+if ( ! function_exists( 'check_ajax_referer' ) ) {
+    function check_ajax_referer( $action, $name ) { return true; }
+}
+if ( ! function_exists( 'wp_unslash' ) ) {
+    function wp_unslash( $value ) {
+        if ( is_array( $value ) ) { return array_map( 'wp_unslash', $value ); }
+        return stripslashes( $value );
+    }
+}
+if ( ! function_exists( 'sanitize_textarea_field' ) ) {
+    function sanitize_textarea_field( $str ) { return $str; }
+}
+if ( ! function_exists( 'wp_kses_post' ) ) {
+    function wp_kses_post( $str ) { return $str; }
+}
+if ( ! function_exists( 'sanitize_key' ) ) {
+    function sanitize_key( $str ) { return $str; }
+}
+if ( ! function_exists( 'update_option' ) ) {
+    function update_option( $name, $value ) { $GLOBALS['gm2_options'][$name] = $value; return true; }
+}
+if ( ! function_exists( 'get_option' ) ) {
+    function get_option( $name, $default = false ) { return $GLOBALS['gm2_options'][$name] ?? $default; }
+}
+if ( ! function_exists( 'wp_send_json_success' ) ) {
+    function wp_send_json_success( $data = null ) { $GLOBALS['gm2_json_result'] = ['success'=>true,'data'=>$data]; return $GLOBALS['gm2_json_result']; }
+}
+if ( ! function_exists( 'wp_send_json_error' ) ) {
+    function wp_send_json_error( $data = null ) { $GLOBALS['gm2_json_result'] = ['success'=>false,'data'=>$data]; return $GLOBALS['gm2_json_result']; }
+}
+
+class BranchRulesTest extends TestCase {
+    protected function setUp(): void {
+        $GLOBALS['gm2_options'] = [];
+        $_POST = [];
+        $GLOBALS['gm2_json_result'] = null;
+    }
+
+    public function test_ajax_save_rules_preserves_quotes() {
+        $_POST['nonce'] = 't';
+        $_POST['rules'] = [ 'branch-leaf' => [ 'include' => '19\\"', 'exclude' => "19\\'" ] ];
+
+        Gm2_Category_Sort_Branch_Rules::ajax_save_rules();
+        $result = $GLOBALS['gm2_json_result'];
+        $this->assertTrue( $result['success'] );
+        $saved = get_option( 'gm2_branch_rules' );
+        $this->assertSame( '19"', $saved['branch-leaf']['include'] );
+        $this->assertSame( "19'", $saved['branch-leaf']['exclude'] );
+    }
+}

--- a/tests/OneClickAssignTest.php
+++ b/tests/OneClickAssignTest.php
@@ -34,6 +34,18 @@ if ( ! function_exists( 'sanitize_key' ) ) {
 if ( ! function_exists( 'sanitize_text_field' ) ) {
     function sanitize_text_field( $str ) { return $str; }
 }
+if ( ! function_exists( 'sanitize_textarea_field' ) ) {
+    function sanitize_textarea_field( $str ) { return $str; }
+}
+if ( ! function_exists( 'wp_kses_post' ) ) {
+    function wp_kses_post( $str ) { return $str; }
+}
+if ( ! function_exists( 'wp_unslash' ) ) {
+    function wp_unslash( $value ) {
+        if ( is_array( $value ) ) { return array_map( 'wp_unslash', $value ); }
+        return stripslashes( $value );
+    }
+}
 if ( ! function_exists( 'wc_get_product' ) ) {
     function wc_get_product( $id ) { return $GLOBALS['gm2_product_objects'][$id] ?? null; }
 }

--- a/tests/ProductCategoryGeneratorTest.php
+++ b/tests/ProductCategoryGeneratorTest.php
@@ -9,6 +9,18 @@ if ( ! function_exists( 'update_option' ) ) {
 if ( ! function_exists( 'sanitize_text_field' ) ) {
     function sanitize_text_field( $str ) { return $str; }
 }
+if ( ! function_exists( 'sanitize_textarea_field' ) ) {
+    function sanitize_textarea_field( $str ) { return $str; }
+}
+if ( ! function_exists( 'wp_kses_post' ) ) {
+    function wp_kses_post( $str ) { return $str; }
+}
+if ( ! function_exists( 'wp_unslash' ) ) {
+    function wp_unslash( $value ) {
+        if ( is_array( $value ) ) { return array_map( 'wp_unslash', $value ); }
+        return stripslashes( $value );
+    }
+}
 if ( ! function_exists( 'sanitize_key' ) ) {
     function sanitize_key( $str ) { return $str; }
 }


### PR DESCRIPTION
## Summary
- preserve quotes when saving branch rule keywords
- stub `wp_kses_post` in tests and adjust unit test helper functions

## Testing
- `vendor/bin/phpunit` *(fails: `vendor/bin/phpunit: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6852106d7a50832780bd1334a648c527