### PR TITLE
Add parent admin menu for GM2 tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ list category names from top to bottom, separated by commas. For example:
 Wheel Simulators,By Brand & Model,Ford Wheel Simulators,F350 Wheel Simulators
 ```
 
-Upload a CSV through **Tools → Import Categories** in the admin area or run
+Upload a CSV through **Gm2 Sort & Filter → Import Categories** in the admin area or run
 `wp gm2-category-sort import &lt;file&gt;` from WP‑CLI. An example file is
 available at `assets/example-categories.csv`.
 
@@ -95,7 +95,7 @@ SKU123,Accessories
 SKU124,Wheel Simulators,By Brand & Model
 ```
 
-Upload a CSV through **Tools → Assign Product Categories** or run
+Upload a CSV through **Gm2 Sort & Filter → Assign Product Categories** or run
 `wp gm2-category-sort assign-categories <file> --overwrite` to replace existing
 categories (omit `--overwrite` to append). An example file is available at
 `assets/example-product-categories.csv`.
@@ -107,11 +107,11 @@ rows. For huge imports consider WP‑CLI which displays a terminal progress bar.
 ## Product CSV Export & Import
 
 All WooCommerce product data can be exported to a CSV file along with any
-assigned categories. Visit **Tools → Export Products** to download the file or
+assigned categories. Visit **Gm2 Sort & Filter → Export Products** to download the file or
 run `wp gm2-category-sort export-products <path>` from WP‑CLI. The CSV matches
 WooCommerce's built‑in format so it can be re‑imported later.
 
-To import product information, open **Tools → Import Products** and upload a
+To import product information, open **Gm2 Sort & Filter → Import Products** and upload a
 CSV created by the exporter (or run `wp gm2-category-sort import-products <file>`
 from WP‑CLI). Existing products are updated when their IDs or SKUs match.
 An example export is provided at `assets/example-products.csv`.
@@ -154,7 +154,7 @@ remove the BOM before reading the headers.
 The plugin can analyze existing products and automatically assign categories
 based on their titles. (Matching on descriptions and attributes has been
 temporarily disabled.) Run the tool from
-**Tools → Auto Assign Categories** in the admin area and choose whether to
+**Gm2 Sort & Filter → Auto Assign Categories** in the admin area and choose whether to
 **Add categories** or **Overwrite categories** before clicking **Start Auto
 Assign**. Use the **Reset All Categories** button to remove every product's
 assigned categories before starting a fresh assignment. A progress bar shows
@@ -186,7 +186,7 @@ exact words being checked.
 ## One Click Categories Assignment
 
 This tool exports the full category tree and individual branch files in one step.
-Open **Tools → One Click Categories Assignment** and click **Study Category Tree**.
+Open **Gm2 Sort & Filter → One Click Categories Assignment** and click **Study Category Tree**.
 The plugin saves `category-tree.csv` plus separate CSVs for every category
 branch under `wp-content/uploads/gm2-category-sort/categories-structure`.
 Use these files to review or modify the structure of specific sections.
@@ -213,7 +213,7 @@ basic stemming so minor wording differences like `lugs` vs `lug`,
 
 ### Branch Rules
 
-Use **Tools → Branch Rules** (requires the `manage_options` capability) to set
+Use **Gm2 Sort & Filter → Branch Rules** (requires the `manage_options` capability) to set
 include and exclude keywords for each category branch. Each rule also provides
 **Include Attributes** and **Exclude Attributes** selectors along with an
 **Allow Multiple Leaves** checkbox. When you run **One

--- a/gm2-category-sort.php
+++ b/gm2-category-sort.php
@@ -16,6 +16,8 @@ define('GM2_CAT_SORT_VERSION', '1.0.16');
 define('GM2_CAT_SORT_PATH', plugin_dir_path(__FILE__));
 define('GM2_CAT_SORT_URL', plugin_dir_url(__FILE__));
 define('GM2_CAT_SORT_CRON_HOOK', 'gm2_category_sort_generate_sitemap');
+// Slug for the top-level admin menu
+define('GM2_CAT_SORT_MENU_SLUG', 'gm2-sort-filter');
 
 register_activation_hook( __FILE__, 'gm2_category_sort_activate' );
 register_deactivation_hook( __FILE__, 'gm2_category_sort_deactivate' );
