### PR TITLE
Fix attribute rules with title matching

### DIFF
--- a/includes/class-one-click-assign.php
+++ b/includes/class-one-click-assign.php
@@ -285,10 +285,17 @@ class Gm2_Category_Sort_One_Click_Assign {
                 }
             }
 
-            if ( in_array( 'attributes', $fields, true ) && count( $fields ) === 1 ) {
-                $cats = Gm2_Category_Sort_Product_Category_Generator::assign_categories_from_attributes( $attr_slugs );
-            } else {
+            $cats = [];
+            if ( in_array( 'title', $fields, true ) || in_array( 'description', $fields, true ) ) {
                 $cats = Gm2_Category_Sort_Product_Category_Generator::assign_categories( $text, $mapping, false, 85, null, $attr_slugs );
+            }
+            if ( in_array( 'attributes', $fields, true ) ) {
+                $extra = Gm2_Category_Sort_Product_Category_Generator::assign_categories_from_attributes( $attr_slugs );
+                foreach ( $extra as $cat ) {
+                    if ( ! in_array( $cat, $cats, true ) ) {
+                        $cats[] = $cat;
+                    }
+                }
             }
             $term_ids = [];
             foreach ( $cats as $name ) {


### PR DESCRIPTION
## Summary
- run both title and attribute assignment logic if both fields selected in One Click Categories Assignment

## Testing
- `composer install` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_685580536e648327abd9cabd9b139df0