### PR TITLE
Add title option to GM2 Category Sort widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Gm2 Category Sort adds a product category sorting widget for WooCommerce shops w
 ## Usage
 1. Edit a WooCommerce shop or archive page with Elementor.
 2. Search for the **GM2 Category Sort** widget and drag it into your layout.
-3. Choose optional parent categories and select the filter logic (Simple or Advanced) in the widget settings.
+3. Enter an optional title, choose parent categories and select the filter logic (Simple or Advanced) in the widget settings.
 4. Save the page. On the frontend, shoppers can expand categories and filter the product list.
    After each filter update, the page automatically scrolls back to the selected
    categories list so it's easy to refine choices.
@@ -28,6 +28,8 @@ Gm2 Category Sort adds a product category sorting widget for WooCommerce shops w
 The **Widget Box** section styles the outer `.gm2-category-sort` container. Set
 a background, border, radius and box shadow here so the widget blends with your
 theme.
+
+The **Title** panel customizes the heading displayed above the category tree. Typography, colour and spacing controls match those of the Selected Categories widget.
 
 The **Layout** panel switches the entire widget between block and inline
 display. Selecting **Inline** adds the `gm2-display-inline` class to

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -301,6 +301,13 @@
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 }
 
+.gm2-widget-title {
+    margin-top: 0;
+    margin-bottom: 10px;
+    font-weight: bold;
+    font-size: 18px;
+}
+
 .gm2-selected-header {
     margin-top: 20px;
     margin-bottom: 0;

--- a/includes/class-renderer.php
+++ b/includes/class-renderer.php
@@ -20,8 +20,8 @@ class Gm2_Category_Sort_Renderer {
              data-per-page="<?= esc_attr(wc_get_loop_prop('per_page')) ?>"
              data-scroll-offset="<?= esc_attr($this->settings['scroll_offset'] ?? 0) ?>"
              data-scroll-offset-tablet="<?= esc_attr($this->settings['scroll_offset_tablet'] ?? '') ?>"
-             data-scroll-offset-mobile="<?= esc_attr($this->settings['scroll_offset_mobile'] ?? '') ?>"
-             data-current-cat="<?php
+            data-scroll-offset-mobile="<?= esc_attr($this->settings['scroll_offset_mobile'] ?? '') ?>"
+            data-current-cat="<?php
                 $current = 0;
                 if ( is_product_category() ) {
                     $obj = get_queried_object();
@@ -31,6 +31,12 @@ class Gm2_Category_Sort_Renderer {
                 }
                 echo esc_attr( $current );
             ?>">
+
+            <?php if ( ! empty( $this->settings['title'] ) ) : ?>
+                <div class="gm2-widget-title">
+                    <?= esc_html( $this->settings['title'] ); ?>
+                </div>
+            <?php endif; ?>
 
             <nav class="gm2-category-tree">
                 <?php $this->render_category_tree(); ?>

--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -23,6 +23,13 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
             'label' => __('Settings', 'gm2-category-sort'),
             'tab' => \Elementor\Controls_Manager::TAB_CONTENT,
         ]);
+
+        $this->add_control('title', [
+            'label'       => __('Title', 'gm2-category-sort'),
+            'type'        => \Elementor\Controls_Manager::TEXT,
+            'default'     => __('Filter Categories', 'gm2-category-sort'),
+            'label_block' => true,
+        ]);
         
         $this->add_control('parent_categories', [
             'label' => __('Parent Categories', 'gm2-category-sort'),
@@ -62,6 +69,44 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
             'type'        => \Elementor\Controls_Manager::NUMBER,
             'default'     => 0,
             'description' => __('Pixels to offset when scrolling to the selected list', 'gm2-category-sort'),
+        ]);
+
+        $this->end_controls_section();
+
+        // Title styles
+        $this->start_controls_section('gm2_title_style_section', [
+            'label' => __('Title', 'gm2-category-sort'),
+            'tab'   => \Elementor\Controls_Manager::TAB_STYLE,
+        ]);
+
+        $this->add_group_control(
+            \Elementor\Group_Control_Typography::get_type(),
+            [
+                'name'     => 'title_typography',
+                'selector' => '{{WRAPPER}} .gm2-widget-title',
+            ]
+        );
+
+        $this->add_control('title_color', [
+            'label' => __('Color', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::COLOR,
+            'selectors' => [
+                '{{WRAPPER}} .gm2-widget-title' => 'color: {{VALUE}};',
+            ],
+        ]);
+
+        $this->add_responsive_control('title_spacing', [
+            'label' => __('Bottom Spacing', 'gm2-category-sort'),
+            'type'  => \Elementor\Controls_Manager::SLIDER,
+            'size_units' => [ 'px' ],
+            'range' => [ 'px' => [ 'min' => 0, 'max' => 100 ] ],
+            'default' => [
+                'size' => 0,
+                'unit' => 'px',
+            ],
+            'selectors' => [
+                '{{WRAPPER}} .gm2-widget-title' => 'margin-bottom: {{SIZE}}{{UNIT}};',
+            ],
         ]);
 
         $this->end_controls_section();
@@ -891,6 +936,7 @@ class Gm2_Category_Sort_Widget extends \Elementor\Widget_Base {
             'filter_type'          => $settings['filter_type'],
             'simple_operator'      => $settings['simple_operator'],
             'widget_id'            => $this->get_id(),
+            'title'                => $settings['title'],
             'synonym_icon'         => $settings['synonym_icon'],
             'synonym_icon_position'=> $settings['synonym_icon_position'],
             'expand_icon'          => $settings['expand_icon'],


### PR DESCRIPTION
## Summary
- enable setting a title for the Category Sort widget
- provide typography, colour and spacing controls for the title
- render the new title in the widget output
- document the new option in the README

## Testing
- `composer install` *(fails: command not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686542b4a4b08327a0fb24f8dcfc0858