### PR TITLE
Fix synonym color styling

### DIFF
--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -654,6 +654,7 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
             'type'  => \Elementor\Controls_Manager::COLOR,
             'selectors' => [
                 '{{WRAPPER}} .gm2-category-synonym' => 'color: {{VALUE}};',
+                '{{WRAPPER}} .gm2-synonyms'        => 'color: {{VALUE}};',
             ],
         ]);
 


### PR DESCRIPTION
## Summary
- update widget to color full synonym display

## Testing
- `composer install` *(fails: command not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b316d79488327a1ecec71ee69c338