### PR TITLE
Add attribute arrays to branch rules

### DIFF
--- a/includes/class-branch-rules.php
+++ b/includes/class-branch-rules.php
@@ -103,13 +103,34 @@ class Gm2_Category_Sort_Branch_Rules {
             wp_send_json_error( 'unauthorized' );
         }
         check_ajax_referer( 'gm2_branch_rules', 'nonce' );
-        $data = isset( $_POST['rules'] ) && is_array( $_POST['rules'] ) ? wp_unslash( $_POST['rules'] ) : [];
+        $data  = isset( $_POST['rules'] ) && is_array( $_POST['rules'] ) ? wp_unslash( $_POST['rules'] ) : [];
         $rules = [];
         foreach ( $data as $slug => $rule ) {
-            $slug          = sanitize_key( $slug );
+            $slug    = sanitize_key( $slug );
+            $include = sanitize_textarea_field( $rule['include'] ?? '' );
+            $exclude = sanitize_textarea_field( $rule['exclude'] ?? '' );
+
+            $include_attrs = [];
+            if ( isset( $rule['include_attrs'] ) && is_array( $rule['include_attrs'] ) ) {
+                foreach ( $rule['include_attrs'] as $attr => $terms ) {
+                    $attr               = sanitize_key( $attr );
+                    $include_attrs[$attr] = array_map( 'sanitize_key', (array) $terms );
+                }
+            }
+
+            $exclude_attrs = [];
+            if ( isset( $rule['exclude_attrs'] ) && is_array( $rule['exclude_attrs'] ) ) {
+                foreach ( $rule['exclude_attrs'] as $attr => $terms ) {
+                    $attr               = sanitize_key( $attr );
+                    $exclude_attrs[$attr] = array_map( 'sanitize_key', (array) $terms );
+                }
+            }
+
             $rules[ $slug ] = [
-                'include' => sanitize_textarea_field( $rule['include'] ?? '' ),
-                'exclude' => sanitize_textarea_field( $rule['exclude'] ?? '' ),
+                'include'       => $include,
+                'exclude'       => $exclude,
+                'include_attrs' => $include_attrs,
+                'exclude_attrs' => $exclude_attrs,
             ];
         }
         update_option( 'gm2_branch_rules', $rules );

--- a/tests/BranchRulesTest.php
+++ b/tests/BranchRulesTest.php
@@ -54,4 +54,22 @@ class BranchRulesTest extends TestCase {
         $this->assertSame( '19"', $saved['branch-leaf']['include'] );
         $this->assertSame( "19'", $saved['branch-leaf']['exclude'] );
     }
+
+    public function test_ajax_save_rules_stores_attr_arrays() {
+        $_POST['nonce'] = 't';
+        $_POST['rules'] = [
+            'branch-leaf' => [
+                'include'       => '',
+                'exclude'       => '',
+                'include_attrs' => [ 'pa_Color' => [ 'Red', 'Blue' ] ],
+                'exclude_attrs' => [ 'pa_Size' => [ 'Large' ] ],
+            ],
+        ];
+
+        Gm2_Category_Sort_Branch_Rules::ajax_save_rules();
+        $saved = get_option( 'gm2_branch_rules' );
+
+        $this->assertSame( [ 'pa_Color' => [ 'Red', 'Blue' ] ], $saved['branch-leaf']['include_attrs'] );
+        $this->assertSame( [ 'pa_Size' => [ 'Large' ] ], $saved['branch-leaf']['exclude_attrs'] );
+    }
 }


### PR DESCRIPTION
## Summary
- handle new `include_attrs` and `exclude_attrs` keys when saving branch rules
- test new branch rule data

## Testing
- `./vendor/bin/phpunit -c phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685469dd4298832789d30d2151cd32d5