### PR TITLE
Track product base segment on install

### DIFF
--- a/gm2-category-sort.php
+++ b/gm2-category-sort.php
@@ -26,6 +26,10 @@ function gm2_category_sort_activate() {
     if ( ! wp_next_scheduled( GM2_CAT_SORT_CRON_HOOK ) ) {
         wp_schedule_event( time(), 'daily', GM2_CAT_SORT_CRON_HOOK );
     }
+    // Track the current product permalink segment before rules are flushed.
+    require_once GM2_CAT_SORT_PATH . 'includes/class-rewrite-rules.php';
+    Gm2_Category_Sort_Rewrite_Rules::maybe_track_base_change();
+
     // Ensure any rewrite rules from previous activations are registered.
     flush_rewrite_rules();
 }

--- a/includes/class-rewrite-rules.php
+++ b/includes/class-rewrite-rules.php
@@ -187,8 +187,22 @@ class Gm2_Category_Sort_Rewrite_Rules {
      */
     protected static function handle_product_base_change( $segment ) {
         $previous = get_option( 'gm2_rewrite_prev_product_segment', '' );
+        $bases    = get_option( 'gm2_rewrite_bases', [] );
+        if ( ! is_array( $bases ) ) {
+            $bases = [];
+        }
+        $updated = false;
+
         if ( $previous === '' ) {
             update_option( 'gm2_rewrite_prev_product_segment', $segment );
+            if ( $segment !== '' && ! in_array( $segment, $bases, true ) ) {
+                $bases[] = $segment;
+                update_option( 'gm2_rewrite_bases', $bases );
+                $updated = true;
+            }
+            if ( $updated ) {
+                flush_rewrite_rules();
+            }
             return;
         }
 
@@ -196,10 +210,6 @@ class Gm2_Category_Sort_Rewrite_Rules {
             return;
         }
 
-        $bases = get_option( 'gm2_rewrite_bases', [] );
-        if ( ! is_array( $bases ) ) {
-            $bases = [];
-        }
         $updated = false;
         if ( ! in_array( $previous, $bases, true ) ) {
             $bases[] = $previous;

--- a/tests/ProductBaseInstallTest.php
+++ b/tests/ProductBaseInstallTest.php
@@ -1,0 +1,34 @@
+<?php
+namespace {
+require_once __DIR__ . '/../includes/class-rewrite-rules.php';
+
+if ( ! function_exists( 'update_option' ) ) {
+    function update_option( $name, $value ) { $GLOBALS['gm2_options'][ $name ] = $value; return true; }
+}
+if ( ! function_exists( 'get_option' ) ) {
+    function get_option( $name, $default = false ) { return $GLOBALS['gm2_options'][ $name ] ?? $default; }
+}
+if ( ! function_exists( 'flush_rewrite_rules' ) ) {
+    function flush_rewrite_rules() { $GLOBALS['gm2_flushed'] = true; }
+}
+}
+
+namespace {
+use PHPUnit\Framework\TestCase;
+
+class ProductBaseInstallTest extends TestCase {
+    protected function setUp(): void {
+        $GLOBALS['gm2_options'] = [];
+        $GLOBALS['gm2_flushed'] = false;
+    }
+
+    public function test_segment_recorded_on_initial_install() {
+        $GLOBALS['gm2_options']['woocommerce_permalinks'] = [ 'product_base' => 'store/%product_cat%' ];
+        Gm2_Category_Sort_Rewrite_Rules::maybe_track_base_change();
+
+        $this->assertSame( 'store', $GLOBALS['gm2_options']['gm2_rewrite_prev_product_segment'] );
+        $this->assertSame( [ 'store' ], $GLOBALS['gm2_options']['gm2_rewrite_bases'] );
+        $this->assertTrue( $GLOBALS['gm2_flushed'] );
+    }
+}
+}


### PR DESCRIPTION
## Summary
- track product permalink segment when plugin is first run or activated
- ensure activation captures WooCommerce product base segment
- flush rewrite rules and save base segment on fresh install
- add PHPUnit test for storing product base segment during initial install

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68830d8081f883279e6f9a8ceaf8e75f