### PR TITLE
Fix responsive columns fallback

### DIFF
--- a/assets/dist/frontend.js
+++ b/assets/dist/frontend.js
@@ -350,7 +350,7 @@ jQuery(document).ready(function ($) {
     }
     var originalClasses = $oldList.data('original-classes') || $oldList.attr('class');
     var match = originalClasses.match(/columns-(\d+)/);
-    if (match) {
+    if (match && !columns) {
       columns = parseInt(match[1], 10);
     }
     if (!columns) {

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -366,7 +366,7 @@ jQuery(document).ready(function($) {
 
         const originalClasses = $oldList.data('original-classes') || $oldList.attr('class');
         const match = originalClasses.match(/columns-(\d+)/);
-        if (match) {
+        if (match && !columns) {
             columns = parseInt(match[1], 10);
         }
 

--- a/tests/js/rows.test.js
+++ b/tests/js/rows.test.js
@@ -51,3 +51,12 @@ describe('gm2GetResponsiveColumns', () => {
     expect(cols).toBe(3);
   });
 });
+
+describe('gm2UpdateProductFiltering', () => {
+  test('fallback to original classes only when columns is zero', () => {
+    const src = fs.readFileSync(path.resolve(__dirname, '../../assets/js/frontend.js'), 'utf8');
+    const fnCode = src.match(/function gm2UpdateProductFiltering([\s\S]+?)function gm2ReinitArchiveWidget/);
+    expect(fnCode).not.toBeNull();
+    expect(fnCode[0]).toMatch(/match && !columns/);
+  });
+});


### PR DESCRIPTION
## Summary
- fix column detection to only use original classes when columns are zero
- rebuild frontend assets
- add regression test for gm2UpdateProductFiltering

## Testing
- `npm test`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6864952f9fe483278d6f5b75973594ff