### PR TITLE
Handle dynamic attribute term selections

### DIFF
--- a/assets/js/branch-rules.js
+++ b/assets/js/branch-rules.js
@@ -53,16 +53,27 @@ jQuery(function($){
 
     load();
 
+    function gatherSelected(container){
+        var selected={};
+        container.find('select').each(function(){
+            var attr=$(this).data('attr');
+            selected[attr]=$(this).val()||[];
+        });
+        return selected;
+    }
+
     form.on('change','.gm2-include-attr',function(){
         var row=$(this).closest('tr');
         var attrsSel=$(this).val()||[];
-        renderTerms(row.find('.gm2-include-terms'),attrsSel);
+        var current=gatherSelected(row.find('.gm2-include-terms'));
+        renderTerms(row.find('.gm2-include-terms'),attrsSel,current);
     });
 
     form.on('change','.gm2-exclude-attr',function(){
         var row=$(this).closest('tr');
         var attrsSel=$(this).val()||[];
-        renderTerms(row.find('.gm2-exclude-terms'),attrsSel);
+        var current=gatherSelected(row.find('.gm2-exclude-terms'));
+        renderTerms(row.find('.gm2-exclude-terms'),attrsSel,current);
     });
 
     form.on('submit',function(e){


### PR DESCRIPTION
## Summary
- persist term selections when changing attribute dropdowns

## Testing
- `npm install`
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6854836082fc8327819747658bf84b57