### PR TITLE
Fix branch rule slug generation with synonyms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Allow Multiple Leaves checkbox to enable multi-leaf category assignment per branch.
 ### Fixed
 - Product CSV export no longer reports WooCommerce missing when the WC_ABSPATH constant is undefined.
+- Branch and rule slugs remove trailing synonym text to match the product categorizer.
 
 ## [1.0.15] - 2025-06-15
 ### Added

--- a/includes/class-branch-rules.php
+++ b/includes/class-branch-rules.php
@@ -103,7 +103,9 @@ class Gm2_Category_Sort_Branch_Rules {
                     continue;
                 }
 
-                $path_slugs[] = Gm2_Category_Sort_Product_Category_Generator::slugify_segment( $segment );
+                $clean = preg_replace( '/\s*\([^\)]*\)$/', '', $segment );
+
+                $path_slugs[] = Gm2_Category_Sort_Product_Category_Generator::slugify_segment( $clean );
                 $path_names[] = preg_replace( '/\s*\([^\)]*\)/', '', $segment );
                 $slug = implode( '-', $path_slugs );
 

--- a/includes/class-one-click-assign.php
+++ b/includes/class-one-click-assign.php
@@ -445,7 +445,8 @@ class Gm2_Category_Sort_One_Click_Assign {
                     continue;
                 }
 
-                $path_slugs[] = Gm2_Category_Sort_Product_Category_Generator::slugify_segment( $segment );
+                $clean      = preg_replace( '/\s*\([^\)]*\)$/', '', $segment );
+                $path_slugs[] = Gm2_Category_Sort_Product_Category_Generator::slugify_segment( $clean );
                 $slug         = implode( '-', $path_slugs );
 
                 // Previously branch CSVs were only written for categories that

--- a/tests/BranchRulesTest.php
+++ b/tests/BranchRulesTest.php
@@ -93,6 +93,26 @@ class BranchRulesTest extends TestCase {
         $this->assertTrue( $result['data']['branch-leaf']['allow_multi'] );
     }
 
+    public function test_save_rule_for_synonym_branch() {
+        $cat = wp_insert_term('Wheel Simulators','product_cat');
+        update_term_meta($cat['term_id'],'gm2_synonyms','Hubcaps');
+
+        $_POST['nonce'] = 't';
+        $_POST['rules'] = [ 'wheel-simulators' => [ 'include' => '', 'exclude' => '', 'allow_multi' => true ] ];
+
+        Gm2_Category_Sort_Branch_Rules::ajax_save_rules();
+        $saved = get_option('gm2_branch_rules');
+
+        $this->assertTrue( $saved['wheel-simulators']['allow_multi'] );
+
+        $_POST = [ 'nonce' => 't' ];
+        Gm2_Category_Sort_Branch_Rules::ajax_get_rules();
+        $result = $GLOBALS['gm2_json_result'];
+
+        $this->assertTrue( $result['success'] );
+        $this->assertTrue( $result['data']['wheel-simulators']['allow_multi'] );
+    }
+
     public function test_ajax_get_rules_returns_multiple_attributes() {
         $_POST['nonce'] = 't';
         $_POST['rules'] = [

--- a/tests/BranchSlugMapTest.php
+++ b/tests/BranchSlugMapTest.php
@@ -30,4 +30,23 @@ class BranchSlugMapTest extends TestCase {
         $this->assertArrayHasKey('root-branch-leaf', $map);
         $this->assertSame('Root > Branch > Leaf', $map['root-branch-leaf']);
     }
+
+    public function test_synonym_suffix_removed_from_slug() {
+        $root = wp_insert_term('Wheel Simulators','product_cat');
+        update_term_meta($root['term_id'],'gm2_synonyms','Hubcaps');
+
+        $dir = sys_get_temp_dir() . '/gm2_slug_map_syn';
+        if (file_exists($dir)) {
+            foreach (glob("$dir/*") as $f) { unlink($f); }
+            rmdir($dir);
+        }
+
+        Gm2_Category_Sort_Product_Category_Generator::export_category_tree_csv($dir);
+
+        $map = Gm2_Category_Sort_Branch_Rules::build_slug_path_map($dir . '/category-tree.csv');
+
+        $this->assertArrayHasKey('wheel-simulators', $map);
+        $this->assertSame('Wheel Simulators', $map['wheel-simulators']);
+        $this->assertArrayNotHasKey('wheel-simulators-hubcaps', $map);
+    }
 }


### PR DESCRIPTION
## Summary
- strip synonym suffixes when generating branch CSV slugs
- ensure build_slug_path_map ignores synonym text
- test branch slug generation with synonyms
- test saving rules for synonym branches
- document fix in changelog

## Testing
- `composer run test`

------
https://chatgpt.com/codex/tasks/task_e_6857262c80cc8327beedeeb294c6f3cd