### PR TITLE
Respect rows for per-page logic

### DIFF
--- a/assets/dist/frontend.js
+++ b/assets/dist/frontend.js
@@ -403,22 +403,17 @@ jQuery(document).ready(function ($) {
     var $oldList = gm2FindProductList($widget);
     var $elementorWidget = $oldList.closest('.elementor-widget');
     var columns = 0;
-    var perPage = 0;
     var rows = 0;
     var settings = $elementorWidget.data('settings');
     if (settings) {
       columns = gm2GetResponsiveColumns(settings);
       rows = gm2GetResponsiveRows(settings);
-      if (rows && columns) {
-        perPage = rows * columns;
-      } else if (settings.posts_per_page) {
-        perPage = parseInt(settings.posts_per_page, 10) || 0;
-      }
     }
     var gm2Rows = gm2GetListRows($oldList);
     if (!rows) {
       rows = gm2Rows;
     }
+    var perPage = 0;
     var originalClasses = $oldList.data('original-classes') || $oldList.attr('class');
     var match = originalClasses.match(/columns-(\d+)/);
     if (match && !columns) {
@@ -430,10 +425,13 @@ jQuery(document).ready(function ($) {
         columns = parseInt(widgetColumns, 10) || 0;
       }
     }
-    if (!perPage && rows && columns) {
+    if (rows && columns) {
       perPage = rows * columns;
     }
-    if (!perPage) {
+    if (!perPage && settings && settings.posts_per_page) {
+      perPage = parseInt(settings.posts_per_page, 10) || 0;
+    }
+    if (!perPage && !rows) {
       var widgetPerPage = $widget.data('per-page');
       if (widgetPerPage) {
         perPage = parseInt(widgetPerPage, 10) || 0;

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -416,24 +416,20 @@ jQuery(document).ready(function($) {
         const $oldList = gm2FindProductList($widget);
         const $elementorWidget = $oldList.closest('.elementor-widget');
         let columns = 0;
-        let perPage = 0;
         let rows = 0;
 
         const settings = $elementorWidget.data('settings');
         if (settings) {
             columns = gm2GetResponsiveColumns(settings);
             rows = gm2GetResponsiveRows(settings);
-            if (rows && columns) {
-                perPage = rows * columns;
-            } else if (settings.posts_per_page) {
-                perPage = parseInt(settings.posts_per_page, 10) || 0;
-            }
         }
 
         const gm2Rows = gm2GetListRows($oldList);
         if (!rows) {
             rows = gm2Rows;
         }
+
+        let perPage = 0;
 
         const originalClasses = $oldList.data('original-classes') || $oldList.attr('class');
         const match = originalClasses.match(/columns-(\d+)/);
@@ -448,11 +444,15 @@ jQuery(document).ready(function($) {
             }
         }
 
-        if (!perPage && rows && columns) {
+        if (rows && columns) {
             perPage = rows * columns;
         }
 
-        if (!perPage) {
+        if (!perPage && settings && settings.posts_per_page) {
+            perPage = parseInt(settings.posts_per_page, 10) || 0;
+        }
+
+        if (!perPage && !rows) {
             const widgetPerPage = $widget.data('per-page');
             if (widgetPerPage) {
                 perPage = parseInt(widgetPerPage, 10) || 0;

--- a/tests/js/rows.test.js
+++ b/tests/js/rows.test.js
@@ -59,4 +59,22 @@ describe('gm2UpdateProductFiltering', () => {
     expect(fnCode).not.toBeNull();
     expect(fnCode[0]).toMatch(/match && !columns/);
   });
+
+  test('uses rows and columns before posts_per_page', () => {
+    const src = fs.readFileSync(path.resolve(__dirname, '../../assets/js/frontend.js'), 'utf8');
+    const fnCode = src.match(/function gm2UpdateProductFiltering([\s\S]+?)\n(?=\s*function gm2ReinitArchiveWidget)/);
+    expect(fnCode).not.toBeNull();
+    const code = fnCode[0];
+    const idxRowsCols = code.indexOf('perPage = rows * columns');
+    const idxPostsPer = code.indexOf('settings.posts_per_page');
+    expect(idxRowsCols).toBeGreaterThan(-1);
+    expect(idxPostsPer).toBeGreaterThan(idxRowsCols);
+  });
+
+  test('widget per-page only used when rows unavailable', () => {
+    const src = fs.readFileSync(path.resolve(__dirname, '../../assets/js/frontend.js'), 'utf8');
+    const fnCode = src.match(/function gm2UpdateProductFiltering([\s\S]+?)\n(?=\s*function gm2ReinitArchiveWidget)/);
+    expect(fnCode).not.toBeNull();
+    expect(fnCode[0]).toMatch(/!perPage && !rows[\s\S]*\.data\('per-page'\)/);
+  });
 });


### PR DESCRIPTION
## Summary
- compute perPage from responsive rows and columns whenever possible
- only fall back to widget `data-per-page` when rows are missing
- rebuild distribution script
- test precedence in JS unit tests

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6864aa2e5eb083279bd7ca0480bdb502