### PR TITLE
Add product CSV export and import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Branch-rule keywords are evaluated for each matched category path.
 - Branch CSV files are now generated for leaf categories so branch rules work for every category.
 - Branch rule slugs now include the full category path so rules apply to deep branches.
+- Export and import WooCommerce products via CSV including assigned categories.
 
 ## [1.0.15] - 2025-06-15
 ### Added

--- a/README.md
+++ b/README.md
@@ -104,6 +104,18 @@ When uploading through the admin screen a progress bar shows the import status
 so large files can be processed incrementally. Each request handles about 50
 rows. For huge imports consider WP‑CLI which displays a terminal progress bar.
 
+## Product CSV Export & Import
+
+All WooCommerce product data can be exported to a CSV file along with any
+assigned categories. Visit **Tools → Export Products** to download the file or
+run `wp gm2-category-sort export-products <path>` from WP‑CLI. The CSV matches
+WooCommerce's built‑in format so it can be re‑imported later.
+
+To import product information, open **Tools → Import Products** and upload a
+CSV created by the exporter (or run `wp gm2-category-sort import-products <file>`
+from WP‑CLI). Existing products are updated when their IDs or SKUs match.
+An example export is provided at `assets/example-products.csv`.
+
 ### Generate Category Assignments from Research CSV
 
 The `scripts/generate_product_categories.py` helper reads

--- a/assets/example-products.csv
+++ b/assets/example-products.csv
@@ -1,0 +1,2 @@
+ID,Name,SKU,Description,Regular price,Sale price,Categories
+1,Sample Product,SAMPLE,This is a sample,9.99,7.99,"Category 1|Category 2"

