### PR TITLE
Improve branch rules slug mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,8 @@ checkbox is left unchecked, only the first matching leaf beneath that branch is
 assigned. Enabling the checkbox permits all matching leaves within the branch to
 be assigned.** The rules are stored in the `gm2_branch_rules` option. Each rule
 is saved using a slug that represents the full category path so even nested
-branches can be targeted.
+branches can be targeted. Every slug from `category-tree.csv` is displayed with
+its complete path so parent categories without children can also receive rules.
 
 ## SEO Improvements
 

--- a/tests/BranchSlugMapTest.php
+++ b/tests/BranchSlugMapTest.php
@@ -1,0 +1,33 @@
+<?php
+use PHPUnit\Framework\TestCase;
+require_once __DIR__ . '/../includes/class-branch-rules.php';
+
+class BranchSlugMapTest extends TestCase {
+    protected function setUp(): void {
+        gm2_test_reset_terms();
+    }
+
+    public function test_map_includes_leaf_parents() {
+        $root   = wp_insert_term('Root','product_cat');
+        $branch = wp_insert_term('Branch','product_cat',['parent'=>$root['term_id']]);
+        wp_insert_term('Leaf','product_cat',['parent'=>$branch['term_id']]);
+        wp_insert_term('Solo','product_cat');
+
+        $dir = sys_get_temp_dir() . '/gm2_slug_map';
+        if (file_exists($dir)) {
+            foreach (glob("$dir/*") as $f) { unlink($f); }
+            rmdir($dir);
+        }
+
+        Gm2_Category_Sort_Product_Category_Generator::export_category_tree_csv($dir);
+
+        $map = Gm2_Category_Sort_Branch_Rules::build_slug_path_map($dir . '/category-tree.csv');
+
+        $this->assertArrayHasKey('solo', $map);
+        $this->assertSame('Solo', $map['solo']);
+        $this->assertArrayHasKey('root-branch', $map);
+        $this->assertSame('Root > Branch', $map['root-branch']);
+        $this->assertArrayHasKey('root-branch-leaf', $map);
+        $this->assertSame('Root > Branch > Leaf', $map['root-branch-leaf']);
+    }
+}


### PR DESCRIPTION
## Summary
- add `build_slug_path_map` helper for branch rules
- list branch rule rows using full slug path map
- document new branch rule behavior
- test slug map helper

## Testing
- `vendor/bin/phpunit --colors=never`

------
https://chatgpt.com/codex/tasks/task_e_6856ecc015e883279fb0ba9c7451fb58