### PR TITLE
Fix duplicate attribute selections

### DIFF
--- a/assets/js/branch-rules.js
+++ b/assets/js/branch-rules.js
@@ -12,6 +12,7 @@ jQuery(function($){
     }
     
 function renderTerms(container,attrList,selected,collapsedState){
+        attrList = Array.from(new Set(attrList || []));
         container.empty();
         var collapseAll = collapsedState === true;
         var stateByAttr = (typeof collapsedState === 'object' && collapsedState) ? collapsedState : {};


### PR DESCRIPTION
## Summary
- dedupe attributes before rendering term selectors

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859de76d8cc8327a6c0270b0e960283