### PR TITLE
Fix remove attribute handler

### DIFF
--- a/assets/js/branch-rules.js
+++ b/assets/js/branch-rules.js
@@ -154,7 +154,13 @@ function gatherSelected(container){
 
     form.on('click','.gm2-attr-group .gm2-remove-attr',function(){
         var group=$(this).closest('.gm2-attr-group');
-        group.toggleClass('collapsed');
+        var attr=group.find('select').data('attr');
+        var row=group.closest('tr');
+        var isInc=group.closest('.gm2-include-terms').length>0;
+        var attrSelect=isInc?row.find('.gm2-include-attr'):row.find('.gm2-exclude-attr');
+        group.remove();
+        attrSelect.find('option[value="'+attr+'"]').prop('selected',false);
+        updateSummary(row);
     });
 
     form.on('click','.gm2-remove-tag',function(){


### PR DESCRIPTION
## Summary
- update handler for `.gm2-remove-attr` to actually remove the attribute group

## Testing
- `composer test`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6859ddaa538083278053992613486a52