### PR TITLE
Add synonym spacing control

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -20,6 +20,7 @@
     --gm2-synonym-icon-hover-bg: var(--gm2-synonym-icon-bg);
     --gm2-synonym-icon-active-size: var(--gm2-synonym-icon-size);
     --gm2-synonym-icon-active-bg: var(--gm2-synonym-icon-bg);
+    --gm2-synonym-below-spacing: 5px;
 }
 /* Full-width tree layout */
 .gm2-category-tree {
@@ -153,7 +154,7 @@
 
 .elementor-widget-gm2-category-sort.gm2-synonym-pos-below .gm2-synonyms-container {
     margin-left: 0;
-    margin-top: 5px;
+    margin-top: var(--gm2-synonym-below-spacing, 5px);
     flex-basis: 100%;
     order: 3;
 }

--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -721,6 +721,23 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
             ],
         ]);
 
+        $this->add_responsive_control('synonym_below_spacing', [
+            'label' => __('Below Spacing', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::SLIDER,
+            'size_units' => ['px'],
+            'range' => [ 'px' => ['min' => 0, 'max' => 50] ],
+            'default' => [
+                'size' => 5,
+                'unit' => 'px',
+            ],
+            'selectors' => [
+                '{{WRAPPER}}' => '--gm2-synonym-below-spacing: {{SIZE}}{{UNIT}};',
+            ],
+            'condition' => [
+                'synonym_position' => 'below',
+            ],
+        ]);
+
         $this->add_control('synonym_icon', [
             'label' => __('Icon', 'gm2-category-sort'),
             'type'  => \Elementor\Controls_Manager::ICONS,


### PR DESCRIPTION
## Summary
- support customizing spacing for synonyms positioned below the category name
- expose a new `synonym_below_spacing` control in Elementor

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_685b2e3ed56c8327949495b3ef6d4d05