### PR TITLE
Remove duplicate branch rule summaries

### DIFF
--- a/assets/css/branch-rules.css
+++ b/assets/css/branch-rules.css
@@ -27,12 +27,6 @@
     color: red;
     transform: scale(1.2);
 }
-.gm2-include-summary,
-.gm2-exclude-summary {
-    margin-top: 4px;
-    font-size: 12px;
-    color: #666;
-}
 
 .gm2-tag {
     display: inline-block;

--- a/assets/js/branch-rules.js
+++ b/assets/js/branch-rules.js
@@ -68,8 +68,6 @@ jQuery(function($){
     function updateSummary(row){
         var inc=gatherSelected(row.find('.gm2-include-terms'));
         var exc=gatherSelected(row.find('.gm2-exclude-terms'));
-        row.find('.gm2-include-summary').text(summarize(inc));
-        row.find('.gm2-exclude-summary').text(summarize(exc));
         renderTags(row.find('.gm2-include-tags'),inc);
         renderTags(row.find('.gm2-exclude-tags'),exc);
     }

--- a/includes/class-branch-rules.php
+++ b/includes/class-branch-rules.php
@@ -118,8 +118,8 @@ class Gm2_Category_Sort_Branch_Rules {
                 echo '<td><strong>' . esc_html( $clean_parent . ' > ' . $clean_child ) . '</strong></td>';
                 echo '<td><textarea data-slug="' . esc_attr( $slug ) . '" data-type="include" rows="2" style="width:100%;">' . esc_textarea( $inc ) . '</textarea></td>';
                 echo '<td><textarea data-slug="' . esc_attr( $slug ) . '" data-type="exclude" rows="2" style="width:100%;">' . esc_textarea( $exc ) . '</textarea></td>';
-                echo '<td><select multiple class="gm2-attr-select gm2-include-attr" data-type="include_attrs" data-slug="' . esc_attr( $slug ) . '" style="width:100%;">' . $options . '</select><div class="gm2-include-terms"></div><div class="gm2-include-tags"></div><div class="gm2-include-summary"></div></td>';
-                echo '<td><select multiple class="gm2-attr-select gm2-exclude-attr" data-type="exclude_attrs" data-slug="' . esc_attr( $slug ) . '" style="width:100%;">' . $options . '</select><div class="gm2-exclude-terms"></div><div class="gm2-exclude-tags"></div><div class="gm2-exclude-summary"></div></td>';
+                echo '<td><select multiple class="gm2-attr-select gm2-include-attr" data-type="include_attrs" data-slug="' . esc_attr( $slug ) . '" style="width:100%;">' . $options . '</select><div class="gm2-include-terms"></div><div class="gm2-include-tags"></div></td>';
+                echo '<td><select multiple class="gm2-attr-select gm2-exclude-attr" data-type="exclude_attrs" data-slug="' . esc_attr( $slug ) . '" style="width:100%;">' . $options . '</select><div class="gm2-exclude-terms"></div><div class="gm2-exclude-tags"></div></td>';
                 echo '</tr>';
             }
         }


### PR DESCRIPTION
## Summary
- drop extra summary output for selected branch rule attributes
- only show tags for selected attributes with removal controls

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6854ce8f29f08327a7461aff8662ee88