### PR TITLE
Add removable attribute selectors to branch rules

### DIFF
--- a/assets/css/branch-rules.css
+++ b/assets/css/branch-rules.css
@@ -1,0 +1,16 @@
+.gm2-attr-group {
+    display: flex;
+    align-items: center;
+    margin-bottom: 4px;
+}
+.gm2-remove-attr {
+    cursor: pointer;
+    font-size: 16px;
+    line-height: 1;
+    margin-right: 4px;
+    padding: 2px;
+}
+.gm2-remove-attr:hover {
+    color: red;
+    transform: scale(1.2);
+}

--- a/assets/js/branch-rules.js
+++ b/assets/js/branch-rules.js
@@ -16,6 +16,7 @@ jQuery(function($){
             var info=attrs[attr];
             if(!info) return;
             var group=$('<span class="gm2-attr-group">');
+            var remove=$('<span class="gm2-remove-attr" data-attr="'+attr+'">&times;</span>');
             var sel=$('<select multiple>').attr('data-attr',attr);
             $.each(info.terms,function(slug,name){
                 var opt=$('<option>').val(slug).text(name);
@@ -24,8 +25,8 @@ jQuery(function($){
                 }
                 sel.append(opt);
             });
+            group.append(remove);
             group.append(sel);
-            group.append($('<button type="button" class="gm2-remove-attr">&times;</button>'));
             container.append(group);
         });
     }
@@ -112,7 +113,7 @@ jQuery(function($){
         var group=$(this).closest('.gm2-attr-group');
         var container=group.closest('.gm2-include-terms,.gm2-exclude-terms');
         var row=group.closest('tr');
-        var attr=group.find('select').data('attr');
+        var attr=$(this).data('attr');
         var attrSelect=container.siblings('select.gm2-attr-select');
         attrSelect.find('option[value="'+attr+'"]').prop('selected',false);
         group.remove();

--- a/includes/class-branch-rules.php
+++ b/includes/class-branch-rules.php
@@ -32,6 +32,14 @@ class Gm2_Category_Sort_Branch_Rules {
             true
         );
 
+        $css_ver = file_exists( GM2_CAT_SORT_PATH . 'assets/css/branch-rules.css' ) ? filemtime( GM2_CAT_SORT_PATH . 'assets/css/branch-rules.css' ) : GM2_CAT_SORT_VERSION;
+        wp_enqueue_style(
+            'gm2-branch-rules',
+            GM2_CAT_SORT_URL . 'assets/css/branch-rules.css',
+            [],
+            $css_ver
+        );
+
         $attrs = wc_get_attribute_taxonomies();
         $attr_data = [];
         if ( $attrs ) {


### PR DESCRIPTION
## Summary
- prepend a remove icon before each attribute term selector
- unselect attribute when removing selector and refresh the summary
- load new stylesheet for branch rules admin page
- style attribute removal button

## Testing
- `npm run build` *(fails: `babel` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854b3495f8c832793397ae468be598c