### PR TITLE
Implement attribute-based category assignment

### DIFF
--- a/includes/class-one-click-assign.php
+++ b/includes/class-one-click-assign.php
@@ -285,7 +285,11 @@ class Gm2_Category_Sort_One_Click_Assign {
                 }
             }
 
-            $cats     = Gm2_Category_Sort_Product_Category_Generator::assign_categories( $text, $mapping, false, 85, null, $attr_slugs );
+            if ( in_array( 'attributes', $fields, true ) && count( $fields ) === 1 ) {
+                $cats = Gm2_Category_Sort_Product_Category_Generator::assign_categories_from_attributes( $attr_slugs );
+            } else {
+                $cats = Gm2_Category_Sort_Product_Category_Generator::assign_categories( $text, $mapping, false, 85, null, $attr_slugs );
+            }
             $term_ids = [];
             foreach ( $cats as $name ) {
                 $term = get_term_by( 'name', $name, 'product_cat' );


### PR DESCRIPTION
## Summary
- add `assign_categories_from_attributes` for attribute-only category checks
- fall back to this method when One Click assignment runs with only attributes selected
- cover attribute-only logic with new unit test

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854f27cb4a48327abe1af3dd7c3818c