### PR TITLE
Include rows in product filter AJAX requests

### DIFF
--- a/assets/dist/frontend.js
+++ b/assets/dist/frontend.js
@@ -270,6 +270,7 @@ jQuery(document).ready(function ($) {
     var $elementorWidget = $oldList.closest('.elementor-widget');
     var columns = 0;
     var perPage = 0;
+    var rows = 0;
     var settings = $elementorWidget.data('settings');
     if (settings) {
       if (settings.columns) {
@@ -290,10 +291,12 @@ jQuery(document).ready(function ($) {
         columns = parseInt(widgetColumns, 10) || 0;
       }
     }
-    if (!perPage && settings && settings.rows && columns) {
-      var rows = parseInt(settings.rows, 10);
-      if (!isNaN(rows)) {
+    if (!perPage && settings && settings.rows) {
+      rows = parseInt(settings.rows, 10);
+      if (!isNaN(rows) && columns) {
         perPage = rows * columns;
+      } else if (isNaN(rows)) {
+        rows = 0;
       }
     }
     if (!perPage) {
@@ -309,6 +312,7 @@ jQuery(document).ready(function ($) {
       gm2_simple_operator: simpleOperator,
       gm2_columns: columns,
       gm2_per_page: perPage,
+      gm2_rows: rows,
       gm2_paged: page,
       orderby: orderby,
       gm2_nonce: gm2CategorySort.nonce || ''

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -278,6 +278,7 @@ jQuery(document).ready(function($) {
         const $elementorWidget = $oldList.closest('.elementor-widget');
         let columns = 0;
         let perPage = 0;
+        let rows = 0;
 
         const settings = $elementorWidget.data('settings');
         if (settings) {
@@ -302,10 +303,12 @@ jQuery(document).ready(function($) {
             }
         }
 
-        if (!perPage && settings && settings.rows && columns) {
-            const rows = parseInt(settings.rows, 10);
-            if (!isNaN(rows)) {
+        if (!perPage && settings && settings.rows) {
+            rows = parseInt(settings.rows, 10);
+            if (!isNaN(rows) && columns) {
                 perPage = rows * columns;
+            } else if (isNaN(rows)) {
+                rows = 0;
             }
         }
 
@@ -323,6 +326,7 @@ jQuery(document).ready(function($) {
             gm2_simple_operator: simpleOperator,
             gm2_columns: columns,
             gm2_per_page: perPage,
+            gm2_rows: rows,
             gm2_paged: page,
             orderby: orderby,
             gm2_nonce: gm2CategorySort.nonce || ''


### PR DESCRIPTION
## Summary
- send detected row count in `gm2UpdateProductFiltering`
- rebuild production JS

## Testing
- `npm run build`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_686462759eac8327bf3e62eeaa13be4a