@@ -31,6 +33,27 @@ function gm2_category_sort_deactivate() {
     if ( $timestamp ) {
         wp_unschedule_event( $timestamp, GM2_CAT_SORT_CRON_HOOK );
     }
+}
+
+// Register top-level admin menu
+add_action( 'admin_menu', 'gm2_category_sort_register_menu' );
+function gm2_category_sort_register_menu() {
+    add_menu_page(
+        __( 'Gm2 Sort & Filter', 'gm2-category-sort' ),
+        __( 'Gm2 Sort & Filter', 'gm2-category-sort' ),
+        'manage_options',
+        GM2_CAT_SORT_MENU_SLUG,
+        'gm2_category_sort_main_page',
+        'dashicons-filter'
+    );
+}
+
+// Default top-level page callback
+function gm2_category_sort_main_page() {
+    echo '<div class="wrap">';
+    echo '<h1>' . esc_html__( 'Gm2 Sort & Filter', 'gm2-category-sort' ) . '</h1>';
+    echo '<p>' . esc_html__( 'Use the submenu links to access the plugin tools.', 'gm2-category-sort' ) . '</p>';
+    echo '</div>';
 }
 
 // Initialize plugin

--- a/includes/class-attribute-fixer.php
+++ b/includes/class-attribute-fixer.php
@@ -15,7 +15,8 @@ class Gm2_Category_Sort_Attribute_Fixer {
      * Register the Tools page.
      */
     public static function register_admin_page() {
-        add_management_page(
+        add_submenu_page(
+            GM2_CAT_SORT_MENU_SLUG,
             __( 'Attributes Fixer', 'gm2-category-sort' ),
             __( 'Attributes Fixer', 'gm2-category-sort' ),
             'manage_options',

--- a/includes/class-auto-assign.php
+++ b/includes/class-auto-assign.php
@@ -30,7 +30,8 @@ class Gm2_Category_Sort_Auto_Assign {
      * Register the Tools page.
      */
     public static function register_admin_page() {
-        add_management_page(
+        add_submenu_page(
+            GM2_CAT_SORT_MENU_SLUG,
             __( 'Auto Assign Categories', 'gm2-category-sort' ),
             __( 'Auto Assign Categories', 'gm2-category-sort' ),
             'manage_options',
@@ -45,7 +46,7 @@ class Gm2_Category_Sort_Auto_Assign {
      * @param string $hook Current admin page hook.
      */
     public static function enqueue_admin_assets( $hook ) {
-        if ( $hook !== 'tools_page_gm2-auto-assign' ) {
+        if ( $hook !== GM2_CAT_SORT_MENU_SLUG . '_page_gm2-auto-assign' ) {
             return;
         }
 

--- a/includes/class-branch-rules.php
+++ b/includes/class-branch-rules.php
@@ -11,7 +11,8 @@ class Gm2_Category_Sort_Branch_Rules {
     }
 
     public static function register_admin_page() {
-        add_management_page(
+        add_submenu_page(
+            GM2_CAT_SORT_MENU_SLUG,
             __( 'Branch Rules', 'gm2-category-sort' ),
             __( 'Branch Rules', 'gm2-category-sort' ),
             'manage_options',
@@ -21,7 +22,7 @@ class Gm2_Category_Sort_Branch_Rules {
     }
 
     public static function enqueue_admin_assets( $hook ) {
-        if ( $hook !== 'tools_page_gm2-branch-rules' ) {
+        if ( $hook !== GM2_CAT_SORT_MENU_SLUG . '_page_gm2-branch-rules' ) {
             return;
         }
 
@@ -419,7 +420,7 @@ class Gm2_Category_Sort_Branch_Rules {
         check_admin_referer( 'gm2_import_branch_rules', 'gm2_import_branch_rules_nonce' );
 
         if ( empty( $_FILES['gm2_branch_rules_file']['tmp_name'] ) ) {
-            $redirect = add_query_arg( 'gm2_import_error', rawurlencode( __( 'No file uploaded.', 'gm2-category-sort' ) ), admin_url( 'tools.php?page=gm2-branch-rules' ) );
+            $redirect = add_query_arg( 'gm2_import_error', rawurlencode( __( 'No file uploaded.', 'gm2-category-sort' ) ), admin_url( 'admin.php?page=gm2-branch-rules' ) );
             wp_safe_redirect( $redirect );
             exit;
         }
@@ -427,13 +428,13 @@ class Gm2_Category_Sort_Branch_Rules {
         $file   = $_FILES['gm2_branch_rules_file']['tmp_name'];
         $result = self::import_from_csv( $file );
         if ( is_wp_error( $result ) ) {
-            $redirect = add_query_arg( 'gm2_import_error', rawurlencode( $result->get_error_message() ), admin_url( 'tools.php?page=gm2-branch-rules' ) );
+            $redirect = add_query_arg( 'gm2_import_error', rawurlencode( $result->get_error_message() ), admin_url( 'admin.php?page=gm2-branch-rules' ) );
             wp_safe_redirect( $redirect );
             exit;
         }
 
         update_option( 'gm2_branch_rules', $result );
-        $redirect = add_query_arg( 'gm2_import_success', '1', admin_url( 'tools.php?page=gm2-branch-rules' ) );
+        $redirect = add_query_arg( 'gm2_import_success', '1', admin_url( 'admin.php?page=gm2-branch-rules' ) );
         wp_safe_redirect( $redirect );
         exit;
     }

--- a/includes/class-category-importer.php
+++ b/includes/class-category-importer.php
@@ -44,7 +44,8 @@ class Gm2_Category_Sort_Category_Importer {
      * Register the admin import page under Tools.
      */
     public static function register_admin_page() {
-        add_management_page(
+        add_submenu_page(
+            GM2_CAT_SORT_MENU_SLUG,
             __( 'Import Categories', 'gm2-category-sort' ),
             __( 'Import Categories', 'gm2-category-sort' ),
             'manage_options',

--- a/includes/class-one-click-assign.php
+++ b/includes/class-one-click-assign.php
@@ -19,7 +19,8 @@ class Gm2_Category_Sort_One_Click_Assign {
      * Register the Tools page.
      */
     public static function register_admin_page() {
-        add_management_page(
+        add_submenu_page(
+            GM2_CAT_SORT_MENU_SLUG,
             __( 'One Click Categories Assignment', 'gm2-category-sort' ),
             __( 'One Click Categories Assignment', 'gm2-category-sort' ),
             'manage_options',
@@ -34,7 +35,7 @@ class Gm2_Category_Sort_One_Click_Assign {
      * @param string $hook Current admin page hook.
      */
     public static function enqueue_admin_assets( $hook ) {
-        if ( $hook !== 'tools_page_gm2-one-click-assign' ) {
+        if ( $hook !== GM2_CAT_SORT_MENU_SLUG . '_page_gm2-one-click-assign' ) {
             return;
         }
 

--- a/includes/class-product-category-importer.php
+++ b/includes/class-product-category-importer.php
@@ -65,7 +65,8 @@ class Gm2_Category_Sort_Product_Category_Importer {
      * Register the admin import page under Tools.
      */
     public static function register_admin_page() {
-        add_management_page(
+        add_submenu_page(
+            GM2_CAT_SORT_MENU_SLUG,
             __( 'Assign Product Categories', 'gm2-category-sort' ),
             __( 'Assign Product Categories', 'gm2-category-sort' ),
             'manage_options',
@@ -262,7 +263,7 @@ class Gm2_Category_Sort_Product_Category_Importer {
      * @param string $hook Current admin page hook.
      */
     public static function enqueue_admin_assets( $hook ) {
-        if ( $hook !== 'tools_page_gm2-product-category-import' ) {
+        if ( $hook !== GM2_CAT_SORT_MENU_SLUG . '_page_gm2-product-category-import' ) {
             return;
         }
 

--- a/includes/class-product-csv.php
+++ b/includes/class-product-csv.php
@@ -25,17 +25,19 @@ class Gm2_Category_Sort_Product_CSV {
     }
 
     /**
-     * Add pages under Tools.
+     * Add pages under the Gm2 Sort & Filter menu.
      */
     public static function register_admin_pages() {
-        add_management_page(
+        add_submenu_page(
+            GM2_CAT_SORT_MENU_SLUG,
             __( 'Export Products', 'gm2-category-sort' ),
             __( 'Export Products', 'gm2-category-sort' ),
             'manage_options',
             'gm2-product-export',
             [ __CLASS__, 'export_page' ]
         );
-        add_management_page(
+        add_submenu_page(
+            GM2_CAT_SORT_MENU_SLUG,
             __( 'Import Products', 'gm2-category-sort' ),
             __( 'Import Products', 'gm2-category-sort' ),
             'manage_options',
@@ -50,7 +52,7 @@ class Gm2_Category_Sort_Product_CSV {
      * @param string $hook Current admin page hook.
      */
     public static function enqueue_admin_assets( $hook ) {
-        if ( $hook !== 'tools_page_gm2-product-export' ) {
+        if ( $hook !== GM2_CAT_SORT_MENU_SLUG . '_page_gm2-product-export' ) {
             return;
         }
 
@@ -96,7 +98,7 @@ class Gm2_Category_Sort_Product_CSV {
             $redirect = add_query_arg(
                 'gm2_export_error',
                 rawurlencode( __( 'Unable to create temporary file.', 'gm2-category-sort' ) ),
-                admin_url( 'tools.php?page=gm2-product-export' )
+                admin_url( 'admin.php?page=gm2-product-export' )
             );
             wp_safe_redirect( $redirect );
             exit;


### PR DESCRIPTION
## Summary
- introduce a `Gm2 Sort & Filter` top‑level admin menu
- register all plugin tools as subpages
- update asset enqueues and redirects for new menu slug
- document new menu location in the README

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862cce7ff408327bfdbe05ac3d3022b