### PR TITLE
Handle zero per_page with default value

### DIFF
--- a/includes/class-ajax.php
+++ b/includes/class-ajax.php
@@ -69,8 +69,14 @@ class Gm2_Category_Sort_Ajax {
             if ($columns && $rows) {
                 $per_page = $columns * $rows;
             } else {
+                // Fall back to the loop's per_page setting when rows are unknown.
                 $per_page = wc_get_loop_prop('per_page');
             }
+        }
+
+        // If still zero, use the shop default via the woocommerce_products_per_page filter.
+        if ( ! $per_page ) {
+            $per_page = apply_filters( 'woocommerce_products_per_page', 12 );
         }
 
         $orderby = isset($_POST['orderby']) ? wc_clean($_POST['orderby']) : '';


### PR DESCRIPTION
## Summary
- apply default woocommerce per-page when computed value is zero
- stub `apply_filters` in test and reset filter globals
- test per_page=0 falls back to shop setting

## Testing
- `phpunit --configuration phpunit.xml --no-coverage`

------
https://chatgpt.com/codex/tasks/task_e_686474aec8a48327975c0ba3c5b43d9f