### PR TITLE
Track product permalink base changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Gm2 Category Sort adds a product category sorting widget for WooCommerce shops w
 3. Activate **Gm2 Category Sort** from the **Plugins** screen in WordPress.
 4. The plugin flushes WordPress rewrite rules on activation and deactivation so custom routes work immediately.
 5. If you change the WooCommerce category base later, the previous value is stored and the rules are flushed automatically.
+6. Changes to the product permalink structure are detected as well when it contains `%product_cat%`; the previous shop segment is added to the alternate bases and rules are flushed.
 
 ## Usage
 1. Edit a WooCommerce shop or archive page with Elementor.

--- a/includes/class-rewrite-rules.php
+++ b/includes/class-rewrite-rules.php
@@ -121,6 +121,12 @@ class Gm2_Category_Sort_Rewrite_Rules {
             ? trim( $permalinks['category_base'], '/' )
             : '';
         self::handle_base_change( $current );
+
+        if ( is_array( $permalinks ) && ! empty( $permalinks['product_base'] ) && strpos( $permalinks['product_base'], '%product_cat%' ) !== false ) {
+            $parts   = explode( '/', trim( $permalinks['product_base'], '/' ) );
+            $segment = $parts[0] ?? '';
+            self::handle_product_base_change( $segment );
+        }
     }
 
     /**
@@ -134,6 +140,12 @@ class Gm2_Category_Sort_Rewrite_Rules {
             ? trim( $value['category_base'], '/' )
             : '';
         self::handle_base_change( $current );
+
+        if ( is_array( $value ) && ! empty( $value['product_base'] ) && strpos( $value['product_base'], '%product_cat%' ) !== false ) {
+            $parts   = explode( '/', trim( $value['product_base'], '/' ) );
+            $segment = $parts[0] ?? '';
+            self::handle_product_base_change( $segment );
+        }
     }
 
     /**
@@ -163,6 +175,38 @@ class Gm2_Category_Sort_Rewrite_Rules {
             $updated = true;
         }
         update_option( 'gm2_rewrite_prev_base', $current );
+        if ( $updated ) {
+            flush_rewrite_rules();
+        }
+    }
+
+    /**
+     * Track product permalink base segments when %product_cat% is used.
+     *
+     * @param string $segment Leading segment before %product_cat%.
+     */
+    protected static function handle_product_base_change( $segment ) {
+        $previous = get_option( 'gm2_rewrite_prev_product_segment', '' );
+        if ( $previous === '' ) {
+            update_option( 'gm2_rewrite_prev_product_segment', $segment );
+            return;
+        }
+
+        if ( $segment === '' || $segment === $previous ) {
+            return;
+        }
+
+        $bases = get_option( 'gm2_rewrite_bases', [] );
+        if ( ! is_array( $bases ) ) {
+            $bases = [];
+        }
+        $updated = false;
+        if ( ! in_array( $previous, $bases, true ) ) {
+            $bases[] = $previous;
+            update_option( 'gm2_rewrite_bases', $bases );
+            $updated = true;
+        }
+        update_option( 'gm2_rewrite_prev_product_segment', $segment );
         if ( $updated ) {
             flush_rewrite_rules();
         }


### PR DESCRIPTION
## Summary
- extend the rewrite rule tracker to monitor WooCommerce product base changes
- add handler for product base segment updates
- document automatic detection of product permalink changes

## Testing
- `composer install`
- `composer test` *(fails: Errors and Failures)*

------
https://chatgpt.com/codex/tasks/task_e_6882fe56e48c83279c96f2b155b9d8bb