### PR TITLE
Flush rewrite rules when bases update

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Gm2 Category Sort adds a product category sorting widget for WooCommerce shops w
 1. Download or clone this repository into the `wp-content/plugins` directory of your WordPress installation.
 2. Make sure WooCommerce and Elementor are installed and activated.
 3. Activate **Gm2 Category Sort** from the **Plugins** screen in WordPress.
+4. The plugin flushes WordPress rewrite rules on activation and deactivation so custom routes work immediately.
+5. If you change the WooCommerce category base later, the previous value is stored and the rules are flushed automatically.
 
 ## Usage
 1. Edit a WooCommerce shop or archive page with Elementor.

--- a/gm2-category-sort.php
+++ b/gm2-category-sort.php
@@ -26,6 +26,7 @@ function gm2_category_sort_activate() {
     if ( ! wp_next_scheduled( GM2_CAT_SORT_CRON_HOOK ) ) {
         wp_schedule_event( time(), 'daily', GM2_CAT_SORT_CRON_HOOK );
     }
+    // Ensure any rewrite rules from previous activations are registered.
     flush_rewrite_rules();
 }
 
@@ -34,6 +35,7 @@ function gm2_category_sort_deactivate() {
     if ( $timestamp ) {
         wp_unschedule_event( $timestamp, GM2_CAT_SORT_CRON_HOOK );
     }
+    // Clean up custom routes when the plugin is disabled.
     flush_rewrite_rules();
 }
 

--- a/includes/class-rewrite-rules.php
+++ b/includes/class-rewrite-rules.php
@@ -142,11 +142,15 @@ class Gm2_Category_Sort_Rewrite_Rules {
         if ( ! is_array( $bases ) ) {
             $bases = [];
         }
+        $updated = false;
         if ( ! in_array( $previous, $bases, true ) ) {
             $bases[] = $previous;
             update_option( 'gm2_rewrite_bases', $bases );
+            $updated = true;
         }
         update_option( 'gm2_rewrite_prev_base', $current );
-        flush_rewrite_rules();
+        if ( $updated ) {
+            flush_rewrite_rules();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- note automatic rewrite flushing in the documentation
- clarify activation/deactivation hooks
- only flush rewrite rules when `gm2_rewrite_bases` changes

## Testing
- `composer test` *(fails: ProductCategoryGeneratorTest, AutoAssignTest, OneClickAssignTest)*

------
https://chatgpt.com/codex/tasks/task_e_6882f0930c3c8327aac0c3e5d9ee9d7b