### PR TITLE
Fix multi-select for attribute list

### DIFF
--- a/assets/js/branch-rules.js
+++ b/assets/js/branch-rules.js
@@ -76,6 +76,14 @@ jQuery(function($){
         populate($(this));
     });
 
+    // Allow selecting multiple attributes without holding Ctrl/Command
+    form.on('mousedown', '.gm2-attr-select option', function(e){
+        e.preventDefault();
+        var opt=$(this);
+        opt.prop('selected', !opt.prop('selected'));
+        opt.parent().trigger('change');
+    });
+
     function load(){
         $.post(ajaxurl,{action:'gm2_branch_rules_get',nonce:gm2BranchRules.nonce})
         .done(function(resp){


### PR DESCRIPTION
## Summary
- allow mousedown toggling on attribute options so previous selections are not cleared

## Testing
- `npm install`
- `npm run build`
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6854c8288ef08327b4edf42711d1e24d