### PR TITLE
Add tests for branch rule attribute handling

### DIFF
--- a/tests/BranchRulesTest.php
+++ b/tests/BranchRulesTest.php
@@ -74,6 +74,35 @@ class BranchRulesTest extends TestCase {
         $this->assertSame( [ 'pa_Size' => [ 'Large' ] ], $saved['branch-leaf']['exclude_attrs'] );
     }
 
+    public function test_ajax_get_rules_returns_multiple_attributes() {
+        $_POST['nonce'] = 't';
+        $_POST['rules'] = [
+            'branch-leaf' => [
+                'include'       => 'foo',
+                'exclude'       => 'bar',
+                'include_attrs' => [
+                    'pa_Color' => [ 'Red' ],
+                    'pa_Size'  => [ 'Large', 'Small' ],
+                ],
+                'exclude_attrs' => [
+                    'pa_Material' => [ 'Steel' ],
+                    'pa_Type'     => [ 'OEM' ],
+                ],
+            ],
+        ];
+
+        $expected = $_POST['rules'];
+
+        Gm2_Category_Sort_Branch_Rules::ajax_save_rules();
+
+        $_POST = [ 'nonce' => 't' ];
+        Gm2_Category_Sort_Branch_Rules::ajax_get_rules();
+        $result = $GLOBALS['gm2_json_result'];
+
+        $this->assertTrue( $result['success'] );
+        $this->assertSame( $expected, $result['data'] );
+    }
+
     public function test_stub_attribute_creation() {
         wc_create_attribute( [ 'slug' => 'color', 'name' => 'Color' ] );
         $tax = wc_attribute_taxonomy_name( 'color' );

--- a/tests/ProductCategoryGeneratorTest.php
+++ b/tests/ProductCategoryGeneratorTest.php
@@ -27,6 +27,8 @@ if ( ! function_exists( 'sanitize_key' ) ) {
 if ( ! function_exists( 'sanitize_title' ) ) {
     function sanitize_title( $str ) { $s = strtolower( $str ); $s = preg_replace( '/[^a-z0-9]+/', '-', $s ); return trim( $s, '-' ); }
 }
+
+require_once __DIR__ . '/../includes/class-branch-rules.php';
 }
 
 namespace {
@@ -832,6 +834,32 @@ class ProductCategoryGeneratorTest extends TestCase {
     public function test_slugify_segment_encodes_quotes() {
         $this->assertSame( '19d', Gm2_Category_Sort_Product_Category_Generator::slugify_segment( '19"' ) );
         $this->assertSame( '19s', Gm2_Category_Sort_Product_Category_Generator::slugify_segment( "19'" ) );
+    }
+
+    public function test_ajax_remove_attribute_deletes_option() {
+        $_POST['nonce'] = 't';
+        $_POST['rules'] = [
+            'branch-leaf' => [
+                'include'       => '',
+                'exclude'       => '',
+                'include_attrs' => [ 'pa_color' => [ 'red' ] ],
+            ],
+        ];
+        Gm2_Category_Sort_Branch_Rules::ajax_save_rules();
+        $saved = get_option( 'gm2_branch_rules' );
+        $this->assertSame( [ 'pa_color' => [ 'red' ] ], $saved['branch-leaf']['include_attrs'] );
+
+        $_POST['nonce'] = 't';
+        $_POST['rules'] = [
+            'branch-leaf' => [
+                'include'       => '',
+                'exclude'       => '',
+                'include_attrs' => [],
+            ],
+        ];
+        Gm2_Category_Sort_Branch_Rules::ajax_save_rules();
+        $saved = get_option( 'gm2_branch_rules' );
+        $this->assertSame( [], $saved['branch-leaf']['include_attrs'] );
     }
 }
 }


### PR DESCRIPTION
## Summary
- test ajax_get_rules() returns multiple attribute selections
- allow tests to include branch rules when posted attributes are removed

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_6854b57443a88327b617eb5b63950c91