### PR TITLE
Add dynamic visibility for Selected Category widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Export and import WooCommerce products via CSV including assigned categories.
 - Allow Multiple Leaves checkbox to enable multi-leaf category assignment per branch.
 - **GM2 Selected Category** widget to display chosen filters with remove icons.
+- Selected Category widget stays hidden until categories are selected.
 ### Fixed
 - Product CSV export no longer reports WooCommerce missing when the WC_ABSPATH constant is undefined.
 - Branch and rule slugs remove trailing synonym text to match the product categorizer.

--- a/README.md
+++ b/README.md
@@ -23,13 +23,15 @@ Gm2 Category Sort adds a product category sorting widget for WooCommerce shops w
    After each filter update, the page automatically scrolls back to the selected
    categories list so it's easy to refine choices.
 5. Drag the **GM2 Selected Category** widget anywhere on the page to display the
-   currently active categories. Each item includes a remove icon so filters can
-   be cleared individually.
+   currently active categories. The widget stays hidden until at least one
+   category is chosen and disappears again when all selections are cleared. Each
+   item includes a remove icon so filters can be cleared individually.
 
 ## GM2 Selected Category Widget
 
 This companion widget lists every selected filter from the main **GM2 Category
-Sort** widget. Visitors can remove individual categories from the list to refine
+Sort** widget. It only renders when categories are selected so it won’t leave
+empty space. Visitors can remove individual categories from the list to refine
 their search without clearing all filters. Use the **Title** control to change
 the header text and adjust typography, colors and borders under the **Style**
 tab.

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -303,6 +303,7 @@
 
 /* Styles for the selected category widget */
 .gm2-selected-category-widget {
+    display: none;
     margin-bottom: 30px;
     border: 1px solid #eaeaea;
     padding: 20px;

--- a/assets/dist/frontend.js
+++ b/assets/dist/frontend.js
@@ -221,9 +221,11 @@ jQuery(document).ready(function ($) {
       if ($cont.children().length > 0) {
         $head.show();
         $cont.show();
+        $w.show();
       } else {
         $head.hide();
         $cont.hide();
+        $w.hide();
       }
     });
   }

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -224,9 +224,11 @@ jQuery(document).ready(function($) {
             if ($cont.children().length > 0) {
                 $head.show();
                 $cont.show();
+                $w.show();
             } else {
                 $head.hide();
                 $cont.hide();
+                $w.hide();
             }
         });
     }

--- a/gm2-category-sort.php
+++ b/gm2-category-sort.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Gm2 Category Sort
  * Description: Adds a collapsible category filter widget for WooCommerce products in Elementor.
- * Version: 1.0.17
+ * Version: 1.0.18
  * Author: ProjectsGm2
  * Text Domain: gm2-category-sort
  */
@@ -10,7 +10,7 @@
 defined('ABSPATH') || exit;
 
 // Plugin version used for cache busting
-define('GM2_CAT_SORT_VERSION', '1.0.17');
+define('GM2_CAT_SORT_VERSION', '1.0.18');
 
 // Define plugin constants
 define('GM2_CAT_SORT_PATH', plugin_dir_path(__FILE__));

--- a/includes/class-selected-widget.php
+++ b/includes/class-selected-widget.php
@@ -149,7 +149,9 @@ class Gm2_Selected_Category_Widget extends \Elementor\Widget_Base {
         $settings  = $this->get_settings_for_display();
         $selected  = $this->get_selected_categories();
 
-        echo '<div class="gm2-selected-category-widget">';
+        $visible  = ! empty( $selected );
+        $style    = $visible ? ' style="display:block"' : ' style="display:none"';
+        echo '<div class="gm2-selected-category-widget"' . $style . '>'; 
         if ( ! empty( $settings['title'] ) ) {
             echo '<div class="gm2-selected-header">' . esc_html( $settings['title'] ) . '</div>';
         }


### PR DESCRIPTION
## Summary
- hide `.gm2-selected-category-widget` by default and show/hide via JS
- output selected widget with display style based on current selections
- document widget visibility and bump version to 1.0.18

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*
- `./vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6862e110c8a483279a4156f27875e507