### PR TITLE
Handle HTML entities in category matching

### DIFF
--- a/includes/class-product-category-generator.php
+++ b/includes/class-product-category-generator.php
@@ -39,6 +39,7 @@ class Gm2_Category_Sort_Product_Category_Generator {
      * @return string Normalized text.
      */
     public static function normalize_text( $text ) {
+        $text = html_entity_decode( $text, ENT_QUOTES | ENT_HTML5 );
         $text = strtr( $text, [
             '′' => "'",
             '″' => '"',
@@ -739,14 +740,15 @@ class Gm2_Category_Sort_Product_Category_Generator {
      * @return array List of category names.
      */
     public static function assign_categories( $text, array $mapping, $fuzzy = false, $threshold = 85, $csv_dir = null ) {
-        $lower = self::normalize_text( $text );
+        $decoded = html_entity_decode( $text, ENT_QUOTES | ENT_HTML5 );
+        $lower   = self::normalize_text( $decoded );
         $cats  = [];
         $words          = preg_split( '/\s+/', $lower );
         $wheel_size_num = null;
         $wheel_size     = null;
         if ( preg_match(
             '/(?<![\d.])(\d{1,2}(?:\.\d+)?)(["\'\x{201C}\x{201D}\x{2019}\x{2032}\x{2033}])(?:[xX])?/u',
-            $text,
+            $decoded,
             $m
         ) ) {
             $wheel_size_num = $m[1];
@@ -809,7 +811,7 @@ class Gm2_Category_Sort_Product_Category_Generator {
             }
         }
 
-        if ( ! $wheel_size_num && $brand_found && preg_match('/(?<![\\d.])(\\d{1,2}(?:\\.\\d+)?)(?=\\s)/u', $text, $m) ) {
+        if ( ! $wheel_size_num && $brand_found && preg_match('/(?<![\\d.])(\\d{1,2}(?:\\.\\d+)?)(?=\\s)/u', $decoded, $m) ) {
             $wheel_size_num = $m[1];
             $wheel_size     = $wheel_size_num . '"';
         }

--- a/tests/ProductCategoryGeneratorTest.php
+++ b/tests/ProductCategoryGeneratorTest.php
@@ -301,6 +301,19 @@ class ProductCategoryGeneratorTest extends TestCase {
         $this->assertContains( '19.5"', $cats );
     }
 
+    public function test_wheel_size_prefix_html_entity() {
+        $root = wp_insert_term( 'By Wheel Size', 'product_cat' );
+        wp_insert_term( '19.5"', 'product_cat', [ 'parent' => $root['term_id'] ] );
+
+        $mapping = Gm2_Category_Sort_Product_Category_Generator::build_mapping_from_globals();
+        $text    = '19.5&quot; wheel simulator';
+
+        $cats = Gm2_Category_Sort_Product_Category_Generator::assign_categories( $text, $mapping );
+
+        $this->assertContains( 'By Wheel Size', $cats );
+        $this->assertContains( '19.5"', $cats );
+    }
+
     public function test_wheel_size_without_brand_word() {
         $root = wp_insert_term( 'By Wheel Size', 'product_cat' );
         wp_insert_term( "19'", 'product_cat', [ 'parent' => $root['term_id'] ] );


### PR DESCRIPTION
## Summary
- decode HTML entities during text normalization
- ensure assign_categories decodes before applying regex
- test wheel size detection with HTML entity

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68534c49a27c832791bd00bb6d99eca1