### PR TITLE
Use taxonomy slugs for branch rule attributes

### DIFF
--- a/includes/class-branch-rules.php
+++ b/includes/class-branch-rules.php
@@ -45,7 +45,7 @@ class Gm2_Category_Sort_Branch_Rules {
                 foreach ( $terms as $term ) {
                     $term_map[ $term->slug ] = $term->name;
                 }
-                $attr_data[ $attr->attribute_name ] = [
+                $attr_data[ $taxonomy ] = [
                     'label' => $attr->attribute_label,
                     'terms' => $term_map,
                 ];
@@ -92,7 +92,8 @@ class Gm2_Category_Sort_Branch_Rules {
         $options = '';
         if ( $attrs ) {
             foreach ( $attrs as $attr ) {
-                $options .= '<option value="' . esc_attr( $attr->attribute_name ) . '">' . esc_html( $attr->attribute_label ) . '</option>';
+                $taxonomy = wc_attribute_taxonomy_name( $attr->attribute_name );
+                $options .= '<option value="' . esc_attr( $taxonomy ) . '">' . esc_html( $attr->attribute_label ) . '</option>';
             }
         }
 

--- a/tests/BranchRulesTest.php
+++ b/tests/BranchRulesTest.php
@@ -41,6 +41,7 @@ class BranchRulesTest extends TestCase {
         $GLOBALS['gm2_options'] = [];
         $_POST = [];
         $GLOBALS['gm2_json_result'] = null;
+        gm2_test_reset_terms();
     }
 
     public function test_ajax_save_rules_preserves_quotes() {


### PR DESCRIPTION
## Summary
- pass attribute taxonomy slug to JS and admin page
- reset term globals in branch rule tests
- keep attribute terms separate from categories in tests

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68549d9c1aa0832799511152d5257c3b