### PR TITLE
Add Selected Category widget docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Branch rule slugs now include the full category path so rules apply to deep branches.
 - Export and import WooCommerce products via CSV including assigned categories.
 - Allow Multiple Leaves checkbox to enable multi-leaf category assignment per branch.
+- **GM2 Selected Category** widget to display chosen filters with remove icons.
 ### Fixed
 - Product CSV export no longer reports WooCommerce missing when the WC_ABSPATH constant is undefined.
 - Branch and rule slugs remove trailing synonym text to match the product categorizer.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ Gm2 Category Sort adds a product category sorting widget for WooCommerce shops w
 4. Save the page. On the frontend, shoppers can expand categories and filter the product list.
    After each filter update, the page automatically scrolls back to the selected
    categories list so it's easy to refine choices.
+5. Drag the **GM2 Selected Category** widget anywhere on the page to display the
+   currently active categories. Each item includes a remove icon so filters can
+   be cleared individually.
+
+## GM2 Selected Category Widget
+
+This companion widget lists every selected filter from the main **GM2 Category
+Sort** widget. Visitors can remove individual categories from the list to refine
+their search without clearing all filters. Use the **Title** control to change
+the header text and adjust typography, colors and borders under the **Style**
+tab.
 
 ## Styling
 

--- a/gm2-category-sort.php
+++ b/gm2-category-sort.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Gm2 Category Sort
  * Description: Adds a collapsible category filter widget for WooCommerce products in Elementor.
- * Version: 1.0.16
+ * Version: 1.0.17
  * Author: ProjectsGm2
  * Text Domain: gm2-category-sort
  */
@@ -10,7 +10,7 @@
 defined('ABSPATH') || exit;
 
 // Plugin version used for cache busting
-define('GM2_CAT_SORT_VERSION', '1.0.16');
+define('GM2_CAT_SORT_VERSION', '1.0.17');
 
 // Define plugin constants
 define('GM2_CAT_SORT_PATH', plugin_dir_path(__FILE__));


### PR DESCRIPTION
## Summary
- document the GM2 Selected Category widget
- note the widget in the changelog
- bump plugin version constant

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862e69a6d188327bd33f1aeb76379a8