### PR TITLE
Improve product list row detection

### DIFF
--- a/assets/dist/frontend.js
+++ b/assets/dist/frontend.js
@@ -95,9 +95,54 @@ jQuery(document).ready(function ($) {
     if (window.jQuery) {
       var $list = jQuery(list);
       rows = parseInt($list.data('rows'), 10);
+      if (!rows) {
+        var $widget = $list.closest('.elementor-widget');
+        var settings = $widget.data('settings') || {};
+        if (settings.rows) {
+          rows = parseInt(settings.rows, 10);
+        }
+        if (!rows) {
+          var columns = gm2GetResponsiveColumns(settings);
+          if (!columns) {
+            columns = parseInt($list.data('columns'), 10) || 0;
+          }
+          var count = $list.children('li').length;
+          if (columns) {
+            rows = Math.ceil(count / columns);
+          }
+        }
+      }
     } else if (list.getAttribute) {
       var attr = list.getAttribute('data-rows');
       rows = attr ? parseInt(attr, 10) : 0;
+      if (!rows) {
+        var widget = list.closest ? list.closest('.elementor-widget') : null;
+        var _settings = {};
+        if (widget) {
+          var sattr = widget.getAttribute('data-settings');
+          if (sattr) {
+            try {
+              _settings = JSON.parse(sattr);
+            } catch (e) {
+              _settings = {};
+            }
+          }
+        }
+        if (_settings.rows) {
+          rows = parseInt(_settings.rows, 10);
+        }
+        if (!rows) {
+          var _columns = gm2GetResponsiveColumns(_settings);
+          if (!_columns) {
+            var cAttr = list.getAttribute('data-columns');
+            if (cAttr) _columns = parseInt(cAttr, 10) || 0;
+          }
+          var _count = list.querySelectorAll('li').length;
+          if (_columns) {
+            rows = Math.ceil(_count / _columns);
+          }
+        }
+      }
     }
     if (isNaN(rows)) rows = 0;
     return rows;
@@ -370,8 +415,9 @@ jQuery(document).ready(function ($) {
         perPage = parseInt(settings.posts_per_page, 10) || 0;
       }
     }
+    var gm2Rows = gm2GetListRows($oldList);
     if (!rows) {
-      rows = gm2GetListRows($oldList);
+      rows = gm2Rows;
     }
     var originalClasses = $oldList.data('original-classes') || $oldList.attr('class');
     var match = originalClasses.match(/columns-(\d+)/);
@@ -400,7 +446,7 @@ jQuery(document).ready(function ($) {
       gm2_simple_operator: simpleOperator,
       gm2_columns: columns,
       gm2_per_page: perPage,
-      gm2_rows: rows,
+      gm2_rows: gm2Rows,
       gm2_paged: page,
       orderby: orderby,
       gm2_nonce: gm2CategorySort.nonce || '',

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -83,9 +83,50 @@ jQuery(document).ready(function($) {
         if (window.jQuery) {
             const $list = jQuery(list);
             rows = parseInt($list.data('rows'), 10);
+            if (!rows) {
+                const $widget = $list.closest('.elementor-widget');
+                const settings = $widget.data('settings') || {};
+                if (settings.rows) {
+                    rows = parseInt(settings.rows, 10);
+                }
+                if (!rows) {
+                    let columns = gm2GetResponsiveColumns(settings);
+                    if (!columns) {
+                        columns = parseInt($list.data('columns'), 10) || 0;
+                    }
+                    const count = $list.children('li').length;
+                    if (columns) {
+                        rows = Math.ceil(count / columns);
+                    }
+                }
+            }
         } else if (list.getAttribute) {
             const attr = list.getAttribute('data-rows');
             rows = attr ? parseInt(attr, 10) : 0;
+            if (!rows) {
+                const widget = list.closest ? list.closest('.elementor-widget') : null;
+                let settings = {};
+                if (widget) {
+                    const sattr = widget.getAttribute('data-settings');
+                    if (sattr) {
+                        try { settings = JSON.parse(sattr); } catch (e) { settings = {}; }
+                    }
+                }
+                if (settings.rows) {
+                    rows = parseInt(settings.rows, 10);
+                }
+                if (!rows) {
+                    let columns = gm2GetResponsiveColumns(settings);
+                    if (!columns) {
+                        const cAttr = list.getAttribute('data-columns');
+                        if (cAttr) columns = parseInt(cAttr, 10) || 0;
+                    }
+                    const count = list.querySelectorAll('li').length;
+                    if (columns) {
+                        rows = Math.ceil(count / columns);
+                    }
+                }
+            }
         }
         if (isNaN(rows)) rows = 0;
         return rows;
@@ -389,8 +430,9 @@ jQuery(document).ready(function($) {
             }
         }
 
+        const gm2Rows = gm2GetListRows($oldList);
         if (!rows) {
-            rows = gm2GetListRows($oldList);
+            rows = gm2Rows;
         }
 
         const originalClasses = $oldList.data('original-classes') || $oldList.attr('class');
@@ -424,7 +466,7 @@ jQuery(document).ready(function($) {
             gm2_simple_operator: simpleOperator,
             gm2_columns: columns,
             gm2_per_page: perPage,
-            gm2_rows: rows,
+            gm2_rows: gm2Rows,
             gm2_paged: page,
             orderby: orderby,
             gm2_nonce: gm2CategorySort.nonce || '',

--- a/tests/js/listRows.test.js
+++ b/tests/js/listRows.test.js
@@ -19,4 +19,26 @@ describe('gm2GetListRows fallback', () => {
     const rows = window.gm2GetListRows(widget);
     expect(rows).toBe(3);
   });
+
+  test('calculates rows from column count when attribute absent', () => {
+    const dom = new JSDOM(`
+      <div class="elementor-widget" data-settings='{"columns":3}'>
+        <ul class="products">
+          <li></li><li></li><li></li><li></li><li></li><li></li><li></li>
+        </ul>
+      </div>
+    `, { runScripts: 'dangerously' });
+    const { window } = dom;
+    const src = fs.readFileSync(path.resolve(__dirname, '../../assets/js/frontend.js'), 'utf8');
+    const findCode = src.match(/function gm2FindProductList([\s\S]+?window.gm2FindProductList = gm2FindProductList;)/);
+    const rowsCode = src.match(/function gm2GetListRows([\s\S]+?window.gm2GetListRows = gm2GetListRows;)/);
+    const colsCode = src.match(/function gm2GetResponsiveColumns([\s\S]+?window.gm2GetResponsiveColumns = gm2GetResponsiveColumns;)/);
+    window.elementorFrontend = {config: {breakpoints: {md: 768, lg: 1024}}};
+    window.eval(findCode[0]);
+    window.eval(rowsCode[0]);
+    window.eval(colsCode[0]);
+    const widget = window.document.querySelector('.elementor-widget');
+    const rows = window.gm2GetListRows(widget);
+    expect(rows).toBe(3);
+  });
 });


### PR DESCRIPTION
## Summary
- improve fallback logic for detecting rows in frontend helper
- always send detected row count when filtering products
- rebuild dist scripts
- add tests for new row detection logic

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6864a65d020483279b2850aa411ebc2f