### PR TITLE
Fix reset to shop when clearing filters on category page

### DIFF
--- a/assets/dist/frontend.js
+++ b/assets/dist/frontend.js
@@ -235,6 +235,7 @@ jQuery(document).ready(function ($) {
     $widget.find('.gm2-category-name.selected').each(function () {
       selectedIds.push($(this).data('term-id'));
     });
+    var currentCat = parseInt($widget.data('current-cat')) || 0;
     var url = gm2CreateURL(window.location.href);
     if (!orderby) {
       orderby = $('.woocommerce-ordering select.orderby').first().val() || '';
@@ -301,7 +302,8 @@ jQuery(document).ready(function ($) {
       gm2_per_page: perPage,
       gm2_paged: page,
       orderby: orderby,
-      gm2_nonce: gm2CategorySort.nonce || ''
+      gm2_nonce: gm2CategorySort.nonce || '',
+      gm2_current_cat: currentCat
     };
     if (typeof gm2CategorySort === 'undefined' || !gm2CategorySort.ajax_url) {
       window.location.href = url.toString();

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -238,6 +238,7 @@ jQuery(document).ready(function($) {
         $widget.find('.gm2-category-name.selected').each(function() {
             selectedIds.push($(this).data('term-id'));
         });
+        const currentCat = parseInt($widget.data('current-cat')) || 0;
         
         const url = gm2CreateURL(window.location.href);
         if (!orderby) {
@@ -315,7 +316,8 @@ jQuery(document).ready(function($) {
             gm2_per_page: perPage,
             gm2_paged: page,
             orderby: orderby,
-            gm2_nonce: gm2CategorySort.nonce || ''
+            gm2_nonce: gm2CategorySort.nonce || '',
+            gm2_current_cat: currentCat
         };
 
         if (typeof gm2CategorySort === 'undefined' || !gm2CategorySort.ajax_url) {

--- a/includes/class-ajax.php
+++ b/includes/class-ajax.php
@@ -25,18 +25,24 @@ class Gm2_Category_Sort_Ajax {
     public static function filter_products() {
         check_ajax_referer('gm2_filter_products', 'gm2_nonce');
 
-        $term_ids = [];
-        if (!empty($_POST['gm2_cat'])) {
-            $term_ids = array_map('intval', explode(',', $_POST['gm2_cat']));
+        $term_ids   = [];
+        if ( ! empty( $_POST['gm2_cat'] ) ) {
+            $term_ids = array_map( 'intval', explode( ',', $_POST['gm2_cat'] ) );
         }
 
-        // When no categories are selected on a product category page,
-        // default to the current category so the results match the
-        // archive context instead of returning all products.
-        if (empty($term_ids) && function_exists('is_product_category') && is_product_category()) {
-            $current = get_queried_object();
-            if ($current && isset($current->term_id)) {
-                $term_ids = [ (int) $current->term_id ];
+        $current_cat = ! empty( $_POST['gm2_current_cat'] ) ? absint( $_POST['gm2_current_cat'] ) : 0;
+
+        // When no categories are selected and a current category was
+        // provided, use that to limit the results. Fallback to the
+        // queried object for front end requests when possible.
+        if ( empty( $term_ids ) ) {
+            if ( $current_cat ) {
+                $term_ids = [ $current_cat ];
+            } elseif ( function_exists( 'is_product_category' ) && is_product_category() ) {
+                $current = get_queried_object();
+                if ( $current && isset( $current->term_id ) ) {
+                    $term_ids = [ (int) $current->term_id ];
+                }
             }
         }
         $filter_type = sanitize_key($_POST['gm2_filter_type'] ?? 'simple');

--- a/includes/class-renderer.php
+++ b/includes/class-renderer.php
@@ -20,7 +20,17 @@ class Gm2_Category_Sort_Renderer {
              data-per-page="<?= esc_attr(wc_get_loop_prop('per_page')) ?>"
              data-scroll-offset="<?= esc_attr($this->settings['scroll_offset'] ?? 0) ?>"
              data-scroll-offset-tablet="<?= esc_attr($this->settings['scroll_offset_tablet'] ?? '') ?>"
-             data-scroll-offset-mobile="<?= esc_attr($this->settings['scroll_offset_mobile'] ?? '') ?>">
+             data-scroll-offset-mobile="<?= esc_attr($this->settings['scroll_offset_mobile'] ?? '') ?>"
+             data-current-cat="<?php
+                $current = 0;
+                if ( is_product_category() ) {
+                    $obj = get_queried_object();
+                    if ( $obj && isset( $obj->term_id ) ) {
+                        $current = (int) $obj->term_id;
+                    }
+                }
+                echo esc_attr( $current );
+            ?>">
 
             <nav class="gm2-category-tree">
                 <?php $this->render_category_tree(); ?>


### PR DESCRIPTION
## Summary
- preserve archive category when no subcategory is selected
- send current category id with AJAX requests

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6864d4a4486c8327a9e27d44f22387ca