### PR TITLE
Add attribute term summaries

### DIFF
--- a/assets/js/branch-rules.js
+++ b/assets/js/branch-rules.js
@@ -27,6 +27,28 @@ jQuery(function($){
         });
     }
 
+    function summarize(selected){
+        var parts=[];
+        $.each(selected,function(attr,terms){
+            if(!terms.length) return;
+            var info=attrs[attr]||{};
+            var label=info.label||attr;
+            var names=[];
+            $.each(terms,function(i,slug){
+                names.push(info.terms && info.terms[slug] ? info.terms[slug] : slug);
+            });
+            parts.push(label+': '+names.join(', '));
+        });
+        return parts.join('; ');
+    }
+
+    function updateSummary(row){
+        var inc=gatherSelected(row.find('.gm2-include-terms'));
+        var exc=gatherSelected(row.find('.gm2-exclude-terms'));
+        row.find('.gm2-include-summary').text(summarize(inc));
+        row.find('.gm2-exclude-summary').text(summarize(exc));
+    }
+
     form.find('.gm2-attr-select').each(function(){
         populate($(this));
     });
@@ -46,6 +68,7 @@ jQuery(function($){
                     row.find('.gm2-exclude-attr').val(excAttrs);
                     renderTerms(row.find('.gm2-include-terms'),incAttrs,r.include_attrs);
                     renderTerms(row.find('.gm2-exclude-terms'),excAttrs,r.exclude_attrs);
+                    updateSummary(row);
                 }
             }
         });
@@ -67,6 +90,7 @@ jQuery(function($){
         var attrsSel=$(this).val()||[];
         var current=gatherSelected(row.find('.gm2-include-terms'));
         renderTerms(row.find('.gm2-include-terms'),attrsSel,current);
+        updateSummary(row);
     });
 
     form.on('change','.gm2-exclude-attr',function(){
@@ -74,6 +98,11 @@ jQuery(function($){
         var attrsSel=$(this).val()||[];
         var current=gatherSelected(row.find('.gm2-exclude-terms'));
         renderTerms(row.find('.gm2-exclude-terms'),attrsSel,current);
+        updateSummary(row);
+    });
+
+    form.on('change','.gm2-include-terms select,.gm2-exclude-terms select',function(){
+        updateSummary($(this).closest('tr'));
     });
 
     form.on('submit',function(e){

--- a/includes/class-branch-rules.php
+++ b/includes/class-branch-rules.php
@@ -108,8 +108,8 @@ class Gm2_Category_Sort_Branch_Rules {
                 echo '<td><strong>' . esc_html( $parent . ' > ' . $child ) . '</strong></td>';
                 echo '<td><textarea data-slug="' . esc_attr( $slug ) . '" data-type="include" rows="2" style="width:100%;">' . esc_textarea( $inc ) . '</textarea></td>';
                 echo '<td><textarea data-slug="' . esc_attr( $slug ) . '" data-type="exclude" rows="2" style="width:100%;">' . esc_textarea( $exc ) . '</textarea></td>';
-                echo '<td><select multiple class="gm2-attr-select gm2-include-attr" data-type="include_attrs" data-slug="' . esc_attr( $slug ) . '" style="width:100%;">' . $options . '</select><div class="gm2-include-terms"></div></td>';
-                echo '<td><select multiple class="gm2-attr-select gm2-exclude-attr" data-type="exclude_attrs" data-slug="' . esc_attr( $slug ) . '" style="width:100%;">' . $options . '</select><div class="gm2-exclude-terms"></div></td>';
+                echo '<td><select multiple class="gm2-attr-select gm2-include-attr" data-type="include_attrs" data-slug="' . esc_attr( $slug ) . '" style="width:100%;">' . $options . '</select><div class="gm2-include-terms"></div><div class="gm2-include-summary"></div></td>';
+                echo '<td><select multiple class="gm2-attr-select gm2-exclude-attr" data-type="exclude_attrs" data-slug="' . esc_attr( $slug ) . '" style="width:100%;">' . $options . '</select><div class="gm2-exclude-terms"></div><div class="gm2-exclude-summary"></div></td>';
                 echo '</tr>';
             }
         }


### PR DESCRIPTION
## Summary
- show selected attribute terms next to each branch rule
- update JS to build a summary string
- live update summaries when selections change

## Testing
- `npm test` *(fails: Missing script)*
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685468d40f788327a00dd8a2a0a5aaf4