### PR TITLE
Fix CSV parsing parameters

### DIFF
--- a/includes/class-branch-rules.php
+++ b/includes/class-branch-rules.php
@@ -91,7 +91,12 @@ class Gm2_Category_Sort_Branch_Rules {
      * @return array Mapping of slug => "Root > Child > ..." path.
      */
     public static function build_slug_path_map( $file ) {
-        $rows = array_map( 'str_getcsv', file( $file ) );
+        $rows = array_map(
+            static function ( $row ) {
+                return str_getcsv( $row, ',', '"', '\\' );
+            },
+            file( $file )
+        );
         $map  = [];
 
         foreach ( $rows as $row ) {
@@ -323,7 +328,7 @@ class Gm2_Category_Sort_Branch_Rules {
         $tree   = trailingslashit( $upload['basedir'] ) . 'gm2-category-sort/categories-structure/category-tree.csv';
         $map    = file_exists( $tree ) ? self::build_slug_path_map( $tree ) : [];
 
-        fputcsv( $fh, [ 'slug', 'path', 'include', 'exclude', 'include_attrs', 'exclude_attrs', 'allow_multi' ] );
+        fputcsv( $fh, [ 'slug', 'path', 'include', 'exclude', 'include_attrs', 'exclude_attrs', 'allow_multi' ], ',', '"', '\\' );
 
         $rules = get_option( 'gm2_branch_rules', [] );
         if ( is_array( $rules ) ) {
@@ -337,7 +342,7 @@ class Gm2_Category_Sort_Branch_Rules {
                     self::attrs_to_string( $rule['exclude_attrs'] ?? [] ),
                     empty( $rule['allow_multi'] ) ? '0' : '1',
                 ];
-                fputcsv( $fh, $row );
+                fputcsv( $fh, $row, ',', '"', '\\' );
             }
         }
 
@@ -361,7 +366,7 @@ class Gm2_Category_Sort_Branch_Rules {
             return new WP_Error( 'gm2_unreadable', __( 'Unable to read file.', 'gm2-category-sort' ) );
         }
 
-        $header = fgetcsv( $fh );
+        $header = fgetcsv( $fh, 0, ',', '"', '\\' );
         if ( ! $header ) {
             fclose( $fh );
             return [];
@@ -369,7 +374,7 @@ class Gm2_Category_Sort_Branch_Rules {
         $header[0] = preg_replace( "/^\xEF\xBB\xBF/", '', $header[0] );
         $cols      = array_flip( $header );
         $rules     = [];
-        while ( ( $row = fgetcsv( $fh ) ) !== false ) {
+        while ( ( $row = fgetcsv( $fh, 0, ',', '"', '\\' ) ) !== false ) {
             if ( empty( $row ) ) {
                 continue;
             }

--- a/includes/class-category-importer.php
+++ b/includes/class-category-importer.php
@@ -112,7 +112,7 @@ class Gm2_Category_Sort_Category_Importer {
         }
 
         $first_row = true;
-        while ( ( $row = fgetcsv( $handle ) ) !== false ) {
+        while ( ( $row = fgetcsv( $handle, 0, ',', '"', '\\' ) ) !== false ) {
             if ( empty( $row ) ) {
                 continue;
             }
@@ -124,7 +124,7 @@ class Gm2_Category_Sort_Category_Importer {
 
             $parent = 0;
             foreach ( $row as $name ) {
-                $name = trim( $name );
+                $name = trim( (string) $name );
                 if ( $name === '' ) {
                     continue;
                 }

--- a/includes/class-one-click-assign.php
+++ b/includes/class-one-click-assign.php
@@ -182,7 +182,12 @@ class Gm2_Category_Sort_One_Click_Assign {
      * @return array<string,array>
      */
     public static function build_branch_map( $file ) {
-        $rows     = array_map( 'str_getcsv', file( $file ) );
+        $rows     = array_map(
+            static function ( $row ) {
+                return str_getcsv( $row, ',', '"', '\\' );
+            },
+            file( $file )
+        );
         $branches = [];
         foreach ( $rows as $row ) {
             $prev       = null;
@@ -443,7 +448,12 @@ class Gm2_Category_Sort_One_Click_Assign {
             unlink( $csv );
         }
 
-        $rows    = array_map( 'str_getcsv', file( $tree_file ) );
+        $rows    = array_map(
+            static function ( $row ) {
+                return str_getcsv( $row, ',', '"', '\\' );
+            },
+            file( $tree_file )
+        );
 
 
         $handles = [];
@@ -478,7 +488,7 @@ class Gm2_Category_Sort_One_Click_Assign {
                     }
                 }
 
-                fputcsv( $handles[ $slug ], $row );
+                fputcsv( $handles[ $slug ], $row, ',', '"', '\\' );
             }
         }
 

--- a/includes/class-product-category-generator.php
+++ b/includes/class-product-category-generator.php
@@ -158,7 +158,12 @@ class Gm2_Category_Sort_Product_Category_Generator {
         if ( ! file_exists( $file ) ) {
             return [ $brands, $models ];
         }
-        $rows = array_map( 'str_getcsv', file( $file ) );
+        $rows = array_map(
+            static function ( $row ) {
+                return str_getcsv( $row, ',', '"', '\\' );
+            },
+            file( $file )
+        );
         foreach ( $rows as $row ) {
             $brand_idx = false;
             foreach ( $row as $i => $seg ) {
@@ -214,7 +219,12 @@ class Gm2_Category_Sort_Product_Category_Generator {
         if ( ! file_exists( $file ) ) {
             return $sizes;
         }
-        $rows = array_map( 'str_getcsv', file( $file ) );
+        $rows = array_map(
+            static function ( $row ) {
+                return str_getcsv( $row, ',', '"', '\\' );
+            },
+            file( $file )
+        );
         foreach ( $rows as $row ) {
             $idx = array_search( 'By Wheel Size', $row, true );
             if ( $idx === false ) {
@@ -248,7 +258,12 @@ class Gm2_Category_Sort_Product_Category_Generator {
         $bfile  = rtrim( $dir, '/' ) . '/brands.csv';
         $mfile  = rtrim( $dir, '/' ) . '/models.csv';
         if ( file_exists( $bfile ) ) {
-            $rows = array_map( 'str_getcsv', file( $bfile ) );
+            $rows = array_map(
+                static function ( $row ) {
+                    return str_getcsv( $row, ',', '"', '\\' );
+                },
+                file( $bfile )
+            );
             array_shift( $rows );
             foreach ( $rows as $row ) {
                 $brand = trim( $row[0] ?? '' );
@@ -257,7 +272,12 @@ class Gm2_Category_Sort_Product_Category_Generator {
             }
         }
         if ( file_exists( $mfile ) ) {
-            $rows = array_map( 'str_getcsv', file( $mfile ) );
+            $rows = array_map(
+                static function ( $row ) {
+                    return str_getcsv( $row, ',', '"', '\\' );
+                },
+                file( $mfile )
+            );
             array_shift( $rows );
             foreach ( $rows as $row ) {
                 $brand = trim( $row[0] ?? '' );
@@ -321,7 +341,7 @@ class Gm2_Category_Sort_Product_Category_Generator {
      * @param int         $threshold  Fuzzy matching threshold.
      * @return array      When $assigned is provided, returns mapping of branch slug => path. Otherwise list of category names.
      */
-    protected static function match_terms( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [], array &$assigned = null, array $branch_rules = [] ) {
+    protected static function match_terms( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [], ?array &$assigned = null, array $branch_rules = [] ) {
         $cats       = [];
         $word_count = count( $words );
         foreach ( $mapping as $term => $paths ) {
@@ -409,7 +429,7 @@ class Gm2_Category_Sort_Product_Category_Generator {
     }
 
     /** Brand and model branch logic. */
-    protected static function check_brand_model( $lower, array $words, array $mapping, $fuzzy, $threshold, $csv_dir, array $attributes = [], array &$assigned = null, array $branch_rules = [] ) {
+    protected static function check_brand_model( $lower, array $words, array $mapping, $fuzzy, $threshold, $csv_dir, array $attributes = [], ?array &$assigned = null, array $branch_rules = [] ) {
         $brands       = [];
         $brand_models = [];
 
@@ -588,7 +608,7 @@ class Gm2_Category_Sort_Product_Category_Generator {
     }
 
     /** Wheel size branch logic. */
-    protected static function check_wheel_size( $lower, array $mapping, $wheel_size_num, $wheel_size, $brand_found, array $attributes = [], array &$assigned = null, array $branch_rules = [] ) {
+    protected static function check_wheel_size( $lower, array $mapping, $wheel_size_num, $wheel_size, $brand_found, array $attributes = [], ?array &$assigned = null, array $branch_rules = [] ) {
         if ( ! $wheel_size_num ) {
             return [];
         }
@@ -721,47 +741,47 @@ class Gm2_Category_Sort_Product_Category_Generator {
     }
 
     /** Generic helpers for additional branches. */
-    protected static function check_wheel_type( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [], array &$assigned = null, array $branch_rules = [] ) {
+    protected static function check_wheel_type( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [], ?array &$assigned = null, array $branch_rules = [] ) {
         return self::match_terms( $lower, $words, self::filter_by_segment( $mapping, 'By Wheel Type' ), $fuzzy, $threshold, $attributes, $assigned, $branch_rules );
     }
 
-    protected static function check_set_sizes( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [], array &$assigned = null, array $branch_rules = [] ) {
+    protected static function check_set_sizes( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [], ?array &$assigned = null, array $branch_rules = [] ) {
         return self::match_terms( $lower, $words, self::filter_by_segment( $mapping, 'By Wheel Set Sizes' ), $fuzzy, $threshold, $attributes, $assigned, $branch_rules );
     }
 
-    protected static function check_fit_type( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [], array &$assigned = null, array $branch_rules = [] ) {
+    protected static function check_fit_type( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [], ?array &$assigned = null, array $branch_rules = [] ) {
         return self::match_terms( $lower, $words, self::filter_by_segment( $mapping, 'By Fit Type' ), $fuzzy, $threshold, $attributes, $assigned, $branch_rules );
     }
 
-    protected static function check_vehicle_type( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [], array &$assigned = null, array $branch_rules = [] ) {
+    protected static function check_vehicle_type( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [], ?array &$assigned = null, array $branch_rules = [] ) {
         return self::match_terms( $lower, $words, self::filter_by_segment( $mapping, 'By Vehicle Type' ), $fuzzy, $threshold, $attributes, $assigned, $branch_rules );
     }
 
-    protected static function check_ring_mount( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [], array &$assigned = null, array $branch_rules = [] ) {
+    protected static function check_ring_mount( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [], ?array &$assigned = null, array $branch_rules = [] ) {
         return self::match_terms( $lower, $words, self::filter_by_segment( $mapping, 'Ring Mount' ), $fuzzy, $threshold, $attributes, $assigned, $branch_rules );
     }
 
-    protected static function check_dayton_spoke( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [], array &$assigned = null, array $branch_rules = [] ) {
+    protected static function check_dayton_spoke( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [], ?array &$assigned = null, array $branch_rules = [] ) {
         return self::match_terms( $lower, $words, self::filter_by_segment( $mapping, 'Dayton Spoke' ), $fuzzy, $threshold, $attributes, $assigned, $branch_rules );
     }
 
-    protected static function check_wheel_center_caps( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [], array &$assigned = null, array $branch_rules = [] ) {
+    protected static function check_wheel_center_caps( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [], ?array &$assigned = null, array $branch_rules = [] ) {
         return self::match_terms( $lower, $words, self::filter_by_segment( $mapping, 'Wheel Center Caps' ), $fuzzy, $threshold, $attributes, $assigned, $branch_rules );
     }
 
-    protected static function check_wheel_cover_parts( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [], array &$assigned = null, array $branch_rules = [] ) {
+    protected static function check_wheel_cover_parts( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [], ?array &$assigned = null, array $branch_rules = [] ) {
         return self::match_terms( $lower, $words, self::filter_by_segment( $mapping, 'Wheel Cover Parts' ), $fuzzy, $threshold, $attributes, $assigned, $branch_rules );
     }
 
-    protected static function check_seat_covers( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [], array &$assigned = null, array $branch_rules = [] ) {
+    protected static function check_seat_covers( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [], ?array &$assigned = null, array $branch_rules = [] ) {
         return self::match_terms( $lower, $words, self::filter_by_segment( $mapping, 'Seat Covers' ), $fuzzy, $threshold, $attributes, $assigned, $branch_rules );
     }
 
-    protected static function check_coverking_accessories( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [], array &$assigned = null, array $branch_rules = [] ) {
+    protected static function check_coverking_accessories( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [], ?array &$assigned = null, array $branch_rules = [] ) {
         return self::match_terms( $lower, $words, self::filter_by_segment( $mapping, 'Coverking Accessories' ), $fuzzy, $threshold, $attributes, $assigned, $branch_rules );
     }
 
-    protected static function check_accessories_hardware( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [], array &$assigned = null, array $branch_rules = [] ) {
+    protected static function check_accessories_hardware( $lower, array $words, array $mapping, $fuzzy, $threshold, array $attributes = [], ?array &$assigned = null, array $branch_rules = [] ) {
         return self::match_terms( $lower, $words, self::filter_by_segment( $mapping, 'Accessories & Hardware' ), $fuzzy, $threshold, $attributes, $assigned, $branch_rules );
     }
 
@@ -1139,7 +1159,7 @@ class Gm2_Category_Sort_Product_Category_Generator {
      * @param array $attributes Mapping of attribute slugs to selected term slugs.
      * @return array Mapping of branch slug => path that match the attribute rules.
      */
-    public static function assign_categories_from_attributes( array $attributes, array &$assigned = null, array $branch_rules_override = [] ) {
+    public static function assign_categories_from_attributes( array $attributes, ?array &$assigned = null, array $branch_rules_override = [] ) {
         $rules = $branch_rules_override ? $branch_rules_override : get_option( 'gm2_branch_rules', [] );
         if ( ! is_array( $rules ) || ! $rules ) {
             return [];
@@ -1214,7 +1234,12 @@ class Gm2_Category_Sort_Product_Category_Generator {
                 return [];
             }
         }
-        $rows = array_map( 'str_getcsv', file( $file ) );
+        $rows = array_map(
+            static function ( $row ) {
+                return str_getcsv( $row, ',', '"', '\\' );
+            },
+            file( $file )
+        );
         if ( empty( $rows ) ) {
             return [];
         }
@@ -1360,19 +1385,19 @@ class Gm2_Category_Sort_Product_Category_Generator {
 
         $brand_file = rtrim( $dir, '/' ) . '/brands.csv';
         if ( $fh = fopen( $brand_file, 'w' ) ) {
-            fputcsv( $fh, [ 'Brand', 'Terms' ] );
+            fputcsv( $fh, [ 'Brand', 'Terms' ], ',', '"', '\\' );
             foreach ( $brands as $brand => $terms ) {
-                fputcsv( $fh, [ $brand, implode( ' | ', array_unique( $terms ) ) ] );
+                fputcsv( $fh, [ $brand, implode( ' | ', array_unique( $terms ) ) ], ',', '"', '\\' );
             }
             fclose( $fh );
         }
 
         $model_file = rtrim( $dir, '/' ) . '/models.csv';
         if ( $fh = fopen( $model_file, 'w' ) ) {
-            fputcsv( $fh, [ 'Brand', 'Model', 'Terms' ] );
+            fputcsv( $fh, [ 'Brand', 'Model', 'Terms' ], ',', '"', '\\' );
             foreach ( $models as $brand => $mset ) {
                 foreach ( $mset as $model => $terms ) {
-                    fputcsv( $fh, [ $brand, $model, implode( ' | ', array_unique( $terms ) ) ] );
+                    fputcsv( $fh, [ $brand, $model, implode( ' | ', array_unique( $terms ) ) ], ',', '"', '\\' );
                 }
             }
             fclose( $fh );
@@ -1381,9 +1406,9 @@ class Gm2_Category_Sort_Product_Category_Generator {
         $sizes = self::build_wheel_sizes_from_tree( $tree_file );
         $size_file = rtrim( $dir, '/' ) . '/wheel-sizes.csv';
         if ( $fh = fopen( $size_file, 'w' ) ) {
-            fputcsv( $fh, [ 'Size', 'Terms' ] );
+            fputcsv( $fh, [ 'Size', 'Terms' ], ',', '"', '\\' );
             foreach ( $sizes as $size => $terms ) {
-                fputcsv( $fh, [ $size, implode( ' | ', array_unique( $terms ) ) ] );
+                fputcsv( $fh, [ $size, implode( ' | ', array_unique( $terms ) ) ], ',', '"', '\\' );
             }
             fclose( $fh );
         }
@@ -1446,7 +1471,7 @@ class Gm2_Category_Sort_Product_Category_Generator {
             }
             $path[] = $name;
             if ( empty( $children[ $id ] ) ) {
-                fputcsv( $fh, $path );
+                fputcsv( $fh, $path, ',', '"', '\\' );
             } else {
                 foreach ( $children[ $id ] as $child ) {
                     $write( $child, $path );

--- a/includes/class-product-category-importer.php
+++ b/includes/class-product-category-importer.php
@@ -166,7 +166,7 @@ class Gm2_Category_Sort_Product_Category_Importer {
         }
 
         for ( $i = 0; $i < $offset; $i++ ) {
-            if ( false === fgetcsv( $handle ) ) {
+            if ( false === fgetcsv( $handle, 0, ',', '"', '\\' ) ) {
                 fclose( $handle );
                 return [
                     'offset' => $offset,
@@ -177,7 +177,7 @@ class Gm2_Category_Sort_Product_Category_Importer {
 
         $count      = 0;
         $first_row  = ( 0 === $offset );
-        while ( ( $row = fgetcsv( $handle ) ) !== false ) {
+        while ( ( $row = fgetcsv( $handle, 0, ',', '"', '\\' ) ) !== false ) {
             if ( $limit && $count >= $limit ) {
                 break;
             }
@@ -250,7 +250,7 @@ class Gm2_Category_Sort_Product_Category_Importer {
             return 0;
         }
         $count = 0;
-        while ( false !== fgetcsv( $handle ) ) {
+        while ( false !== fgetcsv( $handle, 0, ',', '"', '\\' ) ) {
             $count++;
         }
         fclose( $handle );

--- a/tests/BranchCsvExportTest.php
+++ b/tests/BranchCsvExportTest.php
@@ -29,9 +29,24 @@ class BranchCsvExportTest extends TestCase {
         $this->assertFileExists( "$dir/root-branch-leaf.csv" );
         $this->assertFileExists( "$dir/solo.csv" );
 
-        $branch_rows = array_map( 'str_getcsv', file( "$dir/root-branch.csv" ) );
-        $leaf_rows   = array_map( 'str_getcsv', file( "$dir/root-branch-leaf.csv" ) );
-        $solo_rows   = array_map( 'str_getcsv', file( "$dir/solo.csv" ) );
+        $branch_rows = array_map(
+            static function ( $row ) {
+                return str_getcsv( $row, ',', '"', '\\' );
+            },
+            file( "$dir/root-branch.csv" )
+        );
+        $leaf_rows   = array_map(
+            static function ( $row ) {
+                return str_getcsv( $row, ',', '"', '\\' );
+            },
+            file( "$dir/root-branch-leaf.csv" )
+        );
+        $solo_rows   = array_map(
+            static function ( $row ) {
+                return str_getcsv( $row, ',', '"', '\\' );
+            },
+            file( "$dir/solo.csv" )
+        );
 
         $this->assertContains( [ 'Root', 'Branch', 'Leaf' ], $branch_rows );
         $this->assertSame( [ [ 'Root', 'Branch', 'Leaf' ] ], $leaf_rows );

--- a/tests/BranchRulesCsvTest.php
+++ b/tests/BranchRulesCsvTest.php
@@ -35,7 +35,12 @@ class BranchRulesCsvTest extends TestCase {
         $GLOBALS['gm2_options']['gm2_branch_rules'] = $this->sample_rules();
         $file = tempnam(sys_get_temp_dir(), 'gm2_rules');
         Gm2_Category_Sort_Branch_Rules::export_to_csv($file);
-        $rows = array_map('str_getcsv', file($file));
+        $rows = array_map(
+            static function ($row) {
+                return str_getcsv($row, ',', '"', '\\');
+            },
+            file($file)
+        );
         unlink($file);
 
         $this->assertSame(['slug','path','include','exclude','include_attrs','exclude_attrs','allow_multi'], $rows[0]);

--- a/tests/ProductCategoryGeneratorTest.php
+++ b/tests/ProductCategoryGeneratorTest.php
@@ -463,7 +463,12 @@ class ProductCategoryGeneratorTest extends TestCase {
         $this->assertFileExists( $dir . '/models.csv' );
         $this->assertFileExists( $dir . '/wheel-sizes.csv' );
 
-        $brands = array_map( 'str_getcsv', file( $dir . '/brands.csv' ) );
+        $brands = array_map(
+            static function ( $row ) {
+                return str_getcsv( $row, ',', '"', '\\' );
+            },
+            file( $dir . '/brands.csv' )
+        );
         $header = array_shift( $brands );
         $this->assertSame( [ 'Brand', 'Terms' ], $header );
         $found = false;
@@ -475,11 +480,21 @@ class ProductCategoryGeneratorTest extends TestCase {
         }
         $this->assertTrue( $found );
 
-        $sizes = array_map( 'str_getcsv', file( $dir . '/wheel-sizes.csv' ) );
+        $sizes = array_map(
+            static function ( $row ) {
+                return str_getcsv( $row, ',', '"', '\\' );
+            },
+            file( $dir . '/wheel-sizes.csv' )
+        );
         $header = array_shift( $sizes );
         $this->assertSame( [ 'Size', 'Terms' ], $header );
 
-        $models = array_map( 'str_getcsv', file( $dir . '/models.csv' ) );
+        $models = array_map(
+            static function ( $row ) {
+                return str_getcsv( $row, ',', '"', '\\' );
+            },
+            file( $dir . '/models.csv' )
+        );
         $header = array_shift( $models );
         $this->assertSame( [ 'Brand', 'Model', 'Terms' ], $header );
         $found = false;
@@ -507,7 +522,12 @@ class ProductCategoryGeneratorTest extends TestCase {
 
         Gm2_Category_Sort_Product_Category_Generator::export_brand_model_csv( $mapping, $dir );
 
-        $brands = array_map( 'str_getcsv', file( $dir . '/brands.csv' ) );
+        $brands = array_map(
+            static function ( $row ) {
+                return str_getcsv( $row, ',', '"', '\\' );
+            },
+            file( $dir . '/brands.csv' )
+        );
         $header = array_shift( $brands );
         $this->assertSame( [ 'Brand', 'Terms' ], $header );
         $found = false;
@@ -518,7 +538,12 @@ class ProductCategoryGeneratorTest extends TestCase {
         }
         $this->assertTrue( $found );
 
-        $models = array_map( 'str_getcsv', file( $dir . '/models.csv' ) );
+        $models = array_map(
+            static function ( $row ) {
+                return str_getcsv( $row, ',', '"', '\\' );
+            },
+            file( $dir . '/models.csv' )
+        );
         $header = array_shift( $models );
         $this->assertSame( [ 'Brand', 'Model', 'Terms' ], $header );
         $found = false;
@@ -530,7 +555,12 @@ class ProductCategoryGeneratorTest extends TestCase {
         $this->assertTrue( $found );
 
         $this->assertFileExists( $dir . '/wheel-sizes.csv' );
-        $sizes = array_map( 'str_getcsv', file( $dir . '/wheel-sizes.csv' ) );
+        $sizes = array_map(
+            static function ( $row ) {
+                return str_getcsv( $row, ',', '"', '\\' );
+            },
+            file( $dir . '/wheel-sizes.csv' )
+        );
         $header = array_shift( $sizes );
         $this->assertSame( [ 'Size', 'Terms' ], $header );
     }
@@ -847,7 +877,12 @@ class ProductCategoryGeneratorTest extends TestCase {
         Gm2_Category_Sort_Product_Category_Generator::export_category_tree_csv( $dir );
 
         $this->assertFileExists( $dir . '/category-tree.csv' );
-        $rows = array_map( 'str_getcsv', file( $dir . '/category-tree.csv' ) );
+        $rows = array_map(
+            static function ( $row ) {
+                return str_getcsv( $row, ',', '"', '\\' );
+            },
+            file( $dir . '/category-tree.csv' )
+        );
         $this->assertContains( [ 'Top (T)', 'Sub (S1,S2)' ], $rows );
     }
 


### PR DESCRIPTION
## Summary
- set explicit escape parameter for str_getcsv(), fgetcsv(), and fputcsv()
- avoid null warning in category importer
- update tests for new CSV call signature

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68830fe25d0c8327bcf17d0e4c3b0d32