### PR TITLE
Fix rewrite rules priority to avoid WooCommerce conflicts

### DIFF
--- a/includes/class-rewrite-rules.php
+++ b/includes/class-rewrite-rules.php
@@ -1,7 +1,8 @@
 <?php
 class Gm2_Category_Sort_Rewrite_Rules {
     public static function init() {
-        add_action( 'init', [ __CLASS__, 'add_rules' ] );
+        // Run early so WooCommerce product rules added later take precedence.
+        add_action( 'init', [ __CLASS__, 'add_rules' ], 5 );
         add_action( 'init', [ __CLASS__, 'maybe_track_base_change' ] );
         add_filter( 'query_vars', [ __CLASS__, 'add_query_var' ] );
         add_action( 'admin_menu', [ __CLASS__, 'register_page' ] );
@@ -22,7 +23,7 @@ class Gm2_Category_Sort_Rewrite_Rules {
             add_rewrite_rule(
                 '^' . preg_quote( $base, '#' ) . '/(.+?)/?$',
                 'index.php?product_cat=$matches[1]&gm2_alt_base=' . $base,
-                'bottom'
+                'top'
             );
         }
     }

--- a/tests/RewriteRulesSaveTest.php
+++ b/tests/RewriteRulesSaveTest.php
@@ -69,7 +69,7 @@ class RewriteRulesSaveTest extends TestCase {
         $rule = $GLOBALS['gm2_added_rules'][0];
         $this->assertSame( '^alt/(.+?)/?$', $rule['regex'] );
         $this->assertSame( 'index.php?product_cat=$matches[1]&gm2_alt_base=alt', $rule['query'] );
-        $this->assertSame( 'bottom', $rule['position'] );
+        $this->assertSame( 'top', $rule['position'] );
     }
 
     public function test_multiple_windows_line_breaks_create_rules() {


### PR DESCRIPTION
## Summary
- ensure custom rewrite rules execute before WooCommerce's
- revert rewrite rule position to `top`
- update tests

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6883bd4886b8832799cb66db908a9940