### PR TITLE
Implement removable attribute tags for branch rules

### DIFF
--- a/assets/css/branch-rules.css
+++ b/assets/css/branch-rules.css
@@ -21,3 +21,19 @@
     color: #666;
 }
 
+.gm2-tag {
+    display: inline-block;
+    background: #f1f1f1;
+    border: 1px solid #ccc;
+    border-radius: 3px;
+    margin: 2px 4px 2px 0;
+    padding: 2px 4px;
+    font-size: 12px;
+}
+
+.gm2-remove-tag {
+    cursor: pointer;
+    margin-right: 2px;
+    color: #a00;
+}
+

--- a/assets/js/branch-rules.js
+++ b/assets/js/branch-rules.js
@@ -46,11 +46,30 @@ jQuery(function($){
         return parts.join('; ');
     }
 
+    function renderTags(container, selected){
+        container.empty();
+        $.each(selected,function(attr,terms){
+            if(!terms.length) return;
+            var info=attrs[attr]||{};
+            var label=info.label||attr;
+            var names=[];
+            $.each(terms,function(i,slug){
+                names.push(info.terms && info.terms[slug] ? info.terms[slug] : slug);
+            });
+            var tag=$('<span class="gm2-tag" data-attr="'+attr+'">');
+            var remove=$('<span class="gm2-remove-tag" data-attr="'+attr+'">&times;</span>');
+            tag.append(remove).append(' '+label+': '+names.join(', '));
+            container.append(tag);
+        });
+    }
+
     function updateSummary(row){
         var inc=gatherSelected(row.find('.gm2-include-terms'));
         var exc=gatherSelected(row.find('.gm2-exclude-terms'));
         row.find('.gm2-include-summary').text(summarize(inc));
         row.find('.gm2-exclude-summary').text(summarize(exc));
+        renderTags(row.find('.gm2-include-tags'),inc);
+        renderTags(row.find('.gm2-exclude-tags'),exc);
     }
 
     form.find('.gm2-attr-select').each(function(){
@@ -117,6 +136,19 @@ jQuery(function($){
         var attrSelect=container.siblings('select.gm2-attr-select');
         attrSelect.find('option[value="'+attr+'"]').prop('selected',false);
         group.remove();
+        updateSummary(row);
+    });
+
+    form.on('click','.gm2-remove-tag',function(){
+        var tag=$(this).closest('.gm2-tag');
+        var attr=$(this).data('attr');
+        var row=tag.closest('tr');
+        var isInc=tag.closest('.gm2-include-tags').length>0;
+        var attrSelect=isInc?row.find('.gm2-include-attr'):row.find('.gm2-exclude-attr');
+        var termsContainer=isInc?row.find('.gm2-include-terms'):row.find('.gm2-exclude-terms');
+        attrSelect.find('option[value="'+attr+'"]').prop('selected',false);
+        termsContainer.find('select[data-attr="'+attr+'"]').closest('.gm2-attr-group').remove();
+        tag.remove();
         updateSummary(row);
     });
 

--- a/includes/class-branch-rules.php
+++ b/includes/class-branch-rules.php
@@ -118,8 +118,8 @@ class Gm2_Category_Sort_Branch_Rules {
                 echo '<td><strong>' . esc_html( $clean_parent . ' > ' . $clean_child ) . '</strong></td>';
                 echo '<td><textarea data-slug="' . esc_attr( $slug ) . '" data-type="include" rows="2" style="width:100%;">' . esc_textarea( $inc ) . '</textarea></td>';
                 echo '<td><textarea data-slug="' . esc_attr( $slug ) . '" data-type="exclude" rows="2" style="width:100%;">' . esc_textarea( $exc ) . '</textarea></td>';
-                echo '<td><select multiple class="gm2-attr-select gm2-include-attr" data-type="include_attrs" data-slug="' . esc_attr( $slug ) . '" style="width:100%;">' . $options . '</select><div class="gm2-include-terms"></div><div class="gm2-include-summary"></div></td>';
-                echo '<td><select multiple class="gm2-attr-select gm2-exclude-attr" data-type="exclude_attrs" data-slug="' . esc_attr( $slug ) . '" style="width:100%;">' . $options . '</select><div class="gm2-exclude-terms"></div><div class="gm2-exclude-summary"></div></td>';
+                echo '<td><select multiple class="gm2-attr-select gm2-include-attr" data-type="include_attrs" data-slug="' . esc_attr( $slug ) . '" style="width:100%;">' . $options . '</select><div class="gm2-include-terms"></div><div class="gm2-include-tags"></div><div class="gm2-include-summary"></div></td>';
+                echo '<td><select multiple class="gm2-attr-select gm2-exclude-attr" data-type="exclude_attrs" data-slug="' . esc_attr( $slug ) . '" style="width:100%;">' . $options . '</select><div class="gm2-exclude-terms"></div><div class="gm2-exclude-tags"></div><div class="gm2-exclude-summary"></div></td>';
                 echo '</tr>';
             }
         }


### PR DESCRIPTION
## Summary
- support tag containers in Branch Rules table
- render tags for selected attributes in branch-rules.js
- allow removing tags to deselect attribute/term combos
- style tags via CSS

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6854ba065cb083279b511f7afb00cafe