### PR TITLE
Add attribute controls to branch rules

### DIFF
--- a/assets/js/branch-rules.js
+++ b/assets/js/branch-rules.js
@@ -2,6 +2,34 @@ jQuery(function($){
     var form = $('#gm2-branch-rules-form');
     if(!form.length) return;
     var msg = $('#gm2-branch-rules-msg');
+    var attrs = gm2BranchRules.attributes || {};
+
+    function populate(select){
+        $.each(attrs,function(slug,data){
+            select.append($('<option>').val(slug).text(data.label));
+        });
+    }
+
+    function renderTerms(container,attrList,selected){
+        container.empty();
+        attrList.forEach(function(attr){
+            var info=attrs[attr];
+            if(!info) return;
+            var sel=$('<select multiple>').attr('data-attr',attr);
+            $.each(info.terms,function(slug,name){
+                var opt=$('<option>').val(slug).text(name);
+                if(selected && selected[attr] && selected[attr].indexOf(slug)!==-1){
+                    opt.prop('selected',true);
+                }
+                sel.append(opt);
+            });
+            container.append(sel);
+        });
+    }
+
+    form.find('.gm2-attr-select').each(function(){
+        populate($(this));
+    });
 
     function load(){
         $.post(ajaxurl,{action:'gm2_branch_rules_get',nonce:gm2BranchRules.nonce})
@@ -9,8 +37,15 @@ jQuery(function($){
             if(resp.success){
                 for(var slug in resp.data){
                     var r=resp.data[slug];
-                    form.find('tr[data-slug="'+slug+'"]').find('textarea[data-type="include"]').val(r.include);
-                    form.find('tr[data-slug="'+slug+'"]').find('textarea[data-type="exclude"]').val(r.exclude);
+                    var row=form.find('tr[data-slug="'+slug+'"]');
+                    row.find('textarea[data-type="include"]').val(r.include);
+                    row.find('textarea[data-type="exclude"]').val(r.exclude);
+                    var incAttrs=Object.keys(r.include_attrs||{});
+                    var excAttrs=Object.keys(r.exclude_attrs||{});
+                    row.find('.gm2-include-attr').val(incAttrs);
+                    row.find('.gm2-exclude-attr').val(excAttrs);
+                    renderTerms(row.find('.gm2-include-terms'),incAttrs,r.include_attrs);
+                    renderTerms(row.find('.gm2-exclude-terms'),excAttrs,r.exclude_attrs);
                 }
             }
         });
@@ -18,14 +53,41 @@ jQuery(function($){
 
     load();
 
+    form.on('change','.gm2-include-attr',function(){
+        var row=$(this).closest('tr');
+        var attrsSel=$(this).val()||[];
+        renderTerms(row.find('.gm2-include-terms'),attrsSel);
+    });
+
+    form.on('change','.gm2-exclude-attr',function(){
+        var row=$(this).closest('tr');
+        var attrsSel=$(this).val()||[];
+        renderTerms(row.find('.gm2-exclude-terms'),attrsSel);
+    });
+
     form.on('submit',function(e){
         e.preventDefault();
         var rules={};
         form.find('tr[data-slug]').each(function(){
-            var slug=$(this).data('slug');
+            var row=$(this);
+            var slug=row.data('slug');
+            var incAttrs={};
+            var excAttrs={};
+            row.find('.gm2-include-terms select').each(function(){
+                var attr=$(this).data('attr');
+                var terms=$(this).val()||[];
+                if(terms.length) incAttrs[attr]=terms;
+            });
+            row.find('.gm2-exclude-terms select').each(function(){
+                var attr=$(this).data('attr');
+                var terms=$(this).val()||[];
+                if(terms.length) excAttrs[attr]=terms;
+            });
             rules[slug]={
-                include:$(this).find('textarea[data-type="include"]').val(),
-                exclude:$(this).find('textarea[data-type="exclude"]').val()
+                include:row.find('textarea[data-type="include"]').val(),
+                exclude:row.find('textarea[data-type="exclude"]').val(),
+                include_attrs:incAttrs,
+                exclude_attrs:excAttrs
             };
         });
         $.post(ajaxurl,{action:'gm2_branch_rules_save',nonce:gm2BranchRules.nonce,rules:rules})

--- a/includes/class-branch-rules.php
+++ b/includes/class-branch-rules.php
@@ -32,13 +32,34 @@ class Gm2_Category_Sort_Branch_Rules {
             true
         );
 
+        $attrs = wc_get_attribute_taxonomies();
+        $attr_data = [];
+        if ( $attrs ) {
+            foreach ( $attrs as $attr ) {
+                $taxonomy = wc_attribute_taxonomy_name( $attr->attribute_name );
+                $terms    = get_terms( [
+                    'taxonomy'   => $taxonomy,
+                    'hide_empty' => false,
+                ] );
+                $term_map = [];
+                foreach ( $terms as $term ) {
+                    $term_map[ $term->slug ] = $term->name;
+                }
+                $attr_data[ $attr->attribute_name ] = [
+                    'label' => $attr->attribute_label,
+                    'terms' => $term_map,
+                ];
+            }
+        }
+
         wp_localize_script(
             'gm2-branch-rules',
             'gm2BranchRules',
             [
-                'nonce' => wp_create_nonce( 'gm2_branch_rules' ),
-                'saved' => __( 'Rules saved.', 'gm2-category-sort' ),
-                'error' => __( 'Error saving rules.', 'gm2-category-sort' ),
+                'nonce'      => wp_create_nonce( 'gm2_branch_rules' ),
+                'saved'      => __( 'Rules saved.', 'gm2-category-sort' ),
+                'error'      => __( 'Error saving rules.', 'gm2-category-sort' ),
+                'attributes' => $attr_data,
             ]
         );
     }
@@ -67,8 +88,16 @@ class Gm2_Category_Sort_Branch_Rules {
         echo '<h1>' . esc_html__( 'Branch Rules', 'gm2-category-sort' ) . '</h1>';
         echo '<form id="gm2-branch-rules-form">';
         wp_nonce_field( 'gm2_branch_rules', 'gm2_branch_rules_nonce' );
+        $attrs = wc_get_attribute_taxonomies();
+        $options = '';
+        if ( $attrs ) {
+            foreach ( $attrs as $attr ) {
+                $options .= '<option value="' . esc_attr( $attr->attribute_name ) . '">' . esc_html( $attr->attribute_label ) . '</option>';
+            }
+        }
+
         echo '<table class="widefat">';
-        echo '<thead><tr><th>' . esc_html__( 'Branch', 'gm2-category-sort' ) . '</th><th>' . esc_html__( 'Include Keywords', 'gm2-category-sort' ) . '</th><th>' . esc_html__( 'Exclude Keywords', 'gm2-category-sort' ) . '</th></tr></thead>';
+        echo '<thead><tr><th>' . esc_html__( 'Branch', 'gm2-category-sort' ) . '</th><th>' . esc_html__( 'Include Keywords', 'gm2-category-sort' ) . '</th><th>' . esc_html__( 'Exclude Keywords', 'gm2-category-sort' ) . '</th><th>' . esc_html__( 'Include Attributes', 'gm2-category-sort' ) . '</th><th>' . esc_html__( 'Exclude Attributes', 'gm2-category-sort' ) . '</th></tr></thead>';
         echo '<tbody>';
         foreach ( $branches as $parent => $children ) {
             foreach ( $children as $child => $slug ) {
@@ -78,6 +107,8 @@ class Gm2_Category_Sort_Branch_Rules {
                 echo '<td><strong>' . esc_html( $parent . ' > ' . $child ) . '</strong></td>';
                 echo '<td><textarea data-slug="' . esc_attr( $slug ) . '" data-type="include" rows="2" style="width:100%;">' . esc_textarea( $inc ) . '</textarea></td>';
                 echo '<td><textarea data-slug="' . esc_attr( $slug ) . '" data-type="exclude" rows="2" style="width:100%;">' . esc_textarea( $exc ) . '</textarea></td>';
+                echo '<td><select multiple class="gm2-attr-select gm2-include-attr" data-type="include_attrs" data-slug="' . esc_attr( $slug ) . '" style="width:100%;">' . $options . '</select><div class="gm2-include-terms"></div></td>';
+                echo '<td><select multiple class="gm2-attr-select gm2-exclude-attr" data-type="exclude_attrs" data-slug="' . esc_attr( $slug ) . '" style="width:100%;">' . $options . '</select><div class="gm2-exclude-terms"></div></td>';
                 echo '</tr>';
             }
         }


### PR DESCRIPTION
## Summary
- add attribute data when enqueueing branch rules script
- include attribute selectors & term containers in the Branch Rules table
- populate attributes/terms via JS and serialize on save

## Testing
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68546b1ad30c83279f2649b626a64a19