### PR TITLE
Handle Windows line breaks in rewrite rules

### DIFF
--- a/includes/class-rewrite-rules.php
+++ b/includes/class-rewrite-rules.php
@@ -67,10 +67,16 @@ class Gm2_Category_Sort_Rewrite_Rules {
 
     public static function save_rules() {
         check_admin_referer( 'gm2_save_rewrites', 'gm2_rewrites_nonce' );
-        $bases = isset( $_POST['gm2_rewrite_bases'] ) ? explode( "\n", wp_unslash( $_POST['gm2_rewrite_bases'] ) ) : [];
+        if ( isset( $_POST['gm2_rewrite_bases'] ) ) {
+            $text  = wp_unslash( $_POST['gm2_rewrite_bases'] );
+            $bases = preg_split( '/\r?\n/', $text );
+        } else {
+            $bases = [];
+        }
         $clean = [];
         foreach ( $bases as $base ) {
-            $base = trim( sanitize_text_field( $base ), '/' );
+            $base = trim( sanitize_text_field( $base ) );
+            $base = trim( $base, '/' );
             if ( $base !== '' ) {
                 $clean[] = $base;
             }

--- a/tests/RewriteRulesSaveTest.php
+++ b/tests/RewriteRulesSaveTest.php
@@ -1,0 +1,73 @@
+<?php
+namespace {
+require_once __DIR__ . '/../includes/class-rewrite-rules.php';
+
+if ( ! function_exists( 'check_admin_referer' ) ) {
+    function check_admin_referer( $action, $name ) { return true; }
+}
+if ( ! function_exists( 'wp_unslash' ) ) {
+    function wp_unslash( $value ) {
+        if ( is_array( $value ) ) { return array_map( 'wp_unslash', $value ); }
+        return stripslashes( $value );
+    }
+}
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+    function sanitize_text_field( $str ) { return $str; }
+}
+if ( ! function_exists( 'update_option' ) ) {
+    function update_option( $name, $value ) { $GLOBALS['gm2_options'][ $name ] = $value; return true; }
+}
+if ( ! function_exists( 'get_option' ) ) {
+    function get_option( $name, $default = false ) { return $GLOBALS['gm2_options'][ $name ] ?? $default; }
+}
+if ( ! function_exists( 'flush_rewrite_rules' ) ) {
+    function flush_rewrite_rules() { $GLOBALS['gm2_flushed'] = true; }
+}
+class SaveRedirectException extends \Exception {}
+if ( ! function_exists( 'wp_safe_redirect' ) ) {
+    function wp_safe_redirect( $location ) { $GLOBALS['gm2_safe_redirect'] = $location; throw new SaveRedirectException(); }
+}
+if ( ! function_exists( 'menu_page_url' ) ) {
+    function menu_page_url( $slug, $echo = true ) { return '/admin.php?page=' . $slug; }
+}
+if ( ! function_exists( 'add_rewrite_rule' ) ) {
+    function add_rewrite_rule( $regex, $query, $position = 'bottom' ) {
+        $GLOBALS['gm2_added_rules'][] = [ 'regex' => $regex, 'query' => $query, 'position' => $position ];
+    }
+}
+}
+
+namespace {
+use PHPUnit\Framework\TestCase;
+
+class RewriteRulesSaveTest extends TestCase {
+    protected function setUp(): void {
+        $GLOBALS['gm2_options'] = [];
+        $GLOBALS['gm2_added_rules'] = [];
+        $GLOBALS['gm2_safe_redirect'] = null;
+        $GLOBALS['gm2_flushed'] = false;
+        $_POST = [];
+    }
+
+    public function test_windows_line_breaks_create_rule() {
+        $_POST['gm2_rewrites_nonce'] = 't';
+        $_POST['gm2_rewrite_bases'] = "alt\r\n";
+
+        try {
+            Gm2_Category_Sort_Rewrite_Rules::save_rules();
+            $this->fail('SaveRedirectException not thrown');
+        } catch ( SaveRedirectException $e ) {
+            // Expected.
+        }
+
+        $this->assertSame( [ 'alt' ], $GLOBALS['gm2_options']['gm2_rewrite_bases'] );
+
+        Gm2_Category_Sort_Rewrite_Rules::add_rules();
+        $this->assertCount( 1, $GLOBALS['gm2_added_rules'] );
+        $rule = $GLOBALS['gm2_added_rules'][0];
+        $this->assertSame( '^alt/(.+?)/?$', $rule['regex'] );
+        $this->assertSame( 'index.php?product_cat=$matches[1]&gm2_alt_base=alt', $rule['query'] );
+        $this->assertSame( 'top', $rule['position'] );
+    }
+}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -247,8 +247,22 @@ if ( ! function_exists( 'esc_html' ) ) {
 }
 
 if ( ! function_exists( 'add_query_arg' ) ) {
-    function add_query_arg( $params ) {
-        return '?' . http_build_query( $params );
+    function add_query_arg( $param1, $param2 = null, $param3 = null ) {
+        if ( is_array( $param1 ) ) {
+            $params = $param1;
+            $url    = (string) $param2;
+        } else {
+            $params = [ $param1 => $param2 ];
+            $url    = (string) $param3;
+        }
+
+        $query = http_build_query( $params );
+        if ( $url === '' ) {
+            return '?' . $query;
+        }
+
+        $sep = strpos( $url, '?' ) === false ? '?' : '&';
+        return $url . $sep . $query;
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure `save_rules` splits text on Windows line breaks
- trim whitespace before trimming slashes
- extend test bootstrap `add_query_arg` implementation
- add regression test for Windows line breaks

## Testing
- `composer test` *(fails: AutoAssignTest and others fail)*

------
https://chatgpt.com/codex/tasks/task_e_6882fbc2543c8327ba1431fefde15b30