### PR TITLE
Improve product list detection

### DIFF
--- a/assets/dist/frontend.js
+++ b/assets/dist/frontend.js
@@ -57,7 +57,29 @@ jQuery(document).ready(function ($) {
   if (!$('#gm2-loading-overlay').length) {
     $('body').append('<div id="gm2-loading-overlay"><div class="gm2-spinner"></div></div>');
   }
-  var $initialList = $('ul.products').first();
+  function gm2FindProductList() {
+    if (window.jQuery) {
+      var $list = $('.elementor-widget[data-widget_type*="products"] ul.products:visible').first();
+      if ($list.length) return $list;
+      $list = $('ul.products:visible').first();
+      if ($list.length) return $list;
+      return $('ul.products').first();
+    }
+    function isVisible(el) {
+      if (!el) return false;
+      var style = el.style || {};
+      return style.display !== 'none' && style.visibility !== 'hidden';
+    }
+    var widgetLists = Array.from(document.querySelectorAll('.elementor-widget[data-widget_type*="products"] ul.products'));
+    var element = widgetLists.find(isVisible);
+    if (!element) {
+      var lists = Array.from(document.querySelectorAll('ul.products'));
+      element = lists.find(isVisible) || lists[0] || null;
+    }
+    return element;
+  }
+  window.gm2FindProductList = gm2FindProductList;
+  var $initialList = gm2FindProductList();
   if ($initialList.length) {
     $initialList.data('original-classes', $initialList.attr('class'));
   }
@@ -298,7 +320,7 @@ jQuery(document).ready(function ($) {
     } else {
       url.searchParams.delete('orderby');
     }
-    var $oldList = $('.products').first();
+    var $oldList = gm2FindProductList();
     var $elementorWidget = $oldList.closest('.elementor-widget');
     var columns = 0;
     var perPage = 0;

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -42,7 +42,31 @@ jQuery(document).ready(function($) {
         $('body').append('<div id="gm2-loading-overlay"><div class="gm2-spinner"></div></div>');
     }
 
-    const $initialList = $('ul.products').first();
+    function gm2FindProductList() {
+        if (window.jQuery) {
+            let $list = $('.elementor-widget[data-widget_type*="products"] ul.products:visible').first();
+            if ($list.length) return $list;
+            $list = $('ul.products:visible').first();
+            if ($list.length) return $list;
+            return $('ul.products').first();
+        }
+        function isVisible(el) {
+            if (!el) return false;
+            const style = el.style || {};
+            return style.display !== 'none' && style.visibility !== 'hidden';
+        }
+        const widgetLists = Array.from(document.querySelectorAll('.elementor-widget[data-widget_type*="products"] ul.products'));
+        let element = widgetLists.find(isVisible);
+        if (!element) {
+            const lists = Array.from(document.querySelectorAll('ul.products'));
+            element = lists.find(isVisible) || lists[0] || null;
+        }
+        return element;
+    }
+
+    window.gm2FindProductList = gm2FindProductList;
+
+    const $initialList = gm2FindProductList();
     if ($initialList.length) {
         $initialList.data('original-classes', $initialList.attr('class'));
     }
@@ -310,7 +334,7 @@ jQuery(document).ready(function($) {
             url.searchParams.delete('orderby');
         }
         
-        const $oldList = $('.products').first();
+        const $oldList = gm2FindProductList();
         const $elementorWidget = $oldList.closest('.elementor-widget');
         let columns = 0;
         let perPage = 0;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@babel/preset-env": "^7.22.10",
         "autoprefixer": "^10.4.16",
         "jest": "^29.7.0",
+        "jquery": "^3.7.1",
         "jsdom": "^24.0.0",
         "postcss-cli": "^10.1.0"
       }
@@ -4927,6 +4928,13 @@
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
+    },
+    "node_modules/jquery": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -11,17 +11,21 @@
     "@babel/core": "^7.22.10",
     "@babel/preset-env": "^7.22.10",
     "autoprefixer": "^10.4.16",
-    "postcss-cli": "^10.1.0",
     "jest": "^29.7.0",
-    "jsdom": "^24.0.0"
+    "jquery": "^3.7.1",
+    "jsdom": "^24.0.0",
+    "postcss-cli": "^10.1.0"
   },
   "babel": {
     "presets": [
-      ["@babel/preset-env", {
-        "targets": {
-          "ie": "11"
+      [
+        "@babel/preset-env",
+        {
+          "targets": {
+            "ie": "11"
+          }
         }
-      }]
+      ]
     ]
   }
 }

--- a/tests/js/productList.test.js
+++ b/tests/js/productList.test.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const path = require('path');
+const {JSDOM} = require('jsdom');
+
+describe('gm2FindProductList', () => {
+  test('prefers visible product list inside widget', () => {
+    const dom = new JSDOM(`
+      <div class="elementor-widget" data-widget_type="products.default">
+        <ul class="products" id="hidden" style="display:none"></ul>
+      </div>
+      <div class="elementor-widget" data-widget_type="products.default">
+        <ul class="products" id="visible"></ul>
+      </div>
+      <ul class="products" id="outside"></ul>
+    `, {runScripts: 'dangerously'});
+    const { window } = dom;
+    const src = fs.readFileSync(path.resolve(__dirname, '../../assets/js/frontend.js'), 'utf8');
+    const fnCode = src.match(/function gm2FindProductList([\s\S]+?window.gm2FindProductList = gm2FindProductList;)/);
+    window.eval(fnCode[0]);
+    const list = window.gm2FindProductList();
+    const element = list && list.nodeType ? list : (list && list.get ? list.get(0) : null);
+    expect(element.id).toBe('visible');
+  });
+});


### PR DESCRIPTION
## Summary
- add robust gm2FindProductList() utility
- use gm2FindProductList() to store original classes and filter products
- include jquery in dev deps for tests
- build frontend assets
- add jest tests for gm2FindProductList

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68647a6fedac8327b2ca02ad01f3ece6