### PR TITLE
Prefer lug number match in check_lug_hole

### DIFF
--- a/includes/class-product-category-generator.php
+++ b/includes/class-product-category-generator.php
@@ -613,7 +613,21 @@ class Gm2_Category_Sort_Product_Category_Generator {
         if ( ! $candidates ) {
             return [];
         }
-        uksort( $candidates, static function ( $a, $b ) {
+        $lug_num = null;
+        if ( preg_match( '/\b(\d+)\s*lugs?\b/', $lower, $m ) ) {
+            $lug_num = $m[1];
+        }
+        uksort( $candidates, static function ( $a, $b ) use ( $lug_num ) {
+            if ( $lug_num !== null ) {
+                $a_has = strpos( $a, $lug_num ) !== false;
+                $b_has = strpos( $b, $lug_num ) !== false;
+                if ( $a_has && ! $b_has ) {
+                    return -1;
+                }
+                if ( $b_has && ! $a_has ) {
+                    return 1;
+                }
+            }
             return strlen( $b ) <=> strlen( $a );
         } );
         $path = reset( $candidates );

--- a/tests/ProductCategoryGeneratorTest.php
+++ b/tests/ProductCategoryGeneratorTest.php
@@ -663,6 +663,21 @@ class ProductCategoryGeneratorTest extends TestCase {
         $this->assertSame( [ 'By Lug/Hole Configuration', '10 Lug 4 Hole' ], $cats );
     }
 
+    public function test_lug_number_preferred_over_synonyms() {
+        $root = wp_insert_term( 'By Lug/Hole Configuration', 'product_cat' );
+        $six  = wp_insert_term( '6 Lug', 'product_cat', [ 'parent' => $root['term_id'] ] );
+        $five = wp_insert_term( '5 Lug', 'product_cat', [ 'parent' => $root['term_id'] ] );
+        update_term_meta( $six['term_id'], 'gm2_synonyms', 'Trailer' );
+        update_term_meta( $five['term_id'], 'gm2_synonyms', 'Trailer' );
+
+        $mapping = Gm2_Category_Sort_Product_Category_Generator::build_mapping_from_globals();
+        $text    = 'Heavy duty trailer for 5 lug wheels';
+
+        $cats = Gm2_Category_Sort_Product_Category_Generator::assign_categories( $text, $mapping );
+
+        $this->assertSame( [ 'By Lug/Hole Configuration', '5 Lug' ], $cats );
+    }
+
     public function test_wheel_size_respects_branch_rules() {
         $root = wp_insert_term( 'By Wheel Size', 'product_cat' );
         wp_insert_term( '19.5"', 'product_cat', [ 'parent' => $root['term_id'] ] );


### PR DESCRIPTION
## Summary
- account for lug number when sorting lug/hole candidates
- ensure we pick `5 Lug` when description contains "5 lug" even if another lug category has the same synonyms

## Testing
- `./vendor/bin/phpunit -v`

------
https://chatgpt.com/codex/tasks/task_e_68537ea5bb548327b31f0862230708b0