### PR TITLE
Fix synonym link color states

### DIFF
--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -653,8 +653,8 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
             'label' => __('Text Color', 'gm2-category-sort'),
             'type'  => \Elementor\Controls_Manager::COLOR,
             'selectors' => [
-                '{{WRAPPER}} .gm2-category-synonym, {{WRAPPER}} .gm2-category-synonym:visited' => 'color: {{VALUE}};',
-                '{{WRAPPER}} .gm2-synonyms' => 'color: {{VALUE}};',
+                '{{WRAPPER}} .gm2-category-synonym, {{WRAPPER}} .gm2-category-synonym:link, {{WRAPPER}} .gm2-category-synonym:visited, {{WRAPPER}} .gm2-category-synonym:hover, {{WRAPPER}} .gm2-category-synonym:active' => 'color: {{VALUE}} !important;',
+                '{{WRAPPER}} .gm2-synonyms' => 'color: {{VALUE}} !important;',
             ],
         ]);
 


### PR DESCRIPTION
## Summary
- ensure synonym color applies to all link states and is always enforced

## Testing
- `phpunit -c phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685b39919bac8327bb3b8ebff1d27420