### PR TITLE
Add canonical alt base test

### DIFF
--- a/tests/CanonicalAltBaseTest.php
+++ b/tests/CanonicalAltBaseTest.php
@@ -1,0 +1,42 @@
+<?php
+namespace {
+require_once __DIR__ . '/../includes/class-canonical.php';
+
+if ( ! function_exists( 'get_query_var' ) ) {
+    function get_query_var( $key ) {
+        return $GLOBALS['gm2_query_vars'][ $key ] ?? '';
+    }
+}
+
+if ( ! function_exists( 'get_term_link' ) ) {
+    function get_term_link( $term ) {
+        return 'http://example.com/' . $term->slug;
+    }
+}
+}
+
+namespace {
+use PHPUnit\Framework\TestCase;
+
+class CanonicalAltBaseTest extends TestCase {
+    protected function setUp(): void {
+        gm2_test_reset_terms();
+        $GLOBALS['gm2_query_vars'] = [];
+    }
+
+    public function test_outputs_canonical_link_for_alt_base() {
+        wp_insert_term( 'Valid Cat', 'product_cat' );
+        $GLOBALS['gm2_query_vars']['gm2_alt_base'] = 'alt';
+        $GLOBALS['gm2_query_vars']['product_cat'] = 'valid-cat';
+
+        ob_start();
+        Gm2_Category_Sort_Canonical::maybe_output_canonical();
+        $html = ob_get_clean();
+
+        $this->assertSame(
+            '<link rel="canonical" href="http://example.com/valid-cat" />\n',
+            $html
+        );
+    }
+}
+}


### PR DESCRIPTION
## Summary
- add PHPUnit test for canonical link when using alternate base

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68830f0b94688327ac3dfb4c35bd0f9a