### PR TITLE
Add rewrite redirect test

### DIFF
--- a/tests/ProductCategoryImporterTest.php
+++ b/tests/ProductCategoryImporterTest.php
@@ -8,6 +8,14 @@ class ProductCategoryImporterTest extends TestCase {
         // Setup some terms for lookup
         $GLOBALS['gm2_test_terms'][0] = [ 'Cat1' => 1, 'Cat2' => 2 ];
         $GLOBALS['gm2_products'] = [ 'SKU1' => 10, 'SKU2' => 20 ];
+
+        $upload = wp_upload_dir();
+        $dir = trailingslashit( $upload['basedir'] ) . 'gm2-category-sort/categories-structure';
+        if ( ! is_dir( $dir ) ) {
+            mkdir( $dir, 0777, true );
+        }
+        file_put_contents( $dir . '/cat1.csv', "Cat1\n" );
+        file_put_contents( $dir . '/cat2.csv', "Cat2\n" );
     }
 
     private function createCsv(string $contents): string {

--- a/tests/RewriteRulesRedirectTest.php
+++ b/tests/RewriteRulesRedirectTest.php
@@ -1,0 +1,53 @@
+<?php
+namespace {
+require_once __DIR__ . '/../includes/class-rewrite-rules.php';
+
+if ( ! function_exists( 'get_query_var' ) ) {
+    function get_query_var( $key ) {
+        return $GLOBALS['gm2_query_vars'][ $key ] ?? '';
+    }
+}
+
+class RedirectException extends \Exception {}
+
+if ( ! function_exists( 'get_term_link' ) ) {
+    function get_term_link( $term ) {
+        return 'http://example.com/' . $term->slug;
+    }
+}
+
+if ( ! function_exists( 'wp_redirect' ) ) {
+    function wp_redirect( $location, $status = 302 ) {
+        $GLOBALS['gm2_wp_redirect'] = [ 'location' => $location, 'status' => $status ];
+        throw new RedirectException();
+    }
+}
+}
+
+namespace {
+use PHPUnit\Framework\TestCase;
+
+class RewriteRulesRedirectTest extends TestCase {
+    protected function setUp(): void {
+        gm2_test_reset_terms();
+        $GLOBALS['gm2_query_vars'] = [];
+        $GLOBALS['gm2_wp_redirect'] = null;
+    }
+
+    public function test_redirects_when_alt_base_present() {
+        wp_insert_term( 'Valid Cat', 'product_cat' );
+        $GLOBALS['gm2_query_vars']['gm2_alt_base'] = 'alt';
+        $GLOBALS['gm2_query_vars']['product_cat'] = 'valid-cat';
+
+        try {
+            Gm2_Category_Sort_Rewrite_Rules::maybe_redirect();
+            $this->fail( 'RedirectException not thrown' );
+        } catch ( RedirectException $e ) {
+            // Expected.
+        }
+
+        $this->assertSame( 'http://example.com/valid-cat', $GLOBALS['gm2_wp_redirect']['location'] );
+        $this->assertSame( 301, $GLOBALS['gm2_wp_redirect']['status'] );
+    }
+}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -94,11 +94,13 @@ function update_term_meta( $term_id, $key, $value ) {
 }
 
 function get_term_by( $field, $value, $taxonomy ) {
-    if ( $field === 'name' && $taxonomy === 'product_cat' ) {
+    if ( $taxonomy === 'product_cat' ) {
         foreach ( $GLOBALS['gm2_test_terms'] as $parent => $terms ) {
             foreach ( $terms as $name => $id ) {
-                if ( $name === $value ) {
-                    return (object) [ 'term_id' => $id ];
+                $slug = strtolower( preg_replace( '/[^a-z0-9]+/i', '-', $name ) );
+                $slug = trim( $slug, '-' );
+                if ( ( $field === 'name' && $name === $value ) || ( $field === 'slug' && $slug === $value ) ) {
+                    return (object) [ 'term_id' => $id, 'slug' => $slug ];
                 }
             }
         }


### PR DESCRIPTION
## Summary
- stub `get_term_by` slug lookups
- create redirect test
- set up category structure CSVs for importer tests

## Testing
- `composer test` *(fails: RedirectException not thrown and importer tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_6882ec1832f08327b9a3cc0a2cdc46f9