### PR TITLE
Fix rewrite rules flush

### DIFF
--- a/includes/class-rewrite-rules.php
+++ b/includes/class-rewrite-rules.php
@@ -86,6 +86,7 @@ class Gm2_Category_Sort_Rewrite_Rules {
             }
         }
         update_option( 'gm2_rewrite_bases', $clean );
+        self::add_rules();
         flush_rewrite_rules();
         wp_safe_redirect( add_query_arg( 'gm2_saved', 1, menu_page_url( 'gm2-rewrite-rules', false ) ) );
         exit;
@@ -176,6 +177,7 @@ class Gm2_Category_Sort_Rewrite_Rules {
         }
         update_option( 'gm2_rewrite_prev_base', $current );
         if ( $updated ) {
+            self::add_rules();
             flush_rewrite_rules();
         }
     }
@@ -201,6 +203,7 @@ class Gm2_Category_Sort_Rewrite_Rules {
                 $updated = true;
             }
             if ( $updated ) {
+                self::add_rules();
                 flush_rewrite_rules();
             }
             return;
@@ -218,6 +221,7 @@ class Gm2_Category_Sort_Rewrite_Rules {
         }
         update_option( 'gm2_rewrite_prev_product_segment', $segment );
         if ( $updated ) {
+            self::add_rules();
             flush_rewrite_rules();
         }
     }

--- a/tests/RewriteRulesSaveTest.php
+++ b/tests/RewriteRulesSaveTest.php
@@ -65,7 +65,6 @@ class RewriteRulesSaveTest extends TestCase {
 
         $this->assertSame( [ 'alt' ], $GLOBALS['gm2_options']['gm2_rewrite_bases'] );
 
-        Gm2_Category_Sort_Rewrite_Rules::add_rules();
         $this->assertCount( 1, $GLOBALS['gm2_added_rules'] );
         $rule = $GLOBALS['gm2_added_rules'][0];
         $this->assertSame( '^alt/(.+?)/?$', $rule['regex'] );
@@ -86,7 +85,6 @@ class RewriteRulesSaveTest extends TestCase {
 
         $this->assertSame( [ 'alt', 'shop' ], $GLOBALS['gm2_options']['gm2_rewrite_bases'] );
 
-        Gm2_Category_Sort_Rewrite_Rules::add_rules();
         $this->assertCount( 2, $GLOBALS['gm2_added_rules'] );
 
         $rule1 = $GLOBALS['gm2_added_rules'][0];


### PR DESCRIPTION
## Summary
- register fresh rules before flushing so changes take effect immediately
- update rewrite rules test expectations

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6883afa49d8c8327bc301accc589ce8e