### PR TITLE
Add allow_multi column for branch rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,8 @@ basic stemming so minor wording differences like `lugs` vs `lug`,
 
 Use **Tools → Branch Rules** (requires the `manage_options` capability) to set
 include and exclude keywords for each category branch. Each rule also provides
-**Include Attributes** and **Exclude Attributes** selectors. When you run **One
+**Include Attributes** and **Exclude Attributes** selectors along with an
+**Allow Multiple Leaves** checkbox. When you run **One
 Click Categories Assignment** with the **Product Attributes** option enabled,
 these attribute selections are checked in addition to the regular include and
 exclude keywords. A branch is applied when any include term or attribute is

--- a/assets/css/branch-rules.css
+++ b/assets/css/branch-rules.css
@@ -44,3 +44,8 @@
     color: #a00;
 }
 
+.gm2-allow-multi {
+    text-align: center;
+    vertical-align: middle;
+}
+

--- a/assets/js/branch-rules.js
+++ b/assets/js/branch-rules.js
@@ -85,6 +85,7 @@ jQuery(function($){
                     var excAttrs=Object.keys(r.exclude_attrs||{});
                     row.find('.gm2-include-attr').val(incAttrs);
                     row.find('.gm2-exclude-attr').val(excAttrs);
+                    row.find('input[data-type="allow_multi"]').prop('checked', !!r.allow_multi);
                     renderTerms(row.find('.gm2-include-terms'),incAttrs,r.include_attrs,true);
                     renderTerms(row.find('.gm2-exclude-terms'),excAttrs,r.exclude_attrs,true);
                     updateSummary(row);
@@ -169,7 +170,8 @@ jQuery(function($){
                 include:row.find('textarea[data-type="include"]').val(),
                 exclude:row.find('textarea[data-type="exclude"]').val(),
                 include_attrs:incAttrs,
-                exclude_attrs:excAttrs
+                exclude_attrs:excAttrs,
+                allow_multi:row.find('input[data-type="allow_multi"]').is(':checked')
             };
         });
         $.post(ajaxurl,{action:'gm2_branch_rules_save',nonce:gm2BranchRules.nonce,rules:rules})

--- a/includes/class-branch-rules.php
+++ b/includes/class-branch-rules.php
@@ -106,12 +106,13 @@ class Gm2_Category_Sort_Branch_Rules {
         }
 
         echo '<table class="widefat">';
-        echo '<thead><tr><th>' . esc_html__( 'Branch', 'gm2-category-sort' ) . '</th><th>' . esc_html__( 'Include Keywords', 'gm2-category-sort' ) . '</th><th>' . esc_html__( 'Exclude Keywords', 'gm2-category-sort' ) . '</th><th>' . esc_html__( 'Include Attributes', 'gm2-category-sort' ) . '</th><th>' . esc_html__( 'Exclude Attributes', 'gm2-category-sort' ) . '</th></tr></thead>';
+        echo '<thead><tr><th>' . esc_html__( 'Branch', 'gm2-category-sort' ) . '</th><th>' . esc_html__( 'Include Keywords', 'gm2-category-sort' ) . '</th><th>' . esc_html__( 'Exclude Keywords', 'gm2-category-sort' ) . '</th><th>' . esc_html__( 'Include Attributes', 'gm2-category-sort' ) . '</th><th>' . esc_html__( 'Exclude Attributes', 'gm2-category-sort' ) . '</th><th>' . esc_html__( 'Allow Multiple Leaves', 'gm2-category-sort' ) . '</th></tr></thead>';
         echo '<tbody>';
         foreach ( $branches as $parent => $children ) {
             foreach ( $children as $child => $slug ) {
-                $inc = $rules[ $slug ][ 'include' ] ?? '';
-                $exc = $rules[ $slug ][ 'exclude' ] ?? '';
+                $inc   = $rules[ $slug ][ 'include' ] ?? '';
+                $exc   = $rules[ $slug ][ 'exclude' ] ?? '';
+                $multi = ! empty( $rules[ $slug ]['allow_multi'] );
                 $clean_parent = preg_replace( '/\s*\([^\)]*\)/', '', $parent );
                 $clean_child  = preg_replace( '/\s*\([^\)]*\)/', '', $child );
                 echo '<tr data-slug="' . esc_attr( $slug ) . '">';
@@ -120,6 +121,7 @@ class Gm2_Category_Sort_Branch_Rules {
                 echo '<td><textarea data-slug="' . esc_attr( $slug ) . '" data-type="exclude" rows="2" style="width:100%;">' . esc_textarea( $exc ) . '</textarea></td>';
                 echo '<td><select multiple class="gm2-attr-select gm2-include-attr" data-type="include_attrs" data-slug="' . esc_attr( $slug ) . '" style="width:100%;">' . $options . '</select><div class="gm2-include-terms"></div><div class="gm2-include-tags"></div></td>';
                 echo '<td><select multiple class="gm2-attr-select gm2-exclude-attr" data-type="exclude_attrs" data-slug="' . esc_attr( $slug ) . '" style="width:100%;">' . $options . '</select><div class="gm2-exclude-terms"></div><div class="gm2-exclude-tags"></div></td>';
+                echo '<td class="gm2-allow-multi"><input type="checkbox" data-type="allow_multi" data-slug="' . esc_attr( $slug ) . '"' . ( $multi ? ' checked' : '' ) . '></td>';
                 echo '</tr>';
             }
         }
@@ -137,6 +139,9 @@ class Gm2_Category_Sort_Branch_Rules {
         if ( ! is_array( $rules ) ) {
             $rules = [];
         }
+        foreach ( $rules as $slug => $rule ) {
+            $rules[ $slug ]['allow_multi'] = ! empty( $rule['allow_multi'] );
+        }
         wp_send_json_success( $rules );
     }
 
@@ -151,6 +156,7 @@ class Gm2_Category_Sort_Branch_Rules {
             $slug    = sanitize_key( $slug );
             $include = sanitize_textarea_field( $rule['include'] ?? '' );
             $exclude = sanitize_textarea_field( $rule['exclude'] ?? '' );
+            $allow_multi = ! empty( $rule['allow_multi'] );
 
             $include_attrs = [];
             if ( isset( $rule['include_attrs'] ) && is_array( $rule['include_attrs'] ) ) {
@@ -173,6 +179,7 @@ class Gm2_Category_Sort_Branch_Rules {
                 'exclude'       => $exclude,
                 'include_attrs' => $include_attrs,
                 'exclude_attrs' => $exclude_attrs,
+                'allow_multi'   => $allow_multi,
             ];
         }
         update_option( 'gm2_branch_rules', $rules );

--- a/tests/BranchRulesTest.php
+++ b/tests/BranchRulesTest.php
@@ -64,6 +64,7 @@ class BranchRulesTest extends TestCase {
                 'exclude'       => '',
                 'include_attrs' => [ 'pa_Color' => [ 'Red', 'Blue' ] ],
                 'exclude_attrs' => [ 'pa_Size' => [ 'Large' ] ],
+                'allow_multi'   => true,
             ],
         ];
 
@@ -72,6 +73,17 @@ class BranchRulesTest extends TestCase {
 
         $this->assertSame( [ 'pa_Color' => [ 'Red', 'Blue' ] ], $saved['branch-leaf']['include_attrs'] );
         $this->assertSame( [ 'pa_Size' => [ 'Large' ] ], $saved['branch-leaf']['exclude_attrs'] );
+        $this->assertTrue( $saved['branch-leaf']['allow_multi'] );
+    }
+
+    public function test_ajax_save_rules_allow_multi() {
+        $_POST['nonce'] = 't';
+        $_POST['rules'] = [ 'branch-leaf' => [ 'include' => '', 'exclude' => '', 'allow_multi' => true ] ];
+
+        Gm2_Category_Sort_Branch_Rules::ajax_save_rules();
+        $saved = get_option( 'gm2_branch_rules' );
+
+        $this->assertTrue( $saved['branch-leaf']['allow_multi'] );
     }
 
     public function test_ajax_get_rules_returns_multiple_attributes() {
@@ -88,6 +100,7 @@ class BranchRulesTest extends TestCase {
                     'pa_Material' => [ 'Steel' ],
                     'pa_Type'     => [ 'OEM' ],
                 ],
+                'allow_multi'   => true,
             ],
         ];
 
@@ -101,6 +114,7 @@ class BranchRulesTest extends TestCase {
 
         $this->assertTrue( $result['success'] );
         $this->assertSame( $expected, $result['data'] );
+        $this->assertTrue( $result['data']['branch-leaf']['allow_multi'] );
     }
 
     public function test_stub_attribute_creation() {


### PR DESCRIPTION
## Summary
- support selecting "Allow Multiple Leaves" for branch rules
- persist `allow_multi` value through AJAX
- expose `allow_multi` checkbox in admin UI
- style checkbox column and document new option
- test saving/retrieving `allow_multi`

## Testing
- `phpunit -c phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_6856c9b8b3c48327a3fe802833b70a53