### PR TITLE
Fix allow_multi normalization on init

### DIFF
--- a/gm2-category-sort.php
+++ b/gm2-category-sort.php
@@ -37,6 +37,20 @@ function gm2_category_sort_deactivate() {
 // Load after WooCommerce so product CSV tools can access WC classes.
 add_action('plugins_loaded', 'gm2_category_sort_init', 20);
 function gm2_category_sort_init() {
+    $rules   = get_option( 'gm2_branch_rules', [] );
+    $updated = false;
+    if ( is_array( $rules ) ) {
+        foreach ( $rules as $slug => $rule ) {
+            if ( isset( $rule['allow_multi'] ) && is_string( $rule['allow_multi'] ) ) {
+                $rules[ $slug ]['allow_multi'] = filter_var( $rule['allow_multi'], FILTER_VALIDATE_BOOLEAN );
+                $updated = true;
+            }
+        }
+        if ( $updated ) {
+            update_option( 'gm2_branch_rules', $rules );
+        }
+    }
+
     // Check for required plugins
     if (!did_action('elementor/loaded') || !function_exists('WC')) {
         add_action('admin_notices', 'gm2_category_sort_admin_notice');

--- a/tests/InitMigrationTest.php
+++ b/tests/InitMigrationTest.php
@@ -1,0 +1,58 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+if ( ! function_exists( 'plugin_dir_path' ) ) {
+    function plugin_dir_path( $file ) { return dirname( $file ) . '/'; }
+}
+if ( ! function_exists( 'plugin_dir_url' ) ) {
+    function plugin_dir_url( $file ) { return 'http://example.com/' . basename( dirname( $file ) ) . '/'; }
+}
+if ( ! function_exists( 'register_activation_hook' ) ) {
+    function register_activation_hook( $file, $callback ) {}
+}
+if ( ! function_exists( 'register_deactivation_hook' ) ) {
+    function register_deactivation_hook( $file, $callback ) {}
+}
+if ( ! function_exists( 'add_action' ) ) {
+    function add_action( $hook, $callback, $priority = 10, $args = 1 ) {}
+}
+if ( ! function_exists( 'add_filter' ) ) {
+    function add_filter( $hook, $callback, $priority = 10, $args = 1 ) {}
+}
+if ( ! function_exists( 'did_action' ) ) {
+    function did_action( $hook ) { return false; }
+}
+if ( ! function_exists( 'load_plugin_textdomain' ) ) {
+    function load_plugin_textdomain( $domain, $deprecated = false, $path = '' ) {}
+}
+if ( ! function_exists( 'get_option' ) ) {
+    function get_option( $name, $default = false ) { return $GLOBALS['gm2_options'][ $name ] ?? $default; }
+}
+if ( ! function_exists( 'update_option' ) ) {
+    function update_option( $name, $value ) { $GLOBALS['gm2_options'][ $name ] = $value; return true; }
+}
+
+if ( ! defined( 'ABSPATH' ) ) {
+    define( 'ABSPATH', '/' );
+}
+
+require_once __DIR__ . '/../gm2-category-sort.php';
+
+class InitMigrationTest extends TestCase {
+    protected function setUp(): void {
+        $GLOBALS['gm2_options'] = [];
+    }
+
+    public function test_migrates_string_allow_multi() {
+        $GLOBALS['gm2_options']['gm2_branch_rules'] = [
+            'branch' => [ 'allow_multi' => 'true' ],
+            'other'  => [ 'allow_multi' => '0' ],
+        ];
+
+        gm2_category_sort_init();
+
+        $rules = $GLOBALS['gm2_options']['gm2_branch_rules'];
+        $this->assertTrue( $rules['branch']['allow_multi'] );
+        $this->assertFalse( $rules['other']['allow_multi'] );
+    }
+}


### PR DESCRIPTION
## Summary
- normalize `allow_multi` options during `gm2_category_sort_init`
- test migration of `allow_multi` strings to booleans

## Testing
- `php phpunit9.phar --bootstrap tests/bootstrap.php tests/InitMigrationTest.php --debug`


------
https://chatgpt.com/codex/tasks/task_e_685b181b72548327a7a94d4cf4f35ded