### PR TITLE
Fix synonym color CSS

### DIFF
--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -653,8 +653,8 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
             'label' => __('Text Color', 'gm2-category-sort'),
             'type'  => \Elementor\Controls_Manager::COLOR,
             'selectors' => [
-                '{{WRAPPER}} .gm2-category-synonym' => 'color: {{VALUE}};',
-                '{{WRAPPER}} .gm2-synonyms'        => 'color: {{VALUE}};',
+                '{{WRAPPER}} .gm2-category-synonym, {{WRAPPER}} .gm2-category-synonym:visited' => 'color: {{VALUE}};',
+                '{{WRAPPER}} .gm2-synonyms' => 'color: {{VALUE}};',
             ],
         ]);
 


### PR DESCRIPTION
## Summary
- update `synonym_color` control selectors to combine visited styles

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_685b34fdd3a883278bf8ba37e5f2cf14