### PR TITLE
Respect allow_multi in additional helper branches

### DIFF
--- a/includes/class-product-category-generator.php
+++ b/includes/class-product-category-generator.php
@@ -721,48 +721,48 @@ class Gm2_Category_Sort_Product_Category_Generator {
     }
 
     /** Generic helpers for additional branches. */
-    protected static function check_wheel_type( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [] ) {
-        return self::match_terms( $lower, $words, self::filter_by_segment( $mapping, 'By Wheel Type' ), $fuzzy, $threshold, $attributes );
+    protected static function check_wheel_type( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [], array &$assigned = null, array $branch_rules = [] ) {
+        return self::match_terms( $lower, $words, self::filter_by_segment( $mapping, 'By Wheel Type' ), $fuzzy, $threshold, $attributes, $assigned, $branch_rules );
     }
 
-    protected static function check_set_sizes( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [] ) {
-        return self::match_terms( $lower, $words, self::filter_by_segment( $mapping, 'By Wheel Set Sizes' ), $fuzzy, $threshold, $attributes );
+    protected static function check_set_sizes( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [], array &$assigned = null, array $branch_rules = [] ) {
+        return self::match_terms( $lower, $words, self::filter_by_segment( $mapping, 'By Wheel Set Sizes' ), $fuzzy, $threshold, $attributes, $assigned, $branch_rules );
     }
 
-    protected static function check_fit_type( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [] ) {
-        return self::match_terms( $lower, $words, self::filter_by_segment( $mapping, 'By Fit Type' ), $fuzzy, $threshold, $attributes );
+    protected static function check_fit_type( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [], array &$assigned = null, array $branch_rules = [] ) {
+        return self::match_terms( $lower, $words, self::filter_by_segment( $mapping, 'By Fit Type' ), $fuzzy, $threshold, $attributes, $assigned, $branch_rules );
     }
 
-    protected static function check_vehicle_type( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [] ) {
-        return self::match_terms( $lower, $words, self::filter_by_segment( $mapping, 'By Vehicle Type' ), $fuzzy, $threshold, $attributes );
+    protected static function check_vehicle_type( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [], array &$assigned = null, array $branch_rules = [] ) {
+        return self::match_terms( $lower, $words, self::filter_by_segment( $mapping, 'By Vehicle Type' ), $fuzzy, $threshold, $attributes, $assigned, $branch_rules );
     }
 
-    protected static function check_ring_mount( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [] ) {
-        return self::match_terms( $lower, $words, self::filter_by_segment( $mapping, 'Ring Mount' ), $fuzzy, $threshold, $attributes );
+    protected static function check_ring_mount( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [], array &$assigned = null, array $branch_rules = [] ) {
+        return self::match_terms( $lower, $words, self::filter_by_segment( $mapping, 'Ring Mount' ), $fuzzy, $threshold, $attributes, $assigned, $branch_rules );
     }
 
-    protected static function check_dayton_spoke( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [] ) {
-        return self::match_terms( $lower, $words, self::filter_by_segment( $mapping, 'Dayton Spoke' ), $fuzzy, $threshold, $attributes );
+    protected static function check_dayton_spoke( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [], array &$assigned = null, array $branch_rules = [] ) {
+        return self::match_terms( $lower, $words, self::filter_by_segment( $mapping, 'Dayton Spoke' ), $fuzzy, $threshold, $attributes, $assigned, $branch_rules );
     }
 
-    protected static function check_wheel_center_caps( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [] ) {
-        return self::match_terms( $lower, $words, self::filter_by_segment( $mapping, 'Wheel Center Caps' ), $fuzzy, $threshold, $attributes );
+    protected static function check_wheel_center_caps( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [], array &$assigned = null, array $branch_rules = [] ) {
+        return self::match_terms( $lower, $words, self::filter_by_segment( $mapping, 'Wheel Center Caps' ), $fuzzy, $threshold, $attributes, $assigned, $branch_rules );
     }
 
-    protected static function check_wheel_cover_parts( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [] ) {
-        return self::match_terms( $lower, $words, self::filter_by_segment( $mapping, 'Wheel Cover Parts' ), $fuzzy, $threshold, $attributes );
+    protected static function check_wheel_cover_parts( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [], array &$assigned = null, array $branch_rules = [] ) {
+        return self::match_terms( $lower, $words, self::filter_by_segment( $mapping, 'Wheel Cover Parts' ), $fuzzy, $threshold, $attributes, $assigned, $branch_rules );
     }
 
-    protected static function check_seat_covers( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [] ) {
-        return self::match_terms( $lower, $words, self::filter_by_segment( $mapping, 'Seat Covers' ), $fuzzy, $threshold, $attributes );
+    protected static function check_seat_covers( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [], array &$assigned = null, array $branch_rules = [] ) {
+        return self::match_terms( $lower, $words, self::filter_by_segment( $mapping, 'Seat Covers' ), $fuzzy, $threshold, $attributes, $assigned, $branch_rules );
     }
 
-    protected static function check_coverking_accessories( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [] ) {
-        return self::match_terms( $lower, $words, self::filter_by_segment( $mapping, 'Coverking Accessories' ), $fuzzy, $threshold, $attributes );
+    protected static function check_coverking_accessories( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [], array &$assigned = null, array $branch_rules = [] ) {
+        return self::match_terms( $lower, $words, self::filter_by_segment( $mapping, 'Coverking Accessories' ), $fuzzy, $threshold, $attributes, $assigned, $branch_rules );
     }
 
-    protected static function check_accessories_hardware( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [] ) {
-        return self::match_terms( $lower, $words, self::filter_by_segment( $mapping, 'Accessories & Hardware' ), $fuzzy, $threshold, $attributes );
+    protected static function check_accessories_hardware( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [], array &$assigned = null, array $branch_rules = [] ) {
+        return self::match_terms( $lower, $words, self::filter_by_segment( $mapping, 'Accessories & Hardware' ), $fuzzy, $threshold, $attributes, $assigned, $branch_rules );
     }
 
     protected static function check_brands( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [] ) {
@@ -946,77 +946,77 @@ class Gm2_Category_Sort_Product_Category_Generator {
             }
         }
 
-        $wt = self::check_wheel_type( $lower, $words, $mapping, $fuzzy, $threshold, $attributes );
+        $wt = self::check_wheel_type( $lower, $words, $mapping, $fuzzy, $threshold, $attributes, $assigned, $branch_rules );
         foreach ( $wt as $c ) {
             if ( ! in_array( $c, $cats, true ) ) {
                 $cats[] = $c;
             }
         }
 
-        $ss = self::check_set_sizes( $lower, $words, $mapping, $fuzzy, $threshold, $attributes );
+        $ss = self::check_set_sizes( $lower, $words, $mapping, $fuzzy, $threshold, $attributes, $assigned, $branch_rules );
         foreach ( $ss as $c ) {
             if ( ! in_array( $c, $cats, true ) ) {
                 $cats[] = $c;
             }
         }
 
-        $ft = self::check_fit_type( $lower, $words, $mapping, $fuzzy, $threshold, $attributes );
+        $ft = self::check_fit_type( $lower, $words, $mapping, $fuzzy, $threshold, $attributes, $assigned, $branch_rules );
         foreach ( $ft as $c ) {
             if ( ! in_array( $c, $cats, true ) ) {
                 $cats[] = $c;
             }
         }
 
-        $vt = self::check_vehicle_type( $lower, $words, $mapping, $fuzzy, $threshold, $attributes );
+        $vt = self::check_vehicle_type( $lower, $words, $mapping, $fuzzy, $threshold, $attributes, $assigned, $branch_rules );
         foreach ( $vt as $c ) {
             if ( ! in_array( $c, $cats, true ) ) {
                 $cats[] = $c;
             }
         }
 
-        $rm = self::check_ring_mount( $lower, $words, $mapping, $fuzzy, $threshold, $attributes );
+        $rm = self::check_ring_mount( $lower, $words, $mapping, $fuzzy, $threshold, $attributes, $assigned, $branch_rules );
         foreach ( $rm as $c ) {
             if ( ! in_array( $c, $cats, true ) ) {
                 $cats[] = $c;
             }
         }
 
-        $ds = self::check_dayton_spoke( $lower, $words, $mapping, $fuzzy, $threshold, $attributes );
+        $ds = self::check_dayton_spoke( $lower, $words, $mapping, $fuzzy, $threshold, $attributes, $assigned, $branch_rules );
         foreach ( $ds as $c ) {
             if ( ! in_array( $c, $cats, true ) ) {
                 $cats[] = $c;
             }
         }
 
-        $cap = self::check_wheel_center_caps( $lower, $words, $mapping, $fuzzy, $threshold, $attributes );
+        $cap = self::check_wheel_center_caps( $lower, $words, $mapping, $fuzzy, $threshold, $attributes, $assigned, $branch_rules );
         foreach ( $cap as $c ) {
             if ( ! in_array( $c, $cats, true ) ) {
                 $cats[] = $c;
             }
         }
 
-        $wcp = self::check_wheel_cover_parts( $lower, $words, $mapping, $fuzzy, $threshold, $attributes );
+        $wcp = self::check_wheel_cover_parts( $lower, $words, $mapping, $fuzzy, $threshold, $attributes, $assigned, $branch_rules );
         foreach ( $wcp as $c ) {
             if ( ! in_array( $c, $cats, true ) ) {
                 $cats[] = $c;
             }
         }
 
-        $sc = self::check_seat_covers( $lower, $words, $mapping, $fuzzy, $threshold, $attributes );
+        $sc = self::check_seat_covers( $lower, $words, $mapping, $fuzzy, $threshold, $attributes, $assigned, $branch_rules );
         foreach ( $sc as $c ) {
             if ( ! in_array( $c, $cats, true ) ) {
                 $cats[] = $c;
             }
         }
 
-        $cka = self::check_coverking_accessories( $lower, $words, $mapping, $fuzzy, $threshold, $attributes );
+        $cka = self::check_coverking_accessories( $lower, $words, $mapping, $fuzzy, $threshold, $attributes, $assigned, $branch_rules );
         foreach ( $cka as $c ) {
             if ( ! in_array( $c, $cats, true ) ) {
                 $cats[] = $c;
             }
         }
 
-        $ah = self::check_accessories_hardware( $lower, $words, $mapping, $fuzzy, $threshold, $attributes );
+        $ah = self::check_accessories_hardware( $lower, $words, $mapping, $fuzzy, $threshold, $attributes, $assigned, $branch_rules );
         foreach ( $ah as $c ) {
             if ( ! in_array( $c, $cats, true ) ) {
                 $cats[] = $c;

--- a/tests/ProductCategoryGeneratorTest.php
+++ b/tests/ProductCategoryGeneratorTest.php
@@ -1095,5 +1095,99 @@ class ProductCategoryGeneratorTest extends TestCase {
 
         $this->assertSame( [ 'Branch', 'Leaf1', 'Leaf2' ], $cats );
     }
+
+    public function test_helper_branches_allow_multi_blocks_extra_leaves() {
+        $segments = [
+            'By Wheel Type'        => [ 'TypeA', 'TypeB' ],
+            'By Wheel Set Sizes'   => [ 'SetA', 'SetB' ],
+            'By Fit Type'          => [ 'FitA', 'FitB' ],
+            'By Vehicle Type'      => [ 'VehicleA', 'VehicleB' ],
+            'Ring Mount'           => [ 'RingA', 'RingB' ],
+            'Dayton Spoke'         => [ 'DaytonA', 'DaytonB' ],
+            'Wheel Center Caps'    => [ 'CapA', 'CapB' ],
+            'Wheel Cover Parts'    => [ 'CoverA', 'CoverB' ],
+            'Seat Covers'          => [ 'SeatA', 'SeatB' ],
+            'Coverking Accessories'=> [ 'AccessoryA', 'AccessoryB' ],
+            'Accessories & Hardware'=> [ 'HardwareA', 'HardwareB' ],
+        ];
+
+        foreach ( $segments as $segment => $leaves ) {
+            $parent = wp_insert_term( $segment, 'product_cat' );
+            foreach ( $leaves as $leaf ) {
+                wp_insert_term( $leaf, 'product_cat', [ 'parent' => $parent['term_id'] ] );
+            }
+        }
+
+        $mapping = Gm2_Category_Sort_Product_Category_Generator::build_mapping_from_globals();
+
+        $rules = [];
+        $text_parts = [];
+        foreach ( $segments as $segment => $leaves ) {
+            $slug = Gm2_Category_Sort_Product_Category_Generator::slugify_segment( $segment );
+            $rules[ $slug ] = [ 'allow_multi' => false ];
+            $text_parts = array_merge( $text_parts, $leaves );
+        }
+        $GLOBALS['gm2_options']['gm2_branch_rules'] = $rules;
+
+        $text = implode( ' ', $text_parts );
+        $cats = Gm2_Category_Sort_Product_Category_Generator::assign_categories( $text, $mapping );
+
+        foreach ( $segments as $segment => $leaves ) {
+            $count = 0;
+            foreach ( $leaves as $leaf ) {
+                if ( in_array( $leaf, $cats, true ) ) {
+                    $count++;
+                }
+            }
+            $this->assertSame( 1, $count, $segment );
+        }
+    }
+
+    public function test_helper_branches_allow_multi_allows_multiple_leaves() {
+        $segments = [
+            'By Wheel Type'        => [ 'TypeA', 'TypeB' ],
+            'By Wheel Set Sizes'   => [ 'SetA', 'SetB' ],
+            'By Fit Type'          => [ 'FitA', 'FitB' ],
+            'By Vehicle Type'      => [ 'VehicleA', 'VehicleB' ],
+            'Ring Mount'           => [ 'RingA', 'RingB' ],
+            'Dayton Spoke'         => [ 'DaytonA', 'DaytonB' ],
+            'Wheel Center Caps'    => [ 'CapA', 'CapB' ],
+            'Wheel Cover Parts'    => [ 'CoverA', 'CoverB' ],
+            'Seat Covers'          => [ 'SeatA', 'SeatB' ],
+            'Coverking Accessories'=> [ 'AccessoryA', 'AccessoryB' ],
+            'Accessories & Hardware'=> [ 'HardwareA', 'HardwareB' ],
+        ];
+
+        foreach ( $segments as $segment => $leaves ) {
+            $parent = wp_insert_term( $segment, 'product_cat' );
+            foreach ( $leaves as $leaf ) {
+                wp_insert_term( $leaf, 'product_cat', [ 'parent' => $parent['term_id'] ] );
+            }
+        }
+
+        $mapping = Gm2_Category_Sort_Product_Category_Generator::build_mapping_from_globals();
+
+        $rules = [];
+        $text_parts = [];
+        foreach ( $segments as $segment => $leaves ) {
+            $slug = Gm2_Category_Sort_Product_Category_Generator::slugify_segment( $segment );
+            $rules[ $slug ] = [ 'allow_multi' => true ];
+            $text_parts = array_merge( $text_parts, $leaves );
+        }
+        $GLOBALS['gm2_options']['gm2_branch_rules'] = $rules;
+
+        $text = implode( ' ', $text_parts );
+        $cats = Gm2_Category_Sort_Product_Category_Generator::assign_categories( $text, $mapping );
+
+        foreach ( $segments as $segment => $leaves ) {
+            $count = 0;
+            foreach ( $leaves as $leaf ) {
+                if ( in_array( $leaf, $cats, true ) ) {
+                    $count++;
+                }
+            }
+            $this->assertSame( 2, $count, $segment );
+        }
+    }
 }
 }


### PR DESCRIPTION
## Summary
- forward `$assigned` and `$branch_rules` to wheel-related helper methods
- pass these parameters when helpers are invoked
- test that helper branches respect Allow Multiple Leaves setting

## Testing
- `phpunit -c phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685b1aa51f088327b01a867877fa0a54