### PR TITLE
Fix attribute group wrapping

### DIFF
--- a/assets/css/branch-rules.css
+++ b/assets/css/branch-rules.css
@@ -1,7 +1,16 @@
 .gm2-attr-group {
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     margin-bottom: 4px;
+    width: 350px;
+    max-width: 100%;
+    box-sizing: border-box;
+}
+.gm2-attr-group select {
+    flex: 1 1 auto;
+    min-width: 0;
+    width: 100%;
 }
 .gm2-remove-attr {
     cursor: pointer;
@@ -26,6 +35,20 @@
 .gm2-remove-attr:hover {
     color: red;
     transform: scale(1.2);
+}
+
+.gm2-include-terms,
+.gm2-exclude-terms {
+    width: 350px;
+    max-width: 100%;
+    box-sizing: border-box;
+}
+
+.gm2-include-tags,
+.gm2-exclude-tags {
+    width: 350px;
+    max-width: 100%;
+    box-sizing: border-box;
 }
 
 .gm2-tag {


### PR DESCRIPTION
## Summary
- limit attribute group width so text wraps within table cells
- keep selected attribute containers within 350px

## Testing
- `npm install`
- `npm run build`
- `composer install` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859e185417083279037e90c287f82c1