### PR TITLE
Avoid matching single-digit synonyms

### DIFF
--- a/includes/class-auto-assign.php
+++ b/includes/class-auto-assign.php
@@ -215,6 +215,10 @@ class Gm2_Category_Sort_Auto_Assign {
             }
             $terms_list = array_merge( [ $name ], array_filter( array_map( 'trim', explode( ',', $synonyms[ $id ] ?? '' ) ) ) );
             foreach ( $terms_list as $term ) {
+                $norm = Gm2_Category_Sort_Product_Category_Generator::normalize_text( $term );
+                if ( preg_match( '/^\d$/', $norm ) ) {
+                    continue;
+                }
                 $variants = [ $term ];
                 if ( substr( $term, -1 ) !== 's' ) {
                     $variants[] = $term . 's';

--- a/includes/class-one-click-assign.php
+++ b/includes/class-one-click-assign.php
@@ -378,6 +378,10 @@ class Gm2_Category_Sort_One_Click_Assign {
             }
             $terms_list = array_merge( [ $name ], array_filter( array_map( 'trim', explode( ',', $synonyms[ $id ] ?? '' ) ) ) );
             foreach ( $terms_list as $term ) {
+                $norm = Gm2_Category_Sort_Product_Category_Generator::normalize_text( $term );
+                if ( preg_match( '/^\d$/', $norm ) ) {
+                    continue;
+                }
                 $variants = [ $term ];
                 if ( substr( $term, -1 ) !== 's' ) {
                     $variants[] = $term . 's';

--- a/includes/class-product-category-generator.php
+++ b/includes/class-product-category-generator.php
@@ -805,6 +805,10 @@ class Gm2_Category_Sort_Product_Category_Generator {
 
             $terms = array_merge( [ $name ], array_filter( array_map( 'trim', explode( ',', $synonyms[ $id ] ?? '' ) ) ) );
             foreach ( $terms as $term ) {
+                $norm = self::normalize_text( $term );
+                if ( preg_match( '/^\d$/', $norm ) ) {
+                    continue;
+                }
                 $variants = [ $term ];
                 if ( substr( $term, -1 ) !== 's' ) {
                     $variants[] = $term . 's';


### PR DESCRIPTION
## Summary
- skip single digit terms when building synonym mappings to avoid false matches

## Testing
- `bin/install-phpunit.sh`
- `vendor/bin/phpunit` *(fails: `/usr/bin/env: ‘php’: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6866d9734a608327ba6d83de80d46b9e