### PR TITLE
Allow multiple category paths per mapping term

### DIFF
--- a/includes/class-auto-assign.php
+++ b/includes/class-auto-assign.php
@@ -230,7 +230,17 @@ class Gm2_Category_Sort_Auto_Assign {
                 foreach ( $variants as $v ) {
                     $key = Gm2_Category_Sort_Product_Category_Generator::normalize_text( $v );
                     if ( ! isset( $mapping[ $key ] ) ) {
-                        $mapping[ $key ] = $path;
+                        $mapping[ $key ] = [];
+                    }
+                    $exists = false;
+                    foreach ( $mapping[ $key ] as $existing ) {
+                        if ( $existing === $path ) {
+                            $exists = true;
+                            break;
+                        }
+                    }
+                    if ( ! $exists ) {
+                        $mapping[ $key ][] = $path;
                     }
                 }
             }

--- a/includes/class-one-click-assign.php
+++ b/includes/class-one-click-assign.php
@@ -362,7 +362,17 @@ class Gm2_Category_Sort_One_Click_Assign {
                 foreach ( $variants as $v ) {
                     $key = Gm2_Category_Sort_Product_Category_Generator::normalize_text( $v );
                     if ( ! isset( $mapping[ $key ] ) ) {
-                        $mapping[ $key ] = $path;
+                        $mapping[ $key ] = [];
+                    }
+                    $exists = false;
+                    foreach ( $mapping[ $key ] as $existing ) {
+                        if ( $existing === $path ) {
+                            $exists = true;
+                            break;
+                        }
+                    }
+                    if ( ! $exists ) {
+                        $mapping[ $key ][] = $path;
                     }
                 }
             }

--- a/tests/ProductCategoryGeneratorTest.php
+++ b/tests/ProductCategoryGeneratorTest.php
@@ -76,6 +76,24 @@ class ProductCategoryGeneratorTest extends TestCase {
         $this->assertSame( [ 'Parent' ], $cats );
     }
 
+    public function test_overlapping_synonyms_assign_all_categories() {
+        $a = wp_insert_term( 'CatA', 'product_cat' );
+        $b = wp_insert_term( 'CatB', 'product_cat' );
+        update_term_meta( $a['term_id'], 'gm2_synonyms', 'Common' );
+        update_term_meta( $b['term_id'], 'gm2_synonyms', 'Common' );
+
+        $mapping = Gm2_Category_Sort_Product_Category_Generator::build_mapping_from_globals();
+        $key     = Gm2_Category_Sort_Product_Category_Generator::normalize_text( 'Common' );
+
+        $this->assertArrayHasKey( $key, $mapping );
+        $this->assertCount( 2, $mapping[ $key ] );
+
+        $cats = Gm2_Category_Sort_Product_Category_Generator::assign_categories( 'Great common item', $mapping );
+
+        $this->assertContains( 'CatA', $cats );
+        $this->assertContains( 'CatB', $cats );
+    }
+
     public function test_ignores_negative_phrases() {
         $this->create_categories();
 


### PR DESCRIPTION
## Summary
- support multiple category paths per mapping term
- update helpers to iterate over path lists
- adjust lug/hole detection and wheel size checks
- extend generator tests for overlapping synonyms

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68537fdc44a08327b2e7b2ba5930bbb7