### PR TITLE
Remove unused summarize function

### DIFF
--- a/assets/js/branch-rules.js
+++ b/assets/js/branch-rules.js
@@ -39,21 +39,6 @@ jQuery(function($){
         });
     }
 
-    function summarize(selected){
-        var parts=[];
-        $.each(selected,function(attr,terms){
-            if(!terms.length) return;
-            var info=attrs[attr]||{};
-            var label=info.label||attr;
-            var names=[];
-            $.each(terms,function(i,slug){
-                names.push(info.terms && info.terms[slug] ? info.terms[slug] : slug);
-            });
-            parts.push(label+': '+names.join(', '));
-        });
-        return parts.join('; ');
-    }
-
     function renderTags(container, selected){
         container.empty();
         $.each(selected,function(attr,terms){


### PR DESCRIPTION
## Summary
- cleanup: delete leftover `summarize` function in branch-rules.js
- normalize whitespace after removing code

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6854e700b7b08327903138ece64b9577