### PR TITLE
Add responsive spacing controls to Selected widget

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -303,6 +303,7 @@
 
 .gm2-selected-header {
     margin-top: 20px;
+    margin-bottom: 0;
     font-weight: bold;
     padding-bottom: 10px;
     border-bottom: 1px solid #eee;
@@ -311,6 +312,7 @@
 
 .gm2-selected-categories {
     margin-top: 15px;
+    margin-bottom: 0;
     display: flex;
     flex-wrap: wrap;
     gap: 10px;

--- a/includes/class-selected-widget.php
+++ b/includes/class-selected-widget.php
@@ -54,6 +54,20 @@ class Gm2_Selected_Category_Widget extends \Elementor\Widget_Base {
             ],
         ] );
 
+        $this->add_responsive_control( 'title_spacing', [
+            'label' => __( 'Bottom Spacing', 'gm2-category-sort' ),
+            'type'  => \Elementor\Controls_Manager::SLIDER,
+            'size_units' => [ 'px' ],
+            'range' => [ 'px' => [ 'min' => 0, 'max' => 100 ] ],
+            'default' => [
+                'size' => 0,
+                'unit' => 'px',
+            ],
+            'selectors' => [
+                '{{WRAPPER}} .gm2-selected-header' => 'margin-bottom: {{SIZE}}{{UNIT}};',
+            ],
+        ] );
+
         $this->end_controls_section();
 
         // Selected Categories styles copied from the main widget.
@@ -139,6 +153,34 @@ class Gm2_Selected_Category_Widget extends \Elementor\Widget_Base {
             'type'  => \Elementor\Controls_Manager::COLOR,
             'selectors' => [
                 '{{WRAPPER}} .gm2-remove-category:hover' => 'color: {{VALUE}};',
+            ],
+        ] );
+
+        $this->add_responsive_control( 'selected_spacing_top', [
+            'label' => __( 'Top Spacing', 'gm2-category-sort' ),
+            'type'  => \Elementor\Controls_Manager::SLIDER,
+            'size_units' => [ 'px' ],
+            'range' => [ 'px' => [ 'min' => 0, 'max' => 100 ] ],
+            'default' => [
+                'size' => 15,
+                'unit' => 'px',
+            ],
+            'selectors' => [
+                '{{WRAPPER}} .gm2-selected-categories' => 'margin-top: {{SIZE}}{{UNIT}};',
+            ],
+        ] );
+
+        $this->add_responsive_control( 'selected_spacing_bottom', [
+            'label' => __( 'Bottom Spacing', 'gm2-category-sort' ),
+            'type'  => \Elementor\Controls_Manager::SLIDER,
+            'size_units' => [ 'px' ],
+            'range' => [ 'px' => [ 'min' => 0, 'max' => 100 ] ],
+            'default' => [
+                'size' => 0,
+                'unit' => 'px',
+            ],
+            'selectors' => [
+                '{{WRAPPER}} .gm2-selected-categories' => 'margin-bottom: {{SIZE}}{{UNIT}};',
             ],
         ] );
 


### PR DESCRIPTION
## Summary
- add bottom spacing option for the selected categories widget title
- allow top and bottom spacing customization for the selected categories list
- define default margins in CSS for cleaner overrides

## Testing
- `npm install`
- `composer install` *(fails: ext-dom missing initially, installed php-xml)*
- `composer test` *(fails: 3 errors, 11 failures)*

------
https://chatgpt.com/codex/tasks/task_e_6864bcb49db88327bc71babb5ce36e22