### PR TITLE
Add Elementor products widget handling

### DIFF
--- a/assets/dist/frontend.js
+++ b/assets/dist/frontend.js
@@ -329,7 +329,8 @@ jQuery(document).ready(function ($) {
       gm2_rows: rows,
       gm2_paged: page,
       orderby: orderby,
-      gm2_nonce: gm2CategorySort.nonce || ''
+      gm2_nonce: gm2CategorySort.nonce || '',
+      gm2_widget_type: $elementorWidget.data('widget_type') || ''
     };
     if (typeof gm2CategorySort === 'undefined' || !gm2CategorySort.ajax_url) {
       window.location.href = url.toString();

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -345,7 +345,8 @@ jQuery(document).ready(function($) {
             gm2_rows: rows,
             gm2_paged: page,
             orderby: orderby,
-            gm2_nonce: gm2CategorySort.nonce || ''
+            gm2_nonce: gm2CategorySort.nonce || '',
+            gm2_widget_type: $elementorWidget.data('widget_type') || ''
         };
 
         if (typeof gm2CategorySort === 'undefined' || !gm2CategorySort.ajax_url) {


### PR DESCRIPTION
## Summary
- detect Elementor Products widget usage in AJAX filters
- render products through Elementor widget when applicable
- send widget type via JS
- keep wrapper intact in Ajax results
- test Elementor widget rendering

## Testing
- `vendor/bin/phpunit --filter AjaxFilterTest`

------
https://chatgpt.com/codex/tasks/task_e_686466271b10832789c5b583959c2446