### PR TITLE
Fix tax_query reset for category filters

### DIFF
--- a/includes/class-query-handler.php
+++ b/includes/class-query-handler.php
@@ -24,14 +24,18 @@ class Gm2_Category_Sort_Query_Handler {
         
         // Get existing tax query
         $tax_query = $query->get('tax_query') ?: [];
-        
-        // Remove any existing product_cat queries to prevent conflicts
-        foreach ($tax_query as $index => $tax) {
-            if ($tax['taxonomy'] === 'product_cat') {
-                unset($tax_query[$index]);
+
+        // Preserve the relation while removing existing product_cat queries
+        $relation  = isset($tax_query['relation']) ? $tax_query['relation'] : 'AND';
+        $filtered  = ['relation' => $relation];
+
+        foreach ($tax_query as $tax) {
+            if (is_array($tax) && isset($tax['taxonomy']) && $tax['taxonomy'] !== 'product_cat') {
+                $filtered[] = $tax;
             }
         }
-        $tax_query = array_values($tax_query); // Reindex array
+
+        $tax_query = $filtered;
         
         if ($filter_type === 'advanced') {
             // Advanced logic: Custom logic based on your requirements


### PR DESCRIPTION
## Summary
- preserve `relation` when cleaning tax_query

## Testing
- `php -l includes/class-query-handler.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686480c1854c8327ab626707ebee71da