### PR TITLE
Improve lug/hole matching logic

### DIFF
--- a/includes/class-product-category-generator.php
+++ b/includes/class-product-category-generator.php
@@ -646,6 +646,13 @@ class Gm2_Category_Sort_Product_Category_Generator {
     /** Lug/Hole configuration branch logic. */
     protected static function check_lug_hole( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [] ) {
         $subset      = self::filter_by_segment( $mapping, 'By Lug/Hole Configuration' );
+
+        if ( strpos( $lower, 'lug' ) === false && strpos( $lower, 'hole' ) === false ) {
+            if ( ! preg_match( '/\b\d+\s*lugs?\b/', $lower ) ) {
+                return [];
+            }
+        }
+
         $candidates  = [];
         $word_count  = count( $words );
         foreach ( $subset as $term => $paths ) {


### PR DESCRIPTION
## Summary
- avoid lug/hole matches when text lacks lug keywords

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_685afd924968832791bf092d52c1681a