### PR TITLE
Add gm2_rows support for per-page calculations

### DIFF
--- a/includes/class-ajax.php
+++ b/includes/class-ajax.php
@@ -16,6 +16,7 @@ class Gm2_Category_Sort_Ajax {
      * - gm2_per_page: number of products per page.
      * - orderby: orderby string for sorting products.
      * - gm2_columns: number of columns in the product loop.
+     * - gm2_rows:    number of rows in the product loop (optional).
      *
      * Sends a JSON response with the rendered product HTML, result count and
      * pagination for the filtered and sorted products.
@@ -60,9 +61,15 @@ class Gm2_Category_Sort_Ajax {
 
         $paged = isset($_POST['gm2_paged']) ? absint($_POST['gm2_paged']) : 1;
 
+        $columns  = isset($_POST['gm2_columns']) ? absint($_POST['gm2_columns']) : 0;
         $per_page = isset($_POST['gm2_per_page']) ? absint($_POST['gm2_per_page']) : 0;
         if (!$per_page) {
-            $per_page = wc_get_loop_prop('per_page');
+            $rows = isset($_POST['gm2_rows']) ? absint($_POST['gm2_rows']) : 0;
+            if ($columns && $rows) {
+                $per_page = $columns * $rows;
+            } else {
+                $per_page = wc_get_loop_prop('per_page');
+            }
         }
 
         $orderby = isset($_POST['orderby']) ? wc_clean($_POST['orderby']) : '';
@@ -81,7 +88,6 @@ class Gm2_Category_Sort_Ajax {
         }
 
         // Respect column settings from the current product archive
-        $columns = isset($_POST['gm2_columns']) ? absint($_POST['gm2_columns']) : 0;
 
         wc_setup_loop([
             'columns'      => $columns ?: wc_get_loop_prop('columns'),

--- a/tests/AjaxFilterTest.php
+++ b/tests/AjaxFilterTest.php
@@ -82,5 +82,48 @@ class AjaxFilterTest extends TestCase {
         preg_match_all('/<li class="product">item<\/li>/', $html, $matches);
         $this->assertCount(6, $matches[0]);
     }
+
+    public function test_uses_rows_and_columns_when_per_page_missing() {
+        wc_setup_loop(['per_page' => 3]);
+
+        $_POST = [
+            'gm2_cat' => '',
+            'gm2_filter_type' => 'simple',
+            'gm2_simple_operator' => 'IN',
+            'gm2_paged' => '1',
+            'gm2_per_page' => 0,
+            'gm2_columns' => 2,
+            'gm2_rows' => 2,
+            'orderby' => '',
+            'gm2_nonce' => 't'
+        ];
+
+        Gm2_Category_Sort_Ajax::filter_products();
+        $this->assertNotNull($GLOBALS['gm2_json_result']);
+        $html = $GLOBALS['gm2_json_result']['data']['html'];
+        preg_match_all('/<li class="product">item<\/li>/', $html, $matches);
+        $this->assertCount(4, $matches[0]);
+    }
+
+    public function test_falls_back_to_loop_per_page_when_rows_missing() {
+        wc_setup_loop(['per_page' => 3]);
+
+        $_POST = [
+            'gm2_cat' => '',
+            'gm2_filter_type' => 'simple',
+            'gm2_simple_operator' => 'IN',
+            'gm2_paged' => '1',
+            'gm2_per_page' => 0,
+            'gm2_columns' => 2,
+            'orderby' => '',
+            'gm2_nonce' => 't'
+        ];
+
+        Gm2_Category_Sort_Ajax::filter_products();
+        $this->assertNotNull($GLOBALS['gm2_json_result']);
+        $html = $GLOBALS['gm2_json_result']['data']['html'];
+        preg_match_all('/<li class="product">item<\/li>/', $html, $matches);
+        $this->assertCount(3, $matches[0]);
+    }
 }
 }


### PR DESCRIPTION
## Summary
- handle optional `gm2_rows` POST parameter when `gm2_per_page` is missing
- add tests for rows/columns logic

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6862fd3fbc508327aee8e1128499b737