### PR TITLE
Add responsive scroll offset

### DIFF
--- a/assets/dist/frontend.js
+++ b/assets/dist/frontend.js
@@ -76,8 +76,21 @@ jQuery(document).ready(function ($) {
       $target = $('.gm2-category-sort').first();
     }
     if ($target.length) {
+      var $widget = $target.closest('.gm2-category-sort');
+      var offset = parseInt($widget.data('scroll-offset')) || 0;
+      if (window.elementorFrontend && elementorFrontend.config && elementorFrontend.config.breakpoints) {
+        var bp = elementorFrontend.config.breakpoints;
+        var width = window.innerWidth;
+        var offTablet = parseInt($widget.data('scroll-offset-tablet'));
+        var offMobile = parseInt($widget.data('scroll-offset-mobile'));
+        if (width <= bp.md && !isNaN(offMobile)) {
+          offset = offMobile;
+        } else if (width <= bp.lg && !isNaN(offTablet)) {
+          offset = offTablet;
+        }
+      }
       $('html, body').animate({
-        scrollTop: $target.offset().top
+        scrollTop: $target.offset().top - offset
       }, 300);
     }
   }

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -64,7 +64,20 @@ jQuery(document).ready(function($) {
             $target = $('.gm2-category-sort').first();
         }
         if ($target.length) {
-            $('html, body').animate({ scrollTop: $target.offset().top }, 300);
+            const $widget = $target.closest('.gm2-category-sort');
+            let offset = parseInt($widget.data('scroll-offset')) || 0;
+            if (window.elementorFrontend && elementorFrontend.config && elementorFrontend.config.breakpoints) {
+                const bp = elementorFrontend.config.breakpoints;
+                const width = window.innerWidth;
+                const offTablet = parseInt($widget.data('scroll-offset-tablet'));
+                const offMobile = parseInt($widget.data('scroll-offset-mobile'));
+                if (width <= bp.md && !isNaN(offMobile)) {
+                    offset = offMobile;
+                } else if (width <= bp.lg && !isNaN(offTablet)) {
+                    offset = offTablet;
+                }
+            }
+            $('html, body').animate({ scrollTop: $target.offset().top - offset }, 300);
         }
     }
 

--- a/includes/class-renderer.php
+++ b/includes/class-renderer.php
@@ -17,7 +17,10 @@ class Gm2_Category_Sort_Renderer {
              data-filter-type="<?= esc_attr($this->settings['filter_type']) ?>"
              data-simple-operator="<?= esc_attr($this->settings['simple_operator'] ?? 'IN') ?>"
              data-columns="<?= esc_attr(wc_get_loop_prop('columns')) ?>"
-             data-per-page="<?= esc_attr(wc_get_loop_prop('per_page')) ?>">
+             data-per-page="<?= esc_attr(wc_get_loop_prop('per_page')) ?>"
+             data-scroll-offset="<?= esc_attr($this->settings['scroll_offset'] ?? 0) ?>"
+             data-scroll-offset-tablet="<?= esc_attr($this->settings['scroll_offset_tablet'] ?? '') ?>"
+             data-scroll-offset-mobile="<?= esc_attr($this->settings['scroll_offset_mobile'] ?? '') ?>">
              
             <nav class="gm2-category-tree">
                 <?php $this->render_category_tree(); ?>

--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -56,7 +56,14 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
                 'filter_type' => 'simple',
             ],
         ]);
-        
+
+        $this->add_responsive_control('scroll_offset', [
+            'label'       => __('Scroll Offset', 'gm2-category-sort'),
+            'type'        => \Elementor\Controls_Manager::NUMBER,
+            'default'     => 0,
+            'description' => __('Pixels to offset when scrolling to the selected list', 'gm2-category-sort'),
+        ]);
+
         $this->end_controls_section();
         
         // Style Section
@@ -888,6 +895,9 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
             'synonym_icon_position'=> $settings['synonym_icon_position'],
             'expand_icon'          => $settings['expand_icon'],
             'collapse_icon'        => $settings['collapse_icon'],
+            'scroll_offset'        => intval( $settings['scroll_offset'] ),
+            'scroll_offset_tablet' => isset( $settings['scroll_offset_tablet'] ) ? intval( $settings['scroll_offset_tablet'] ) : null,
+            'scroll_offset_mobile' => isset( $settings['scroll_offset_mobile'] ) ? intval( $settings['scroll_offset_mobile'] ) : null,
         ]);
         
         echo $renderer->generate_html();


### PR DESCRIPTION
## Summary
- make scroll offset a responsive control
- expose tablet and mobile values in markup
- adjust scroll function to use breakpoints
- rebuild frontend assets

## Testing
- `npm install`
- `npm run build`
- `php ./vendor/bin/phpunit` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6862da9a44bc832780ad306cb4b17a4a