### PR TITLE
Fix product list fallback search

### DIFF
--- a/assets/dist/frontend.js
+++ b/assets/dist/frontend.js
@@ -58,27 +58,34 @@ jQuery(document).ready(function ($) {
     $('body').append('<div id="gm2-loading-overlay"><div class="gm2-spinner"></div></div>');
   }
   function gm2FindProductList(root) {
-    if (window.jQuery) {
-      var $scope = root ? jQuery(root) : jQuery(document);
-      var $list = $scope.find('.elementor-widget[data-widget_type*="products"] ul.products:visible').first();
-      if ($list.length) return $list;
-      $list = $scope.find('ul.products:visible').first();
-      if ($list.length) return $list;
-      return $scope.find('ul.products').first();
+    function search(scope) {
+      if (window.jQuery) {
+        var $list = jQuery(scope).find('.elementor-widget[data-widget_type*="products"] ul.products:visible').first();
+        if ($list.length) return $list;
+        $list = jQuery(scope).find('ul.products:visible').first();
+        if ($list.length) return $list;
+        return jQuery(scope).find('ul.products').first();
+      }
+      function isVisible(el) {
+        if (!el) return false;
+        var style = el.style || {};
+        return style.display !== 'none' && style.visibility !== 'hidden';
+      }
+      var widgetLists = Array.from(scope.querySelectorAll('.elementor-widget[data-widget_type*="products"] ul.products'));
+      var element = widgetLists.find(isVisible);
+      if (!element) {
+        var lists = Array.from(scope.querySelectorAll('ul.products'));
+        element = lists.find(isVisible) || lists[0] || null;
+      }
+      return element;
     }
-    function isVisible(el) {
-      if (!el) return false;
-      var style = el.style || {};
-      return style.display !== 'none' && style.visibility !== 'hidden';
+    if (root) {
+      var found = search(root);
+      if (found && (found.length ? found.length : found)) {
+        return found;
+      }
     }
-    var scope = root || document;
-    var widgetLists = Array.from(scope.querySelectorAll('.elementor-widget[data-widget_type*="products"] ul.products'));
-    var element = widgetLists.find(isVisible);
-    if (!element) {
-      var lists = Array.from(scope.querySelectorAll('ul.products'));
-      element = lists.find(isVisible) || lists[0] || null;
-    }
-    return element;
+    return search(document);
   }
   window.gm2FindProductList = gm2FindProductList;
   function gm2GetListRows(root) {

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -43,27 +43,35 @@ jQuery(document).ready(function($) {
     }
 
     function gm2FindProductList(root) {
-        if (window.jQuery) {
-            const $scope = root ? jQuery(root) : jQuery(document);
-            let $list = $scope.find('.elementor-widget[data-widget_type*="products"] ul.products:visible').first();
-            if ($list.length) return $list;
-            $list = $scope.find('ul.products:visible').first();
-            if ($list.length) return $list;
-            return $scope.find('ul.products').first();
+        function search(scope) {
+            if (window.jQuery) {
+                let $list = jQuery(scope).find('.elementor-widget[data-widget_type*="products"] ul.products:visible').first();
+                if ($list.length) return $list;
+                $list = jQuery(scope).find('ul.products:visible').first();
+                if ($list.length) return $list;
+                return jQuery(scope).find('ul.products').first();
+            }
+            function isVisible(el) {
+                if (!el) return false;
+                const style = el.style || {};
+                return style.display !== 'none' && style.visibility !== 'hidden';
+            }
+            const widgetLists = Array.from(scope.querySelectorAll('.elementor-widget[data-widget_type*="products"] ul.products'));
+            let element = widgetLists.find(isVisible);
+            if (!element) {
+                const lists = Array.from(scope.querySelectorAll('ul.products'));
+                element = lists.find(isVisible) || lists[0] || null;
+            }
+            return element;
         }
-        function isVisible(el) {
-            if (!el) return false;
-            const style = el.style || {};
-            return style.display !== 'none' && style.visibility !== 'hidden';
+
+        if (root) {
+            const found = search(root);
+            if (found && (found.length ? found.length : found)) {
+                return found;
+            }
         }
-        const scope = root || document;
-        const widgetLists = Array.from(scope.querySelectorAll('.elementor-widget[data-widget_type*="products"] ul.products'));
-        let element = widgetLists.find(isVisible);
-        if (!element) {
-            const lists = Array.from(scope.querySelectorAll('ul.products'));
-            element = lists.find(isVisible) || lists[0] || null;
-        }
-        return element;
+        return search(document);
     }
 
     window.gm2FindProductList = gm2FindProductList;

--- a/tests/js/gm2FindProductList.test.js
+++ b/tests/js/gm2FindProductList.test.js
@@ -17,4 +17,19 @@ describe('gm2FindProductList helper', () => {
     const element = list && list.nodeType ? list : (list && list.get ? list.get(0) : null);
     expect(element.id).toBe('visible');
   });
+
+  test('falls back to document when widget has no list', () => {
+    const dom = new JSDOM(`
+      <div id="filter" class="gm2-category-sort"></div>
+      <ul class="products" id="main"></ul>
+    `, { runScripts: 'dangerously' });
+    const { window } = dom;
+    const src = fs.readFileSync(path.resolve(__dirname, '../../assets/js/frontend.js'), 'utf8');
+    const fnCode = src.match(/function gm2FindProductList([\s\S]+?window.gm2FindProductList = gm2FindProductList;)/);
+    window.eval(fnCode[0]);
+    const widget = window.document.getElementById('filter');
+    const list = window.gm2FindProductList(widget);
+    const element = list && list.nodeType ? list : (list && list.get ? list.get(0) : null);
+    expect(element.id).toBe('main');
+  });
 });


### PR DESCRIPTION
## Summary
- improve gm2FindProductList so it searches the page when the widget doesn't contain a list
- regenerate frontend.js bundle
- test gm2FindProductList fallback logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862f1c0a02c8327abc5465446212caa