### PR TITLE
Ensure rewrite rules registered on activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ Gm2 Category Sort adds a product category sorting widget for WooCommerce shops w
 1. Download or clone this repository into the `wp-content/plugins` directory of your WordPress installation.
 2. Make sure WooCommerce and Elementor are installed and activated.
 3. Activate **Gm2 Category Sort** from the **Plugins** screen in WordPress.
-4. The plugin flushes WordPress rewrite rules on activation and deactivation so custom routes work immediately.
+4. On activation the plugin registers its rewrite rules by calling
+   `Gm2_Category_Sort_Rewrite_Rules::add_rules()` and flushes them so custom
+   routes work immediately. Deactivating the plugin flushes the rules again.
 5. If you change the WooCommerce category base later, the previous value is stored and the rules are flushed automatically.
 6. Changes to the product permalink structure are detected as well when it contains `%product_cat%`; the previous shop segment is added to the alternate bases and rules are flushed.
 

--- a/gm2-category-sort.php
+++ b/gm2-category-sort.php
@@ -30,6 +30,9 @@ function gm2_category_sort_activate() {
     require_once GM2_CAT_SORT_PATH . 'includes/class-rewrite-rules.php';
     Gm2_Category_Sort_Rewrite_Rules::maybe_track_base_change();
 
+    // Register custom rewrite rules immediately so the flush picks them up.
+    Gm2_Category_Sort_Rewrite_Rules::add_rules();
+
     // Ensure any rewrite rules from previous activations are registered.
     flush_rewrite_rules();
 }


### PR DESCRIPTION
## Summary
- register rewrite rules via `Gm2_Category_Sort_Rewrite_Rules::add_rules()` during activation
- clarify the activation behavior in the README

## Testing
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68830e6a94c48327a038c6d8e07e1102