### PR TITLE
Enhance one-click category assignment

### DIFF
--- a/assets/js/one-click-assign.js
+++ b/assets/js/one-click-assign.js
@@ -4,6 +4,11 @@ jQuery(function($){
     var fieldsSel = $('#gm2-oca-fields');
     var msg = $('#gm2-one-click-message');
     var results = $('#gm2-branch-results');
+    var progress = $('#gm2-oca-progress');
+    var list = $('#gm2-oca-list');
+    var overwriteRadios = $('input[name="gm2_oca_overwrite"]');
+    var resetBtn = $('#gm2-oca-reset');
+    var resetProgress = $('#gm2-oca-reset-progress');
     if(!btn.length) return;
 
     function loadBranches(){
@@ -43,22 +48,87 @@ jQuery(function($){
         });
     });
 
-    assignBtn.on('click', function(e){
-        e.preventDefault();
-        msg.text(gm2OneClickAssign.assigning);
-        var fields = fieldsSel.val() || [];
+    function append(items){
+        items.forEach(function(item){
+            var cats = item.cats.join(', ');
+            list.append('<li>'+ item.sku +' - '+ item.title +' => '+ cats +'</li>');
+        });
+    }
+
+    function step(offset, overwrite, fields){
         $.post(ajaxurl, {
             action: 'gm2_one_click_assign_categories',
             nonce: gm2OneClickAssign.nonce,
+            offset: offset,
+            overwrite: overwrite ? 1 : 0,
             fields: fields
         }).done(function(resp){
-            if(resp.success){
-                msg.text(gm2OneClickAssign.assignDone);
-            }else{
+            if(!resp.success){
+                progress.hide();
                 msg.text(resp.data || gm2OneClickAssign.error);
+                return;
+            }
+            var d = resp.data;
+            append(d.items);
+            if(d.total){
+                var pct = Math.min(100, Math.round(d.offset / d.total * 100));
+                progress.val(pct).show();
+            }
+            if(!d.done){
+                step(d.offset, overwrite, fields);
+            }else{
+                progress.val(100);
+                msg.text(gm2OneClickAssign.assignDone);
             }
         }).fail(function(){
+            progress.hide();
             msg.text(gm2OneClickAssign.error);
         });
+    }
+
+    assignBtn.on('click', function(e){
+        e.preventDefault();
+        msg.text(gm2OneClickAssign.assigning);
+        list.empty();
+        progress.val(0).show();
+        var fields = fieldsSel.val() || [];
+        var overwrite = overwriteRadios.filter(':checked').val() === '1';
+        step(0, overwrite, fields);
+    });
+
+    function resetStep(offset, reset){
+        $.post(ajaxurl, {
+            action: 'gm2_reset_product_categories',
+            nonce: gm2OneClickAssign.nonce,
+            offset: offset,
+            reset: reset ? 1 : 0
+        }).done(function(resp){
+            if(!resp.success){
+                resetProgress.hide();
+                msg.text(gm2OneClickAssign.error);
+                return;
+            }
+            if(resp.data.total){
+                var percent = Math.round((resp.data.offset/resp.data.total)*100);
+                resetProgress.val(percent).show();
+            }
+            if(!resp.data.done){
+                resetStep(resp.data.offset, false);
+            }else{
+                resetProgress.hide();
+                msg.text(gm2OneClickAssign.resetDone);
+            }
+        }).fail(function(){
+            resetProgress.hide();
+            msg.text(gm2OneClickAssign.error);
+        });
+    }
+
+    resetBtn.on('click', function(e){
+        e.preventDefault();
+        msg.text('');
+        list.empty();
+        resetProgress.val(0).show();
+        resetStep(0, true);
     });
 });

--- a/includes/class-auto-assign.php
+++ b/includes/class-auto-assign.php
@@ -440,6 +440,7 @@ class Gm2_Category_Sort_Auto_Assign {
             $progress = [ 'offset' => 0 ];
             delete_option( 'gm2_auto_assign_progress' );
             delete_option( 'gm2_auto_assign_log' );
+            delete_option( 'gm2_one_click_log' );
             wp_defer_term_counting( true );
         }
 
@@ -476,6 +477,7 @@ class Gm2_Category_Sort_Auto_Assign {
             delete_option( 'gm2_reset_progress' );
             delete_option( 'gm2_auto_assign_progress' );
             delete_option( 'gm2_auto_assign_log' );
+            delete_option( 'gm2_one_click_log' );
             wp_defer_term_counting( false );
         } else {
             update_option( 'gm2_reset_progress', [ 'offset' => $new_offset ] );

--- a/includes/class-one-click-assign.php
+++ b/includes/class-one-click-assign.php
@@ -57,6 +57,7 @@ class Gm2_Category_Sort_One_Click_Assign {
                 'loadingBranches' => __( 'Loading categories...', 'gm2-category-sort' ),
                 'assigning'       => __( 'Assigning categories...', 'gm2-category-sort' ),
                 'assignDone'      => __( 'Category assignment complete.', 'gm2-category-sort' ),
+                'resetDone'       => __( 'All categories reset.', 'gm2-category-sort' ),
                 'error'           => __( 'Error generating files.', 'gm2-category-sort' ),
             ]
         );
@@ -66,6 +67,10 @@ class Gm2_Category_Sort_One_Click_Assign {
      * Render the admin page.
      */
     public static function admin_page() {
+        $log = get_option( 'gm2_one_click_log', [] );
+        if ( ! is_array( $log ) ) {
+            $log = [];
+        }
         ?>
         <div class="wrap">
             <h1><?php esc_html_e( 'One Click Categories Assignment', 'gm2-category-sort' ); ?></h1>
@@ -84,8 +89,31 @@ class Gm2_Category_Sort_One_Click_Assign {
                     <?php esc_html_e( 'Assign Categories', 'gm2-category-sort' ); ?>
                 </button>
             </p>
+            <p>
+                <label>
+                    <input type="radio" name="gm2_oca_overwrite" value="0" checked>
+                    <?php esc_html_e( 'Add to existing categories', 'gm2-category-sort' ); ?>
+                </label>
+                &nbsp;
+                <label>
+                    <input type="radio" name="gm2_oca_overwrite" value="1">
+                    <?php esc_html_e( 'Overwrite existing categories', 'gm2-category-sort' ); ?>
+                </label>
+            </p>
+            <p>
+                <button id="gm2-oca-reset" class="button">
+                    <?php esc_html_e( 'Reset All Categories', 'gm2-category-sort' ); ?>
+                </button>
+            </p>
+            <p><progress id="gm2-oca-progress" value="0" max="100" style="display:none;width:100%;"></progress></p>
+            <p><progress id="gm2-oca-reset-progress" value="0" max="100" style="display:none;width:100%;"></progress></p>
             <div id="gm2-one-click-message"></div>
             <div id="gm2-branch-results" style="margin-top:15px;"></div>
+            <ul id="gm2-oca-list" style="background:#fff;border:1px solid #ccc;padding:5px;max-height:300px;overflow:auto;">
+                <?php foreach ( $log as $line ) : ?>
+                    <li><?php echo esc_html( $line ); ?></li>
+                <?php endforeach; ?>
+            </ul>
         </div>
         <?php
     }
@@ -191,17 +219,32 @@ class Gm2_Category_Sort_One_Click_Assign {
             $fields = [ 'title' ];
         }
 
+        $overwrite = ! empty( $_POST['overwrite'] );
+        $offset    = isset( $_POST['offset'] ) ? max( 0, (int) $_POST['offset'] ) : 0;
+        $limit     = 50;
+
         $mapping = self::build_mapping();
+
+        $total_query = wp_count_posts( 'product' )->publish;
 
         $query = new WP_Query(
             [
                 'post_type'      => 'product',
                 'post_status'    => 'publish',
                 'fields'         => 'ids',
-                'posts_per_page' => -1,
+                'posts_per_page' => $limit,
+                'offset'         => $offset,
+                'orderby'        => 'ID',
+                'order'          => 'ASC',
             ]
         );
 
+        $items = [];
+        $log   = get_option( 'gm2_one_click_log', [] );
+        if ( $offset === 0 ) {
+            $log = [];
+        }
+        $log = (array) $log;
         foreach ( $query->posts as $product_id ) {
             $product = wc_get_product( $product_id );
             if ( ! $product ) {
@@ -226,7 +269,7 @@ class Gm2_Category_Sort_One_Click_Assign {
                 }
             }
 
-            $cats = Gm2_Category_Sort_Product_Category_Generator::assign_categories( $text, $mapping );
+            $cats     = Gm2_Category_Sort_Product_Category_Generator::assign_categories( $text, $mapping );
             $term_ids = [];
             foreach ( $cats as $name ) {
                 $term = get_term_by( 'name', $name, 'product_cat' );
@@ -235,11 +278,30 @@ class Gm2_Category_Sort_One_Click_Assign {
                 }
             }
             if ( $term_ids ) {
-                wp_set_object_terms( $product_id, $term_ids, 'product_cat', true );
+                wp_set_object_terms( $product_id, $term_ids, 'product_cat', ! $overwrite );
             }
+
+            $items[] = [
+                'sku'   => $product->get_sku(),
+                'title' => $product->get_name(),
+                'cats'  => array_values( $cats ),
+            ];
+            $log[] = $product->get_sku() . ' - ' . $product->get_name() . ' => ' . implode( ', ', $cats );
         }
 
-        wp_send_json_success();
+        $new_offset = $offset + count( $query->posts );
+        $done       = $new_offset >= $total_query || empty( $query->posts );
+
+        update_option( 'gm2_one_click_log', $log );
+
+        wp_send_json_success(
+            [
+                'offset' => $new_offset,
+                'total'  => (int) $total_query,
+                'done'   => $done,
+                'items'  => $items,
+            ]
+        );
     }
 
     /**

--- a/includes/class-product-category-generator.php
+++ b/includes/class-product-category-generator.php
@@ -954,11 +954,15 @@ class Gm2_Category_Sort_Product_Category_Generator {
             return true;
         }
         for ( $i = 0; $i < count( $path ) - 1; $i++ ) {
-            $slug = self::slugify_segment( $path[ $i ] ) . '-' . self::slugify_segment( $path[ $i + 1 ] );
-            if ( ! isset( $rules[ $slug ] ) ) {
+            $slug        = self::slugify_segment( $path[ $i ] ) . '-' . self::slugify_segment( $path[ $i + 1 ] );
+            $legacy_slug = sanitize_title( $path[ $i ] ) . '-' . sanitize_title( $path[ $i + 1 ] );
+            if ( isset( $rules[ $slug ] ) ) {
+                $rule = $rules[ $slug ];
+            } elseif ( isset( $rules[ $legacy_slug ] ) ) {
+                $rule = $rules[ $legacy_slug ];
+            } else {
                 continue;
             }
-            $rule     = $rules[ $slug ];
             $includes = array_filter( array_map( 'trim', explode( ',', $rule['include'] ?? '' ) ) );
             $excludes = array_filter( array_map( 'trim', explode( ',', $rule['exclude'] ?? '' ) ) );
             if ( $includes ) {
@@ -995,7 +999,12 @@ class Gm2_Category_Sort_Product_Category_Generator {
         $dir    = trailingslashit( $upload['basedir'] ) . 'gm2-category-sort/categories-structure';
         $file   = rtrim( $dir, '/' ) . '/' . sanitize_key( $slug ) . '.csv';
         if ( ! file_exists( $file ) ) {
-            return [];
+            $legacy = rtrim( $dir, '/' ) . '/' . sanitize_key( sanitize_title( $slug ) ) . '.csv';
+            if ( file_exists( $legacy ) ) {
+                $file = $legacy;
+            } else {
+                return [];
+            }
         }
         $rows = array_map( 'str_getcsv', file( $file ) );
         if ( empty( $rows ) ) {


### PR DESCRIPTION
## Summary
- keep one-click assignment results across page loads
- wipe one-click log when resetting all products
- ensure branch rules work with legacy slugs

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68522bb7476c8327b454d5da7a4ed7de