### PR TITLE
Add allow_multi_global widget option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Gm2 Category Sort adds a product category sorting widget for WooCommerce shops w
 1. Edit a WooCommerce shop or archive page with Elementor.
 2. Search for the **GM2 Category Sort** widget and drag it into your layout.
 3. Choose optional parent categories and select the filter logic (Simple or Advanced) in the widget settings.
-4. Save the page. On the frontend, shoppers can expand categories and filter the product list.
+4. Enable **Allow Multiple Selection** if shoppers should be able to pick categories from several groups at once.
+5. Save the page. On the frontend, shoppers can expand categories and filter the product list.
    After each filter update, the page automatically scrolls back to the selected
    categories list so it's easy to refine choices.
 

--- a/assets/dist/frontend.js
+++ b/assets/dist/frontend.js
@@ -141,6 +141,7 @@ jQuery(document).ready(function ($) {
       $link = $link.closest('.gm2-category-name-container').find('.gm2-category-name').first();
     }
     var $widget = $link.closest('.gm2-category-sort');
+    var allowMulti = $widget.data('allow-multi') === true || $widget.data('allow-multi') === 'true';
     var isSelected = $link.hasClass('selected');
 
     // Toggle selection on canonical label

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -132,6 +132,7 @@ jQuery(document).ready(function($) {
             $link = $link.closest('.gm2-category-name-container').find('.gm2-category-name').first();
         }
         const $widget = $link.closest('.gm2-category-sort');
+        const allowMulti = $widget.data('allow-multi') === true || $widget.data('allow-multi') === 'true';
         const isSelected = $link.hasClass('selected');
 
         // Toggle selection on canonical label

--- a/includes/class-renderer.php
+++ b/includes/class-renderer.php
@@ -17,7 +17,8 @@ class Gm2_Category_Sort_Renderer {
              data-filter-type="<?= esc_attr($this->settings['filter_type']) ?>"
              data-simple-operator="<?= esc_attr($this->settings['simple_operator'] ?? 'IN') ?>"
              data-columns="<?= esc_attr(wc_get_loop_prop('columns')) ?>"
-             data-per-page="<?= esc_attr(wc_get_loop_prop('per_page')) ?>">
+             data-per-page="<?= esc_attr(wc_get_loop_prop('per_page')) ?>"
+             data-allow-multi="<?= $this->settings['allow_multi_global'] ? 'true' : 'false' ?>">
              
             <nav class="gm2-category-tree">
                 <?php $this->render_category_tree(); ?>

--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -56,6 +56,12 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
                 'filter_type' => 'simple',
             ],
         ]);
+
+        $this->add_control('allow_multi_global', [
+            'label' => __('Allow Multiple Selection', 'gm2-category-sort'),
+            'type' => \Elementor\Controls_Manager::SWITCHER,
+            'default' => '',
+        ]);
         
         $this->end_controls_section();
         
@@ -870,6 +876,7 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
             'synonym_icon_position'=> $settings['synonym_icon_position'],
             'expand_icon'          => $settings['expand_icon'],
             'collapse_icon'        => $settings['collapse_icon'],
+            'allow_multi_global'   => $settings['allow_multi_global'] ?? '',
         ]);
         
         echo $renderer->generate_html();


### PR DESCRIPTION
## Summary
- add **Allow Multiple Selection** option to widget
- send allow multi flag to the renderer and output as `data-allow-multi`
- expose new flag in frontend script
- document the new setting in README

## Testing
- `npm run build`
- `composer install` *(fails: ext-dom missing)*

------
https://chatgpt.com/codex/tasks/task_e_6856e1fa088c8327b6b55e91e8292790