### PR TITLE
Add selected category widget CSS

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -301,6 +301,24 @@
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 }
 
+/* Styles for the selected category widget */
+.gm2-selected-category-widget {
+    margin-bottom: 30px;
+    border: 1px solid #eaeaea;
+    padding: 20px;
+    border-radius: 5px;
+    background: #ffffff;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+}
+
+.gm2-selected-category-widget .gm2-selected-header {
+    margin-top: 0;
+}
+
+.gm2-selected-category-widget .gm2-selected-categories {
+    margin-top: 15px;
+}
+
 .gm2-selected-header {
     margin-top: 20px;
     font-weight: bold;


### PR DESCRIPTION
## Summary
- style selected-category widget like the main category container
- allow selected header and category list to display inside this widget

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6862e56b882883278d2bfb19a789133b