### PR TITLE
Fix README auto assign note

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ remove the BOM before reading the headers.
 ## Auto Assign Categories
 
 The plugin can analyze existing products and automatically assign categories
-based on their titles. (Matching on descriptions and attributes has been
+based on their titles and attributes. (Matching on descriptions has been
 temporarily disabled.) Run the tool from
 **Gm2 Sort & Filter → Auto Assign Categories** in the admin area and choose whether to
 **Add categories** or **Overwrite categories** before clicking **Start Auto


### PR DESCRIPTION
## Summary
- clarify auto assign description in README

## Testing
- `npm install`
- `npm run build`
- `composer test` *(fails: missing PHP extensions)*

------
https://chatgpt.com/codex/tasks/task_e_6862d0507fcc8327a03e0c68afc28b29