### PR TITLE
Enhance one-click category assignment

### DIFF
--- a/assets/js/one-click-assign.js
+++ b/assets/js/one-click-assign.js
@@ -4,6 +4,11 @@ jQuery(function($){
     var fieldsSel = $('#gm2-oca-fields');
     var msg = $('#gm2-one-click-message');
     var results = $('#gm2-branch-results');
+    var progress = $('#gm2-oca-progress');
+    var list = $('#gm2-oca-list');
+    var overwriteRadios = $('input[name="gm2_oca_overwrite"]');
+    var resetBtn = $('#gm2-oca-reset');
+    var resetProgress = $('#gm2-oca-reset-progress');
     if(!btn.length) return;
 
     function loadBranches(){
@@ -43,22 +48,87 @@ jQuery(function($){
         });
     });
 
-    assignBtn.on('click', function(e){
-        e.preventDefault();
-        msg.text(gm2OneClickAssign.assigning);
-        var fields = fieldsSel.val() || [];
+    function append(items){
+        items.forEach(function(item){
+            var cats = item.cats.join(', ');
+            list.append('<li>'+ item.sku +' - '+ item.title +' => '+ cats +'</li>');
+        });
+    }
+
+    function step(offset, overwrite, fields){
         $.post(ajaxurl, {
             action: 'gm2_one_click_assign_categories',
             nonce: gm2OneClickAssign.nonce,
+            offset: offset,
+            overwrite: overwrite ? 1 : 0,
             fields: fields
         }).done(function(resp){
-            if(resp.success){
-                msg.text(gm2OneClickAssign.assignDone);
-            }else{
+            if(!resp.success){
+                progress.hide();
                 msg.text(resp.data || gm2OneClickAssign.error);
+                return;
+            }
+            var d = resp.data;
+            append(d.items);
+            if(d.total){
+                var pct = Math.min(100, Math.round(d.offset / d.total * 100));
+                progress.val(pct).show();
+            }
+            if(!d.done){
+                step(d.offset, overwrite, fields);
+            }else{
+                progress.val(100);
+                msg.text(gm2OneClickAssign.assignDone);
             }
         }).fail(function(){
+            progress.hide();
             msg.text(gm2OneClickAssign.error);
         });
+    }
+
+    assignBtn.on('click', function(e){
+        e.preventDefault();
+        msg.text(gm2OneClickAssign.assigning);
+        list.empty();
+        progress.val(0).show();
+        var fields = fieldsSel.val() || [];
+        var overwrite = overwriteRadios.filter(':checked').val() === '1';
+        step(0, overwrite, fields);
+    });
+
+    function resetStep(offset, reset){
+        $.post(ajaxurl, {
+            action: 'gm2_reset_product_categories',
+            nonce: gm2OneClickAssign.nonce,
+            offset: offset,
+            reset: reset ? 1 : 0
+        }).done(function(resp){
+            if(!resp.success){
+                resetProgress.hide();
+                msg.text(gm2OneClickAssign.error);
+                return;
+            }
+            if(resp.data.total){
+                var percent = Math.round((resp.data.offset/resp.data.total)*100);
+                resetProgress.val(percent).show();
+            }
+            if(!resp.data.done){
+                resetStep(resp.data.offset, false);
+            }else{
+                resetProgress.hide();
+                msg.text(gm2OneClickAssign.resetDone);
+            }
+        }).fail(function(){
+            resetProgress.hide();
+            msg.text(gm2OneClickAssign.error);
+        });
+    }
+
+    resetBtn.on('click', function(e){
+        e.preventDefault();
+        msg.text('');
+        list.empty();
+        resetProgress.val(0).show();
+        resetStep(0, true);
     });
 });


### PR DESCRIPTION
## Summary
- add add/overwrite option, progress and reset button
- implement AJAX assignment batching and product list

## Testing
- `composer install`
- `composer test` *(fails: ProductCategoryGeneratorTest::test_wheel_size_respects_branch_rules)*

------
https://chatgpt.com/codex/tasks/task_e_68522bb7476c8327b454d5da7a4ed7de