### PR TITLE
Fix boolean handling for allow_multi

### DIFF
--- a/includes/class-branch-rules.php
+++ b/includes/class-branch-rules.php
@@ -201,7 +201,11 @@ class Gm2_Category_Sort_Branch_Rules {
             $rules = [];
         }
         foreach ( $rules as $slug => $rule ) {
-            $rules[ $slug ]['allow_multi'] = isset( $rule['allow_multi'] ) ? (bool) $rule['allow_multi'] : false;
+            if ( array_key_exists( 'allow_multi', $rule ) ) {
+                $rules[ $slug ]['allow_multi'] = filter_var( $rule['allow_multi'], FILTER_VALIDATE_BOOLEAN );
+            } else {
+                $rules[ $slug ]['allow_multi'] = false;
+            }
         }
         wp_send_json_success( $rules );
     }

--- a/tests/BranchRulesTest.php
+++ b/tests/BranchRulesTest.php
@@ -110,6 +110,19 @@ class BranchRulesTest extends TestCase {
         $this->assertFalse( $result['data']['branch-leaf']['allow_multi'] );
     }
 
+    public function test_ajax_get_rules_handles_string_false() {
+        $GLOBALS['gm2_options']['gm2_branch_rules'] = [
+            'branch-leaf' => [ 'allow_multi' => 'false' ],
+        ];
+
+        $_POST = [ 'nonce' => 't' ];
+        Gm2_Category_Sort_Branch_Rules::ajax_get_rules();
+        $result = $GLOBALS['gm2_json_result'];
+
+        $this->assertTrue( $result['success'] );
+        $this->assertFalse( $result['data']['branch-leaf']['allow_multi'] );
+    }
+
     public function test_save_rule_for_synonym_branch() {
         $cat = wp_insert_term('Wheel Simulators','product_cat');
         update_term_meta($cat['term_id'],'gm2_synonyms','Hubcaps');


### PR DESCRIPTION
## Summary
- sanitize `allow_multi` retrieval using `FILTER_VALIDATE_BOOLEAN`
- test that `'false'` string is interpreted as `false`

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_685b158080f08327b3e343445535570f