### PR TITLE
Fix rewrite rules capability check

### DIFF
--- a/gm2-category-sort.php
+++ b/gm2-category-sort.php
@@ -121,6 +121,7 @@ function gm2_category_sort_init() {
     Gm2_Category_Sort_One_Click_Assign::init();
     Gm2_Category_Sort_Branch_Rules::init();
     Gm2_Category_Sort_Rewrite_Rules::init();
+    add_action( 'admin_post_gm2_save_rewrites', [ 'Gm2_Category_Sort_Rewrite_Rules', 'save_rules' ] );
     Gm2_Category_Sort_Product_CSV::init();
     
     add_filter('pre_get_document_title', 'gm2_category_sort_modify_title');

--- a/includes/class-rewrite-rules.php
+++ b/includes/class-rewrite-rules.php
@@ -5,7 +5,6 @@ class Gm2_Category_Sort_Rewrite_Rules {
         add_action( 'init', [ __CLASS__, 'maybe_track_base_change' ] );
         add_filter( 'query_vars', [ __CLASS__, 'add_query_var' ] );
         add_action( 'admin_menu', [ __CLASS__, 'register_page' ] );
-        add_action( 'admin_post_gm2_save_rewrites', [ __CLASS__, 'save_rules' ] );
         add_action( 'template_redirect', [ __CLASS__, 'maybe_redirect' ] );
         add_action( 'update_option_woocommerce_permalinks', [ __CLASS__, 'permalinks_updated' ], 10, 2 );
     }
@@ -66,6 +65,11 @@ class Gm2_Category_Sort_Rewrite_Rules {
     }
 
     public static function save_rules() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_safe_redirect( add_query_arg( 'gm2_error', 1, menu_page_url( 'gm2-rewrite-rules', false ) ) );
+            exit;
+        }
+
         check_admin_referer( 'gm2_save_rewrites', 'gm2_rewrites_nonce' );
         if ( isset( $_POST['gm2_rewrite_bases'] ) ) {
             $text  = wp_unslash( $_POST['gm2_rewrite_bases'] );

--- a/tests/RewriteRulesSaveTest.php
+++ b/tests/RewriteRulesSaveTest.php
@@ -35,6 +35,9 @@ if ( ! function_exists( 'add_rewrite_rule' ) ) {
         $GLOBALS['gm2_added_rules'][] = [ 'regex' => $regex, 'query' => $query, 'position' => $position ];
     }
 }
+if ( ! function_exists( 'current_user_can' ) ) {
+    function current_user_can( $cap ) { return true; }
+}
 }
 
 namespace {


### PR DESCRIPTION
## Summary
- ensure rewrite settings only save for users who can manage options
- hook `gm2_save_rewrites` action after required plugins load
- update tests for new capability check

## Testing
- `composer install`
- `composer test` *(fails: ProductCategoryGeneratorTest and others)*

------
https://chatgpt.com/codex/tasks/task_e_6882fd7adf8c8327b9398b67bbe0d784