### PR TITLE
Add rows fallback logic

### DIFF
--- a/assets/dist/frontend.js
+++ b/assets/dist/frontend.js
@@ -81,6 +81,21 @@ jQuery(document).ready(function ($) {
     return element;
   }
   window.gm2FindProductList = gm2FindProductList;
+  function gm2GetListRows(root) {
+    var list = gm2FindProductList(root);
+    if (!list) return 0;
+    var rows = 0;
+    if (window.jQuery) {
+      var $list = jQuery(list);
+      rows = parseInt($list.data('rows'), 10);
+    } else if (list.getAttribute) {
+      var attr = list.getAttribute('data-rows');
+      rows = attr ? parseInt(attr, 10) : 0;
+    }
+    if (isNaN(rows)) rows = 0;
+    return rows;
+  }
+  window.gm2GetListRows = gm2GetListRows;
   var $initialList = gm2FindProductList();
   if ($initialList.length) {
     $initialList.data('original-classes', $initialList.attr('class'));
@@ -348,6 +363,9 @@ jQuery(document).ready(function ($) {
         perPage = parseInt(settings.posts_per_page, 10) || 0;
       }
     }
+    if (!rows) {
+      rows = gm2GetListRows($oldList);
+    }
     var originalClasses = $oldList.data('original-classes') || $oldList.attr('class');
     var match = originalClasses.match(/columns-(\d+)/);
     if (match && !columns) {
@@ -359,7 +377,7 @@ jQuery(document).ready(function ($) {
         columns = parseInt(widgetColumns, 10) || 0;
       }
     }
-    if (!perPage && settings && rows) {
+    if (!perPage && rows && columns) {
       perPage = rows * columns;
     }
     if (!perPage) {

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -68,6 +68,23 @@ jQuery(document).ready(function($) {
 
     window.gm2FindProductList = gm2FindProductList;
 
+    function gm2GetListRows(root) {
+        const list = gm2FindProductList(root);
+        if (!list) return 0;
+        let rows = 0;
+        if (window.jQuery) {
+            const $list = jQuery(list);
+            rows = parseInt($list.data('rows'), 10);
+        } else if (list.getAttribute) {
+            const attr = list.getAttribute('data-rows');
+            rows = attr ? parseInt(attr, 10) : 0;
+        }
+        if (isNaN(rows)) rows = 0;
+        return rows;
+    }
+
+    window.gm2GetListRows = gm2GetListRows;
+
     const $initialList = gm2FindProductList();
     if ($initialList.length) {
         $initialList.data('original-classes', $initialList.attr('class'));
@@ -364,6 +381,10 @@ jQuery(document).ready(function($) {
             }
         }
 
+        if (!rows) {
+            rows = gm2GetListRows($oldList);
+        }
+
         const originalClasses = $oldList.data('original-classes') || $oldList.attr('class');
         const match = originalClasses.match(/columns-(\d+)/);
         if (match && !columns) {
@@ -377,7 +398,7 @@ jQuery(document).ready(function($) {
             }
         }
 
-        if (!perPage && settings && rows) {
+        if (!perPage && rows && columns) {
             perPage = rows * columns;
         }
 

--- a/tests/js/listRows.test.js
+++ b/tests/js/listRows.test.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('gm2GetListRows fallback', () => {
+  test('reads rows from product list when data-settings missing', () => {
+    const dom = new JSDOM(`
+      <div class="elementor-widget">
+        <ul class="products" data-rows="3"></ul>
+      </div>
+    `, { runScripts: 'dangerously' });
+    const { window } = dom;
+    const src = fs.readFileSync(path.resolve(__dirname, '../../assets/js/frontend.js'), 'utf8');
+    const findCode = src.match(/function gm2FindProductList([\s\S]+?window.gm2FindProductList = gm2FindProductList;)/);
+    const rowsCode = src.match(/function gm2GetListRows([\s\S]+?window.gm2GetListRows = gm2GetListRows;)/);
+    window.eval(findCode[0]);
+    window.eval(rowsCode[0]);
+    const widget = window.document.querySelector('.elementor-widget');
+    const rows = window.gm2GetListRows(widget);
+    expect(rows).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- read `data-rows` on product list via new `gm2GetListRows` helper
- fallback to `gm2GetListRows` in `gm2UpdateProductFiltering`
- rebuild distribution file
- test `gm2GetListRows` when widget settings are missing

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68649742321c832799deaf4a50c5347b