### PR TITLE
Add attribute term group toggle

### DIFF
--- a/assets/css/branch-rules.css
+++ b/assets/css/branch-rules.css
@@ -10,6 +10,19 @@
     margin-right: 4px;
     padding: 2px;
 }
+.gm2-toggle-attr {
+    cursor: pointer;
+    font-size: 12px;
+    line-height: 1;
+    margin-right: 4px;
+    padding: 2px;
+}
+.gm2-attr-group.collapsed select {
+    display: none;
+}
+.gm2-attr-group.collapsed .gm2-toggle-attr {
+    transform: rotate(-90deg);
+}
 .gm2-remove-attr:hover {
     color: red;
     transform: scale(1.2);

--- a/assets/js/branch-rules.js
+++ b/assets/js/branch-rules.js
@@ -16,6 +16,7 @@ jQuery(function($){
             var info=attrs[attr];
             if(!info) return;
             var group=$('<span class="gm2-attr-group">');
+            var toggle=$('<span class="gm2-toggle-attr" data-attr="'+attr+'">&#9660;</span>');
             var remove=$('<span class="gm2-remove-attr" data-attr="'+attr+'">&times;</span>');
             var sel=$('<select multiple>').attr('data-attr',attr);
             $.each(info.terms,function(slug,name){
@@ -25,6 +26,7 @@ jQuery(function($){
                 }
                 sel.append(opt);
             });
+            group.append(toggle);
             group.append(remove);
             group.append(sel);
             container.append(group);
@@ -134,6 +136,11 @@ jQuery(function($){
 
     form.on('change','.gm2-include-terms select,.gm2-exclude-terms select',function(){
         updateSummary($(this).closest('tr'));
+    });
+
+    form.on('click','.gm2-attr-group .gm2-toggle-attr',function(){
+        var group=$(this).closest('.gm2-attr-group');
+        group.toggleClass('collapsed');
     });
 
     form.on('click','.gm2-attr-group .gm2-remove-attr',function(){


### PR DESCRIPTION
## Summary
- add a toggle icon when rendering attribute term selects
- allow collapsing/expanding term select groups
- hide selects in collapsed groups via CSS

## Testing
- `composer test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6854cf215b6c83278dbd7bc44ff4c198