### PR TITLE
Fix allow_multi unchecked state

### DIFF
--- a/includes/class-branch-rules.php
+++ b/includes/class-branch-rules.php
@@ -217,7 +217,7 @@ class Gm2_Category_Sort_Branch_Rules {
             $slug    = sanitize_key( $slug );
             $include = sanitize_textarea_field( $rule['include'] ?? '' );
             $exclude = sanitize_textarea_field( $rule['exclude'] ?? '' );
-            $allow_multi = isset( $rule['allow_multi'] ) ? (bool) $rule['allow_multi'] : false;
+            $allow_multi = isset( $rule['allow_multi'] ) ? filter_var( $rule['allow_multi'], FILTER_VALIDATE_BOOLEAN ) : false;
 
             $include_attrs = [];
             if ( isset( $rule['include_attrs'] ) && is_array( $rule['include_attrs'] ) ) {

--- a/tests/BranchRulesTest.php
+++ b/tests/BranchRulesTest.php
@@ -93,6 +93,23 @@ class BranchRulesTest extends TestCase {
         $this->assertTrue( $result['data']['branch-leaf']['allow_multi'] );
     }
 
+    public function test_ajax_save_rules_unchecked_multi() {
+        $_POST['nonce'] = 't';
+        $_POST['rules'] = [ 'branch-leaf' => [ 'include' => '', 'exclude' => '', 'allow_multi' => 'false' ] ];
+
+        Gm2_Category_Sort_Branch_Rules::ajax_save_rules();
+        $saved = get_option( 'gm2_branch_rules' );
+
+        $this->assertFalse( $saved['branch-leaf']['allow_multi'] );
+
+        $_POST = [ 'nonce' => 't' ];
+        Gm2_Category_Sort_Branch_Rules::ajax_get_rules();
+        $result = $GLOBALS['gm2_json_result'];
+
+        $this->assertTrue( $result['success'] );
+        $this->assertFalse( $result['data']['branch-leaf']['allow_multi'] );
+    }
+
     public function test_save_rule_for_synonym_branch() {
         $cat = wp_insert_term('Wheel Simulators','product_cat');
         update_term_meta($cat['term_id'],'gm2_synonyms','Hubcaps');


### PR DESCRIPTION
## Summary
- handle string values when saving `allow_multi` to support JS submission
- add regression test for unchecked "Allow Multiple Leaves" state

## Testing
- `composer install` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b04f3b110832797c2119beae10b62