### PR TITLE
Handle nearest widget actions

### DIFF
--- a/assets/dist/frontend.js
+++ b/assets/dist/frontend.js
@@ -91,13 +91,24 @@ jQuery(document).ready(function ($) {
   function gm2HideLoading() {
     $('#gm2-loading-overlay').removeClass('gm2-visible');
   }
-  function gm2ScrollToSelectedSection() {
-    var $target = $('.gm2-selected-header:visible').first();
-    if (!$target.length) {
-      $target = $('.gm2-selected-categories:visible').first();
-    }
-    if (!$target.length) {
-      $target = $('.gm2-category-sort').first();
+  function gm2ScrollToSelectedSection($root) {
+    var $target;
+    if ($root && $root.length) {
+      $target = $root.find('.gm2-selected-header:visible').first();
+      if (!$target.length) {
+        $target = $root.find('.gm2-selected-categories:visible').first();
+      }
+      if (!$target.length) {
+        $target = $root.first();
+      }
+    } else {
+      $target = $('.gm2-selected-header:visible').first();
+      if (!$target.length) {
+        $target = $('.gm2-selected-categories:visible').first();
+      }
+      if (!$target.length) {
+        $target = $('.gm2-category-sort').first();
+      }
     }
     if ($target.length) {
       var $widget = $target.closest('.gm2-category-sort');
@@ -204,7 +215,7 @@ jQuery(document).ready(function ($) {
     $('.gm2-category-sort').each(function () {
       gm2RefreshSelectedList($(this));
     });
-    var $widget = $('.gm2-category-sort').first();
+    var $widget = $(this).closest('.gm2-category-sort');
     gm2UpdateProductFiltering($widget, 1);
   }
   function gm2RefreshSelectedList($widget) {
@@ -442,7 +453,7 @@ jQuery(document).ready(function ($) {
       gm2DisplayNoProducts($oldList, url);
     }).always(function () {
       gm2HideLoading();
-      gm2ScrollToSelectedSection();
+      gm2ScrollToSelectedSection($widget);
     });
   }
   function gm2ReinitArchiveWidget($list) {
@@ -485,14 +496,14 @@ jQuery(document).ready(function ($) {
         page = 1;
       }
     }
-    var $widget = $('.gm2-category-sort').first();
+    var $widget = $(this).closest('.gm2-category-sort');
     gm2UpdateProductFiltering($widget, page);
     return false;
   });
   $(document).on('change', '.woocommerce-ordering select.orderby', function (e) {
     e.preventDefault();
     var val = $(this).val();
-    var $widget = $('.gm2-category-sort').first();
+    var $widget = $(this).closest('.gm2-category-sort');
     gm2UpdateProductFiltering($widget, 1, val);
   });
   $(document).on('submit', 'form.woocommerce-ordering', function (e) {

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -81,13 +81,24 @@ jQuery(document).ready(function($) {
         $('#gm2-loading-overlay').removeClass('gm2-visible');
     }
   
-    function gm2ScrollToSelectedSection() {
-        let $target = $('.gm2-selected-header:visible').first();
-        if (!$target.length) {
-            $target = $('.gm2-selected-categories:visible').first();
-        }
-        if (!$target.length) {
-            $target = $('.gm2-category-sort').first();
+    function gm2ScrollToSelectedSection($root) {
+        let $target;
+        if ($root && $root.length) {
+            $target = $root.find('.gm2-selected-header:visible').first();
+            if (!$target.length) {
+                $target = $root.find('.gm2-selected-categories:visible').first();
+            }
+            if (!$target.length) {
+                $target = $root.first();
+            }
+        } else {
+            $target = $('.gm2-selected-header:visible').first();
+            if (!$target.length) {
+                $target = $('.gm2-selected-categories:visible').first();
+            }
+            if (!$target.length) {
+                $target = $('.gm2-category-sort').first();
+            }
         }
         if ($target.length) {
             const $widget = $target.closest('.gm2-category-sort');
@@ -203,7 +214,7 @@ jQuery(document).ready(function($) {
             gm2RefreshSelectedList($(this));
         });
 
-        const $widget = $('.gm2-category-sort').first();
+        const $widget = $(this).closest('.gm2-category-sort');
         gm2UpdateProductFiltering($widget, 1);
     }
 
@@ -472,7 +483,7 @@ jQuery(document).ready(function($) {
             gm2DisplayNoProducts($oldList, url);
         }).always(function() {
             gm2HideLoading();
-            gm2ScrollToSelectedSection();
+            gm2ScrollToSelectedSection($widget);
         });
     }
 
@@ -524,7 +535,7 @@ jQuery(document).ready(function($) {
                 page = 1;
             }
         }
-        const $widget = $('.gm2-category-sort').first();
+        const $widget = $(this).closest('.gm2-category-sort');
         gm2UpdateProductFiltering($widget, page);
         return false;
     });
@@ -532,7 +543,7 @@ jQuery(document).ready(function($) {
     $(document).on('change', '.woocommerce-ordering select.orderby', function(e) {
         e.preventDefault();
         const val = $(this).val();
-        const $widget = $('.gm2-category-sort').first();
+        const $widget = $(this).closest('.gm2-category-sort');
         gm2UpdateProductFiltering($widget, 1, val);
     });
 

--- a/tests/js/widgetHandlers.test.js
+++ b/tests/js/widgetHandlers.test.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('frontend handlers use closest widget', () => {
+  const src = fs.readFileSync(path.resolve(__dirname, '../../assets/js/frontend.js'), 'utf8');
+
+  test('gm2HandleRemoveClick uses closest widget', () => {
+    const match = src.match(/function gm2HandleRemoveClick[\s\S]*?\$widget = \$\(this\)\.closest\('\.gm2-category-sort'\)/);
+    expect(match).not.toBeNull();
+  });
+
+  test('pagination click handler uses closest widget', () => {
+    const regex = /\.woocommerce-pagination a'[\s\S]*?\$widget = \$\(this\)\.closest\('\.gm2-category-sort'\)/;
+    expect(regex.test(src)).toBe(true);
+  });
+
+  test('orderby change handler uses closest widget', () => {
+    const regex = /\.woocommerce-ordering select\.orderby'[\s\S]*?\$widget = \$\(this\)\.closest\('\.gm2-category-sort'\)/;
+    expect(regex.test(src)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- refine scroll helper to accept root widget
- trigger category removal, pagination and order updates on the closest widget
- rebuild compiled frontend JS
- verify handlers via tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68648f2135648327a0cf6517b0548274