### PR TITLE
Add product rewrite support and canonical handling

### DIFF
--- a/includes/class-canonical.php
+++ b/includes/class-canonical.php
@@ -7,6 +7,17 @@ class Gm2_Category_Sort_Canonical {
     public static function maybe_output_canonical() {
         $alt = get_query_var( 'gm2_alt_base' );
         if ( $alt ) {
+            $product_slug = get_query_var( 'product' );
+            if ( $product_slug ) {
+                $product = get_page_by_path( $product_slug, OBJECT, 'product' );
+                if ( $product ) {
+                    $link = get_permalink( $product );
+                    if ( $link ) {
+                        echo '<link rel="canonical" href="' . esc_url( $link ) . '" />\n';
+                    }
+                }
+                return;
+            }
             $slug = get_query_var( 'product_cat' );
             $term = $slug ? get_term_by( 'slug', $slug, 'product_cat' ) : false;
             if ( $term && ! is_wp_error( $term ) ) {

--- a/includes/class-rewrite-rules.php
+++ b/includes/class-rewrite-rules.php
@@ -25,6 +25,12 @@ class Gm2_Category_Sort_Rewrite_Rules {
                 'index.php?product_cat=$matches[1]&gm2_alt_base=' . $base,
                 'top'
             );
+            // Match products when using an alternate base before the category rule.
+            add_rewrite_rule(
+                '^' . preg_quote( $base, '#' ) . '/(.+?)/([^/]+)/?$',
+                'index.php?product_cat=$matches[1]&product=$matches[2]&gm2_alt_base=' . $base,
+                'top'
+            );
         }
     }
 
@@ -105,6 +111,17 @@ class Gm2_Category_Sort_Rewrite_Rules {
         $base = get_query_var( 'gm2_alt_base' );
         if ( ! $base ) {
             return;
+        }
+        $product_slug = get_query_var( 'product' );
+        if ( $product_slug ) {
+            $product = get_page_by_path( $product_slug, OBJECT, 'product' );
+            if ( $product ) {
+                $link = get_permalink( $product );
+                if ( $link ) {
+                    wp_redirect( $link, 301 );
+                    exit;
+                }
+            }
         }
         $slug = get_query_var( 'product_cat' );
         if ( strpos( $slug, '/' ) !== false ) {

--- a/tests/RewriteRulesRedirectTest.php
+++ b/tests/RewriteRulesRedirectTest.php
@@ -2,6 +2,10 @@
 namespace {
 require_once __DIR__ . '/../includes/class-rewrite-rules.php';
 
+if ( ! defined( 'OBJECT' ) ) {
+    define( 'OBJECT', 'OBJECT' );
+}
+
 if ( ! function_exists( 'get_query_var' ) ) {
     function get_query_var( $key ) {
         return $GLOBALS['gm2_query_vars'][ $key ] ?? '';
@@ -22,6 +26,19 @@ if ( ! function_exists( 'wp_redirect' ) ) {
         throw new RedirectException();
     }
 }
+
+if ( ! function_exists( 'get_page_by_path' ) ) {
+    function get_page_by_path( $slug, $output = OBJECT, $post_type = 'page' ) {
+        return $GLOBALS['gm2_products'][ $slug ] ?? null;
+    }
+}
+
+if ( ! function_exists( 'get_permalink' ) ) {
+    function get_permalink( $post ) {
+        $slug = is_object( $post ) ? $post->post_name : $post;
+        return 'http://example.com/product/' . $slug;
+    }
+}
 }
 
 namespace {
@@ -32,6 +49,7 @@ class RewriteRulesRedirectTest extends TestCase {
         gm2_test_reset_terms();
         $GLOBALS['gm2_query_vars'] = [];
         $GLOBALS['gm2_wp_redirect'] = null;
+        $GLOBALS['gm2_products'] = [];
     }
 
     public function test_redirects_when_alt_base_present() {
@@ -65,6 +83,25 @@ class RewriteRulesRedirectTest extends TestCase {
         }
 
         $this->assertSame( 'http://example.com/child', $GLOBALS['gm2_wp_redirect']['location'] );
+        $this->assertSame( 301, $GLOBALS['gm2_wp_redirect']['status'] );
+    }
+
+    public function test_redirects_product_alt_base() {
+        wp_insert_term( 'Cat', 'product_cat' );
+        $GLOBALS['gm2_products']['sample-product'] = (object) [ 'post_name' => 'sample-product' ];
+
+        $GLOBALS['gm2_query_vars']['gm2_alt_base'] = 'alt';
+        $GLOBALS['gm2_query_vars']['product_cat']  = 'cat';
+        $GLOBALS['gm2_query_vars']['product']      = 'sample-product';
+
+        try {
+            Gm2_Category_Sort_Rewrite_Rules::maybe_redirect();
+            $this->fail( 'RedirectException not thrown' );
+        } catch ( RedirectException $e ) {
+            // Expected.
+        }
+
+        $this->assertSame( 'http://example.com/product/sample-product', $GLOBALS['gm2_wp_redirect']['location'] );
         $this->assertSame( 301, $GLOBALS['gm2_wp_redirect']['status'] );
     }
 }

--- a/tests/RewriteRulesSaveTest.php
+++ b/tests/RewriteRulesSaveTest.php
@@ -65,11 +65,17 @@ class RewriteRulesSaveTest extends TestCase {
 
         $this->assertSame( [ 'alt' ], $GLOBALS['gm2_options']['gm2_rewrite_bases'] );
 
-        $this->assertCount( 1, $GLOBALS['gm2_added_rules'] );
-        $rule = $GLOBALS['gm2_added_rules'][0];
-        $this->assertSame( '^alt/(.+?)/?$', $rule['regex'] );
-        $this->assertSame( 'index.php?product_cat=$matches[1]&gm2_alt_base=alt', $rule['query'] );
-        $this->assertSame( 'top', $rule['position'] );
+        $this->assertCount( 2, $GLOBALS['gm2_added_rules'] );
+        $cat_rule   = $GLOBALS['gm2_added_rules'][0];
+        $product_rule = $GLOBALS['gm2_added_rules'][1];
+
+        $this->assertSame( '^alt/(.+?)/?$', $cat_rule['regex'] );
+        $this->assertSame( 'index.php?product_cat=$matches[1]&gm2_alt_base=alt', $cat_rule['query'] );
+        $this->assertSame( 'top', $cat_rule['position'] );
+
+        $this->assertSame( '^alt/(.+?)/([^/]+)/?$', $product_rule['regex'] );
+        $this->assertSame( 'index.php?product_cat=$matches[1]&product=$matches[2]&gm2_alt_base=alt', $product_rule['query'] );
+        $this->assertSame( 'top', $product_rule['position'] );
     }
 
     public function test_multiple_windows_line_breaks_create_rules() {
@@ -85,15 +91,25 @@ class RewriteRulesSaveTest extends TestCase {
 
         $this->assertSame( [ 'alt', 'shop' ], $GLOBALS['gm2_options']['gm2_rewrite_bases'] );
 
-        $this->assertCount( 2, $GLOBALS['gm2_added_rules'] );
+        $this->assertCount( 4, $GLOBALS['gm2_added_rules'] );
 
         $rule1 = $GLOBALS['gm2_added_rules'][0];
         $this->assertSame( '^alt/(.+?)/?$', $rule1['regex'] );
         $this->assertSame( 'index.php?product_cat=$matches[1]&gm2_alt_base=alt', $rule1['query'] );
 
         $rule2 = $GLOBALS['gm2_added_rules'][1];
-        $this->assertSame( '^shop/(.+?)/?$', $rule2['regex'] );
-        $this->assertSame( 'index.php?product_cat=$matches[1]&gm2_alt_base=shop', $rule2['query'] );
+        $this->assertSame( '^alt/(.+?)/([^/]+)/?$', $rule2['regex'] );
+        $this->assertSame( 'index.php?product_cat=$matches[1]&product=$matches[2]&gm2_alt_base=alt', $rule2['query'] );
+
+        $rule3 = $GLOBALS['gm2_added_rules'][2];
+        $this->assertSame( '^shop/(.+?)/?$', $rule3['regex'] );
+        $this->assertSame( 'index.php?product_cat=$matches[1]&gm2_alt_base=shop', $rule3['query'] );
+        $this->assertSame( 'top', $rule3['position'] );
+
+        $rule4 = $GLOBALS['gm2_added_rules'][3];
+        $this->assertSame( '^shop/(.+?)/([^/]+)/?$', $rule4['regex'] );
+        $this->assertSame( 'index.php?product_cat=$matches[1]&product=$matches[2]&gm2_alt_base=shop', $rule4['query'] );
+        $this->assertSame( 'top', $rule4['position'] );
     }
 }
 }


### PR DESCRIPTION
## Summary
- add product rewrite rule for alternate bases
- redirect alternate base product URLs to the proper permalink
- output canonical links for products when using an alternate base
- update tests for new rules and redirects

## Testing
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6883e6d2c8b083278c20316a2add0209