### PR TITLE
Add responsive column support

### DIFF
--- a/assets/dist/frontend.js
+++ b/assets/dist/frontend.js
@@ -248,6 +248,22 @@ jQuery(document).ready(function ($) {
     return rows;
   }
   window.gm2GetResponsiveRows = gm2GetResponsiveRows;
+  function gm2GetResponsiveColumns(settings) {
+    if (!settings) return 0;
+    var columns = settings.columns ? parseInt(settings.columns, 10) : 0;
+    if (window.elementorFrontend && elementorFrontend.config && elementorFrontend.config.breakpoints) {
+      var bp = elementorFrontend.config.breakpoints;
+      var width = window.innerWidth;
+      if (width <= bp.md && settings.columns_mobile) {
+        columns = parseInt(settings.columns_mobile, 10);
+      } else if (width <= bp.lg && settings.columns_tablet) {
+        columns = parseInt(settings.columns_tablet, 10);
+      }
+    }
+    if (isNaN(columns)) columns = 0;
+    return columns;
+  }
+  window.gm2GetResponsiveColumns = gm2GetResponsiveColumns;
   function gm2UpdateProductFiltering($widget) {
     var page = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 1;
     var orderby = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : null;
@@ -289,9 +305,7 @@ jQuery(document).ready(function ($) {
     var rows = 0;
     var settings = $elementorWidget.data('settings');
     if (settings) {
-      if (settings.columns) {
-        columns = parseInt(settings.columns, 10) || 0;
-      }
+      columns = gm2GetResponsiveColumns(settings);
       rows = gm2GetResponsiveRows(settings);
       if (rows && columns) {
         perPage = rows * columns;

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -254,6 +254,24 @@ jQuery(document).ready(function($) {
 
     window.gm2GetResponsiveRows = gm2GetResponsiveRows;
 
+    function gm2GetResponsiveColumns(settings) {
+        if (!settings) return 0;
+        let columns = settings.columns ? parseInt(settings.columns, 10) : 0;
+        if (window.elementorFrontend && elementorFrontend.config && elementorFrontend.config.breakpoints) {
+            const bp = elementorFrontend.config.breakpoints;
+            const width = window.innerWidth;
+            if (width <= bp.md && settings.columns_mobile) {
+                columns = parseInt(settings.columns_mobile, 10);
+            } else if (width <= bp.lg && settings.columns_tablet) {
+                columns = parseInt(settings.columns_tablet, 10);
+            }
+        }
+        if (isNaN(columns)) columns = 0;
+        return columns;
+    }
+
+    window.gm2GetResponsiveColumns = gm2GetResponsiveColumns;
+
       function gm2UpdateProductFiltering($widget, page = 1, orderby = null) {
         const selectedIds = [];
         $widget.find('.gm2-category-name.selected').each(function() {
@@ -300,9 +318,7 @@ jQuery(document).ready(function($) {
 
         const settings = $elementorWidget.data('settings');
         if (settings) {
-            if (settings.columns) {
-                columns = parseInt(settings.columns, 10) || 0;
-            }
+            columns = gm2GetResponsiveColumns(settings);
             rows = gm2GetResponsiveRows(settings);
             if (rows && columns) {
                 perPage = rows * columns;

--- a/tests/js/rows.test.js
+++ b/tests/js/rows.test.js
@@ -26,3 +26,28 @@ describe('gm2GetResponsiveRows', () => {
     expect(rows).toBe(3);
   });
 });
+
+describe('gm2GetResponsiveColumns', () => {
+  let window;
+  beforeEach(() => {
+    const dom = new JSDOM('', {runScripts: 'dangerously'});
+    window = dom.window;
+    window.elementorFrontend = {config: {breakpoints: {md: 768, lg: 1024}}};
+    Object.defineProperty(window, 'innerWidth', {writable: true, configurable: true, value: 1200});
+    const src = fs.readFileSync(path.resolve(__dirname, '../../assets/js/frontend.js'), 'utf8');
+    const fnCode = src.match(/function gm2GetResponsiveColumns([\s\S]+?window.gm2GetResponsiveColumns = gm2GetResponsiveColumns;)/);
+    window.eval(fnCode[0]);
+  });
+
+  test('uses mobile columns when width <= md', () => {
+    window.innerWidth = 500;
+    const cols = window.gm2GetResponsiveColumns({columns: 4, columns_tablet: 3, columns_mobile: 2});
+    expect(cols).toBe(2);
+  });
+
+  test('uses tablet columns when width <= lg', () => {
+    window.innerWidth = 800;
+    const cols = window.gm2GetResponsiveColumns({columns: 5, columns_tablet: 3, columns_mobile: 2});
+    expect(cols).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- handle responsive columns in frontend script
- adjust product filtering to use responsive columns
- rebuild frontend assets
- test responsive columns helper

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686473d66ab4832789011d50c57e618d