### PR TITLE
Support hierarchical slugs in redirect rules

### DIFF
--- a/includes/class-rewrite-rules.php
+++ b/includes/class-rewrite-rules.php
@@ -21,7 +21,7 @@ class Gm2_Category_Sort_Rewrite_Rules {
                 continue;
             }
             add_rewrite_rule(
-                '^' . preg_quote( $base, '#' ) . '/([^/]+)/?$',
+                '^' . preg_quote( $base, '#' ) . '/(.+?)/?$',
                 'index.php?product_cat=$matches[1]&gm2_alt_base=' . $base,
                 'top'
             );
@@ -87,6 +87,10 @@ class Gm2_Category_Sort_Rewrite_Rules {
             return;
         }
         $slug = get_query_var( 'product_cat' );
+        if ( strpos( $slug, '/' ) !== false ) {
+            $parts = explode( '/', trim( $slug, '/' ) );
+            $slug  = end( $parts );
+        }
         $term = get_term_by( 'slug', $slug, 'product_cat' );
         if ( ! $term || is_wp_error( $term ) ) {
             return;

--- a/tests/RewriteRulesRedirectTest.php
+++ b/tests/RewriteRulesRedirectTest.php
@@ -49,5 +49,23 @@ class RewriteRulesRedirectTest extends TestCase {
         $this->assertSame( 'http://example.com/valid-cat', $GLOBALS['gm2_wp_redirect']['location'] );
         $this->assertSame( 301, $GLOBALS['gm2_wp_redirect']['status'] );
     }
+
+    public function test_redirects_with_nested_path() {
+        $parent = wp_insert_term( 'Parent', 'product_cat' );
+        wp_insert_term( 'Child', 'product_cat', [ 'parent' => $parent['term_id'] ] );
+
+        $GLOBALS['gm2_query_vars']['gm2_alt_base'] = 'shop';
+        $GLOBALS['gm2_query_vars']['product_cat'] = 'parent/child';
+
+        try {
+            Gm2_Category_Sort_Rewrite_Rules::maybe_redirect();
+            $this->fail( 'RedirectException not thrown' );
+        } catch ( RedirectException $e ) {
+            // Expected.
+        }
+
+        $this->assertSame( 'http://example.com/child', $GLOBALS['gm2_wp_redirect']['location'] );
+        $this->assertSame( 301, $GLOBALS['gm2_wp_redirect']['status'] );
+    }
 }
 }


### PR DESCRIPTION
## Summary
- capture full category paths in rewrite rules
- parse hierarchical slug in the redirect handler
- test redirect with a nested category path

## Testing
- `vendor/bin/phpunit tests/RewriteRulesRedirectTest.php`

------
https://chatgpt.com/codex/tasks/task_e_6882f7114798832782bef6ce2a5d34fd