### PR TITLE
Sort child categories by saved order

### DIFF
--- a/includes/class-renderer.php
+++ b/includes/class-renderer.php
@@ -71,9 +71,10 @@ class Gm2_Category_Sort_Renderer {
     private function render_category_node($term, $depth) {
         $children = get_terms([
             'taxonomy' => 'product_cat',
-            'parent' => $term->term_id,
+            'parent'    => $term->term_id,
             'hide_empty' => false,
-            'orderby' => 'name'
+            'orderby'   => 'term_order',
+            'order'     => 'ASC',
         ]);
         foreach ($children as $child) {
             if (is_wp_error($child) || !is_object($child)) {


### PR DESCRIPTION
## Summary
- ensure child categories respect the order defined in the admin

## Testing
- `composer install` *(fails: command not found)*
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862d4b0181483279d7d0fbd23ad4fb6