### PR TITLE
Fix duplicate scroll_offset renderer option

### DIFF
--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -896,7 +896,6 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
             'expand_icon'          => $settings['expand_icon'],
             'collapse_icon'        => $settings['collapse_icon'],
             'scroll_offset'        => intval( $settings['scroll_offset'] ),
-            'scroll_offset'        => intval( $settings['scroll_offset'] ),
             'scroll_offset_tablet' => isset( $settings['scroll_offset_tablet'] ) ? intval( $settings['scroll_offset_tablet'] ) : null,
             'scroll_offset_mobile' => isset( $settings['scroll_offset_mobile'] ) ? intval( $settings['scroll_offset_mobile'] ) : null,
         ]);


### PR DESCRIPTION
## Summary
- remove duplicate `scroll_offset` value in widget renderer arguments

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6862fe61d11883278b63991c04261cb0