### PR TITLE
Fix export cleanup

### DIFF
--- a/includes/class-product-csv.php
+++ b/includes/class-product-csv.php
@@ -173,6 +173,8 @@ class Gm2_Category_Sort_Product_CSV {
         if ( ! @copy( $source, $file ) ) { // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
             return new WP_Error( 'gm2_copy_failed', __( 'Unable to copy export file.', 'gm2-category-sort' ) );
         }
+
+        @unlink( $source ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
         return true;
     }
 


### PR DESCRIPTION
## Summary
- ensure product exports don't clutter uploads directory

## Testing
- `vendor/bin/phpunit` *(fails: `/usr/bin/env: ‘php’: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68545078a7e883279ffa8083569e9465