### PR TITLE
Implement gm2FindProductList helper

### DIFF
--- a/assets/dist/frontend.js
+++ b/assets/dist/frontend.js
@@ -57,23 +57,25 @@ jQuery(document).ready(function ($) {
   if (!$('#gm2-loading-overlay').length) {
     $('body').append('<div id="gm2-loading-overlay"><div class="gm2-spinner"></div></div>');
   }
-  function gm2FindProductList() {
+  function gm2FindProductList(root) {
     if (window.jQuery) {
-      var $list = $('.elementor-widget[data-widget_type*="products"] ul.products:visible').first();
+      var $scope = root ? jQuery(root) : jQuery(document);
+      var $list = $scope.find('.elementor-widget[data-widget_type*="products"] ul.products:visible').first();
       if ($list.length) return $list;
-      $list = $('ul.products:visible').first();
+      $list = $scope.find('ul.products:visible').first();
       if ($list.length) return $list;
-      return $('ul.products').first();
+      return $scope.find('ul.products').first();
     }
     function isVisible(el) {
       if (!el) return false;
       var style = el.style || {};
       return style.display !== 'none' && style.visibility !== 'hidden';
     }
-    var widgetLists = Array.from(document.querySelectorAll('.elementor-widget[data-widget_type*="products"] ul.products'));
+    var scope = root || document;
+    var widgetLists = Array.from(scope.querySelectorAll('.elementor-widget[data-widget_type*="products"] ul.products'));
     var element = widgetLists.find(isVisible);
     if (!element) {
-      var lists = Array.from(document.querySelectorAll('ul.products'));
+      var lists = Array.from(scope.querySelectorAll('ul.products'));
       element = lists.find(isVisible) || lists[0] || null;
     }
     return element;
@@ -384,10 +386,7 @@ jQuery(document).ready(function ($) {
       if (response && response.success) {
         var html = response.data && response.data.html ? response.data.html : '';
         var $response = $(html);
-        var $newList = $response.filter('ul.products').first();
-        if (!$newList.length) {
-          $newList = $response.find('ul.products').first();
-        }
+        var $newList = $(gm2FindProductList($response));
         if (!$newList.length) {
           var message = $response.filter('.woocommerce-info').first().text();
           gm2DisplayNoProducts($oldList, url, message);

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -42,23 +42,25 @@ jQuery(document).ready(function($) {
         $('body').append('<div id="gm2-loading-overlay"><div class="gm2-spinner"></div></div>');
     }
 
-    function gm2FindProductList() {
+    function gm2FindProductList(root) {
         if (window.jQuery) {
-            let $list = $('.elementor-widget[data-widget_type*="products"] ul.products:visible').first();
+            const $scope = root ? jQuery(root) : jQuery(document);
+            let $list = $scope.find('.elementor-widget[data-widget_type*="products"] ul.products:visible').first();
             if ($list.length) return $list;
-            $list = $('ul.products:visible').first();
+            $list = $scope.find('ul.products:visible').first();
             if ($list.length) return $list;
-            return $('ul.products').first();
+            return $scope.find('ul.products').first();
         }
         function isVisible(el) {
             if (!el) return false;
             const style = el.style || {};
             return style.display !== 'none' && style.visibility !== 'hidden';
         }
-        const widgetLists = Array.from(document.querySelectorAll('.elementor-widget[data-widget_type*="products"] ul.products'));
+        const scope = root || document;
+        const widgetLists = Array.from(scope.querySelectorAll('.elementor-widget[data-widget_type*="products"] ul.products'));
         let element = widgetLists.find(isVisible);
         if (!element) {
-            const lists = Array.from(document.querySelectorAll('ul.products'));
+            const lists = Array.from(scope.querySelectorAll('ul.products'));
             element = lists.find(isVisible) || lists[0] || null;
         }
         return element;
@@ -406,10 +408,7 @@ jQuery(document).ready(function($) {
             if (response && response.success) {
                 const html = response.data && response.data.html ? response.data.html : '';
                 const $response = $(html);
-                let $newList = $response.filter('ul.products').first();
-                if (!$newList.length) {
-                    $newList = $response.find('ul.products').first();
-                }
+                let $newList = $(gm2FindProductList($response));
                 if (!$newList.length) {
                     let message = $response.filter('.woocommerce-info').first().text();
                     gm2DisplayNoProducts($oldList, url, message);

--- a/tests/js/gm2FindProductList.test.js
+++ b/tests/js/gm2FindProductList.test.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('gm2FindProductList helper', () => {
+  test('selects the visible product list', () => {
+    const dom = new JSDOM(`
+      <ul class="products" id="first" style="display:none"></ul>
+      <ul class="products" id="visible"></ul>
+      <ul class="products" id="last"></ul>
+    `, { runScripts: 'dangerously' });
+    const { window } = dom;
+    const src = fs.readFileSync(path.resolve(__dirname, '../../assets/js/frontend.js'), 'utf8');
+    const fnCode = src.match(/function gm2FindProductList([\s\S]+?window.gm2FindProductList = gm2FindProductList;)/);
+    window.eval(fnCode[0]);
+    const list = window.gm2FindProductList();
+    const element = list && list.nodeType ? list : (list && list.get ? list.get(0) : null);
+    expect(element.id).toBe('visible');
+  });
+});


### PR DESCRIPTION
## Summary
- add flexible `gm2FindProductList` helper that works with arbitrary DOM scopes
- replace hard‑coded list detection in filtering code
- regenerate frontend distribution file
- add unit test for `gm2FindProductList`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68647d04959c832781921b0f89f54ed0