--- a/gm2-category-sort.php
+++ b/gm2-category-sort.php
@@ -58,6 +58,7 @@ function gm2_category_sort_init() {
     require_once GM2_CAT_SORT_PATH . 'includes/class-category-importer.php';
     require_once GM2_CAT_SORT_PATH . 'includes/class-product-category-generator.php';
     require_once GM2_CAT_SORT_PATH . 'includes/class-product-category-importer.php';
+    require_once GM2_CAT_SORT_PATH . 'includes/class-product-csv.php';
     require_once GM2_CAT_SORT_PATH . 'includes/class-attribute-fixer.php';
     require_once GM2_CAT_SORT_PATH . 'includes/class-auto-assign.php';
     require_once GM2_CAT_SORT_PATH . 'includes/class-one-click-assign.php';
@@ -76,6 +77,7 @@ function gm2_category_sort_init() {
     Gm2_Category_Sort_Auto_Assign::init();
     Gm2_Category_Sort_One_Click_Assign::init();
     Gm2_Category_Sort_Branch_Rules::init();
+    Gm2_Category_Sort_Product_CSV::init();
     
     add_filter('pre_get_document_title', 'gm2_category_sort_modify_title');
     add_action('wp_head', 'gm2_category_sort_meta_description');

--- a/includes/class-product-csv.php
+++ b/includes/class-product-csv.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * Export and import WooCommerce products via CSV.
+ */
+class Gm2_Category_Sort_Product_CSV {
+
+    /**
+     * Register hooks.
+     */
+    public static function init() {
+        self::register_cli();
+        add_action( 'admin_menu', [ __CLASS__, 'register_admin_pages' ] );
+    }
+
+    /**
+     * Register WP-CLI commands.
+     */
+    public static function register_cli() {
+        if ( defined( 'WP_CLI' ) && WP_CLI ) {
+            \WP_CLI::add_command( 'gm2-category-sort export-products', [ __CLASS__, 'cli_export' ] );
+            \WP_CLI::add_command( 'gm2-category-sort import-products', [ __CLASS__, 'cli_import' ] );
+        }
+    }
+
+    /**
+     * Add pages under Tools.
+     */
+    public static function register_admin_pages() {
+        add_management_page(
+            __( 'Export Products', 'gm2-category-sort' ),
+            __( 'Export Products', 'gm2-category-sort' ),
+            'manage_options',
+            'gm2-product-export',
+            [ __CLASS__, 'export_page' ]
+        );
+        add_management_page(
+            __( 'Import Products', 'gm2-category-sort' ),
+            __( 'Import Products', 'gm2-category-sort' ),
+            'manage_options',
+            'gm2-product-import',
+            [ __CLASS__, 'import_page' ]
+        );
+    }
+
+    /**
+     * Render export page.
+     */
+    public static function export_page() {
+        if ( isset( $_POST['gm2_export_nonce'] ) ) {
+            check_admin_referer( 'gm2_export_products', 'gm2_export_nonce' );
+            $file   = wp_tempnam( 'products.csv' );
+            $result = self::export_to_csv( $file );
+            if ( is_wp_error( $result ) ) {
+                echo '<div class="notice notice-error"><p>' . esc_html( $result->get_error_message() ) . '</p></div>';
+            } else {
+                header( 'Content-Type: text/csv' );
+                header( 'Content-Disposition: attachment; filename="products.csv"' );
+                readfile( $file );
+                unlink( $file );
+                exit;
+            }
+        }
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e( 'Export Products', 'gm2-category-sort' ); ?></h1>
+            <form method="post">
+                <?php wp_nonce_field( 'gm2_export_products', 'gm2_export_nonce' ); ?>
+                <?php submit_button( __( 'Download CSV', 'gm2-category-sort' ) ); ?>
+            </form>
+        </div>
+        <?php
+    }
+
+    /**
+     * Render import page.
+     */
+    public static function import_page() {
+        $message = '';
+        $error   = '';
+        if ( isset( $_POST['gm2_import_nonce'] ) ) {
+            check_admin_referer( 'gm2_import_products', 'gm2_import_nonce' );
+            if ( ! empty( $_FILES['gm2_import_file']['tmp_name'] ) ) {
+                $file   = $_FILES['gm2_import_file']['tmp_name'];
+                $result = self::import_from_csv( $file );
+                if ( is_wp_error( $result ) ) {
+                    $error = $result->get_error_message();
+                } else {
+                    $message = __( 'Products imported successfully.', 'gm2-category-sort' );
+                }
+            } else {
+                $error = __( 'Please select a CSV file.', 'gm2-category-sort' );
+            }
+        }
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e( 'Import Products', 'gm2-category-sort' ); ?></h1>
+            <?php if ( $message ) : ?>
+                <div class="notice notice-success"><p><?php echo esc_html( $message ); ?></p></div>
+            <?php elseif ( $error ) : ?>
+                <div class="notice notice-error"><p><?php echo esc_html( $error ); ?></p></div>
+            <?php endif; ?>
+            <form method="post" enctype="multipart/form-data">
+                <?php wp_nonce_field( 'gm2_import_products', 'gm2_import_nonce' ); ?>
+                <input type="file" name="gm2_import_file" accept=".csv">
+                <?php submit_button( __( 'Import', 'gm2-category-sort' ) ); ?>
+            </form>
+        </div>
+        <?php
+    }
+
+    /**
+     * WP-CLI export handler.
+     *
+     * @param array $args Command args.
+     */
+    public static function cli_export( $args ) {
+        $file = $args[0] ?? '';
+        if ( ! $file ) {
+            \WP_CLI::error( 'Please provide a CSV file path.' );
+        }
+        $result = self::export_to_csv( $file );
+        if ( is_wp_error( $result ) ) {
+            \WP_CLI::error( $result->get_error_message() );
+        }
+        \WP_CLI::success( 'Products exported successfully.' );
+    }
+
+    /**
+     * WP-CLI import handler.
+     *
+     * @param array $args Command args.
+     */
+    public static function cli_import( $args ) {
+        $file = $args[0] ?? '';
+        if ( ! $file ) {
+            \WP_CLI::error( 'Please provide a CSV file path.' );
+        }
+        $result = self::import_from_csv( $file );
+        if ( is_wp_error( $result ) ) {
+            \WP_CLI::error( $result->get_error_message() );
+        }
+        \WP_CLI::success( 'Products imported successfully.' );
+    }
+
+    /**
+     * Export products to a CSV file.
+     *
+     * @param string $file Destination path.
+     * @return true|WP_Error
+     */
+    public static function export_to_csv( $file ) {
+        if ( ! class_exists( 'WC_Product_CSV_Exporter' ) ) {
+            return new WP_Error( 'gm2_missing_wc', __( 'WooCommerce not installed.', 'gm2-category-sort' ) );
+        }
+
+        include_once WC_ABSPATH . 'includes/export/class-wc-product-csv-exporter.php';
+
+        $exporter = new WC_Product_CSV_Exporter();
+        $exporter->set_columns_to_export( array_keys( $exporter->get_default_column_names() ) );
+        $exporter->set_filename( basename( $file ) );
+        $exporter->generate_file();
+
+        $source = $exporter->get_file_path();
+        if ( ! @copy( $source, $file ) ) { // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+            return new WP_Error( 'gm2_copy_failed', __( 'Unable to copy export file.', 'gm2-category-sort' ) );
+        }
+        return true;
+    }
+
+    /**
+     * Import products from a CSV file.
+     *
+     * @param string $file CSV path.
+     * @return true|WP_Error
+     */
+    public static function import_from_csv( $file ) {
+        if ( ! class_exists( 'WC_Product_CSV_Importer' ) ) {
+            return new WP_Error( 'gm2_missing_wc', __( 'WooCommerce not installed.', 'gm2-category-sort' ) );
+        }
+
+        include_once WC_ABSPATH . 'includes/import/class-wc-product-csv-importer.php';
+
+        $importer = new WC_Product_CSV_Importer( $file, [ 'update_existing' => true ] );
+        $importer->import();
+
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
- allow exporting WooCommerce products with categories to a CSV
- allow importing products from a CSV
- document new product CSV commands
- provide example products CSV

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6854379b3f7c8327a5d64559ec7847ab