### PR TITLE
Fix attribute group wrapping

### DIFF
--- a/assets/css/branch-rules.css
+++ b/assets/css/branch-rules.css
@@ -1,7 +1,16 @@
 .gm2-attr-group {
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     margin-bottom: 4px;
+    width: 100%;
+    max-width: 350px;
+    box-sizing: border-box;
+}
+.gm2-attr-group select {
+    flex: 1 1 auto;
+    min-width: 0;
+    width: 100%;
 }
 .gm2-remove-attr {
     cursor: pointer;


### PR DESCRIPTION
## Summary
- limit attribute group width so text wraps within table cells

## Testing
- `npm install`
- `composer install` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859e185417083279037e90c287f82c1