### PR TITLE
Add widget box styling controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Allow Multiple Leaves checkbox to enable multi-leaf category assignment per branch.
 - **GM2 Selected Category** widget to display chosen filters with remove icons.
 - Selected Category widget stays hidden until categories are selected.
+- Style controls for the Selected Category widget box including background, border, radius, padding, margin and shadow.
 ### Fixed
 - Product CSV export no longer reports WooCommerce missing when the WC_ABSPATH constant is undefined.
 - Branch and rule slugs remove trailing synonym text to match the product categorizer.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ Sort** widget. It only renders when categories are selected so it won’t leave
 empty space. Visitors can remove individual categories from the list to refine
 their search without clearing all filters. Use the **Title** control to change
 the header text and adjust typography, colors and borders under the **Style**
-tab.
+tab. A **Widget Box** section lets you style the surrounding container with a
+background, border, radius, padding, margin and box shadow so it matches your
+theme.
 
 ## Styling
 

--- a/gm2-category-sort.php
+++ b/gm2-category-sort.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Gm2 Category Sort
  * Description: Adds a collapsible category filter widget for WooCommerce products in Elementor.
- * Version: 1.0.18
+ * Version: 1.0.19
  * Author: ProjectsGm2
  * Text Domain: gm2-category-sort
  */
@@ -10,7 +10,7 @@
 defined('ABSPATH') || exit;
 
 // Plugin version used for cache busting
-define('GM2_CAT_SORT_VERSION', '1.0.18');
+define('GM2_CAT_SORT_VERSION', '1.0.19');
 
 // Define plugin constants
 define('GM2_CAT_SORT_PATH', plugin_dir_path(__FILE__));

--- a/includes/class-selected-widget.php
+++ b/includes/class-selected-widget.php
@@ -56,6 +56,62 @@ class Gm2_Selected_Category_Widget extends \Elementor\Widget_Base {
 
         $this->end_controls_section();
 
+        // Widget Box styles.
+        $this->start_controls_section( 'gm2_widget_box_section', [
+            'label' => __( 'Widget Box', 'gm2-category-sort' ),
+            'tab'   => \Elementor\Controls_Manager::TAB_STYLE,
+        ] );
+
+        $this->add_group_control(
+            \Elementor\Group_Control_Background::get_type(),
+            [
+                'name'     => 'widget_box_bg',
+                'selector' => '{{WRAPPER}} .gm2-selected-category-widget',
+            ]
+        );
+
+        $this->add_group_control(
+            \Elementor\Group_Control_Border::get_type(),
+            [
+                'name'     => 'widget_box_border',
+                'selector' => '{{WRAPPER}} .gm2-selected-category-widget',
+            ]
+        );
+
+        $this->add_responsive_control( 'widget_box_radius', [
+            'label' => __( 'Border Radius', 'gm2-category-sort' ),
+            'type'  => \Elementor\Controls_Manager::DIMENSIONS,
+            'selectors' => [
+                '{{WRAPPER}} .gm2-selected-category-widget' => 'border-radius: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+            ],
+        ] );
+
+        $this->add_group_control(
+            \Elementor\Group_Control_Box_Shadow::get_type(),
+            [
+                'name'     => 'widget_box_shadow',
+                'selector' => '{{WRAPPER}} .gm2-selected-category-widget',
+            ]
+        );
+
+        $this->add_responsive_control( 'widget_box_padding', [
+            'label' => __( 'Padding', 'gm2-category-sort' ),
+            'type'  => \Elementor\Controls_Manager::DIMENSIONS,
+            'selectors' => [
+                '{{WRAPPER}} .gm2-selected-category-widget' => 'padding: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+            ],
+        ] );
+
+        $this->add_responsive_control( 'widget_box_margin', [
+            'label' => __( 'Margin', 'gm2-category-sort' ),
+            'type'  => \Elementor\Controls_Manager::DIMENSIONS,
+            'selectors' => [
+                '{{WRAPPER}} .gm2-selected-category-widget' => 'margin: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+            ],
+        ] );
+
+        $this->end_controls_section();
+
         // Selected Categories styles copied from the main widget.
         $this->start_controls_section( 'gm2_selected_section', [
             'label' => __( 'Selected Categories', 'gm2-category-sort' ),


### PR DESCRIPTION
## Summary
- allow customizing the Selected Category widget box
- document styling options for the Selected Category widget
- note widget box style controls in the changelog
- bump version to 1.0.19

## Testing
- `npm install`
- `composer install` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862f06aa1d48327a920ca74a09f9c9f