### PR TITLE
Fix product_cat redirect with full path

### DIFF
--- a/includes/class-rewrite-rules.php
+++ b/includes/class-rewrite-rules.php
@@ -124,11 +124,46 @@ class Gm2_Category_Sort_Rewrite_Rules {
             }
         }
         $slug = get_query_var( 'product_cat' );
+        $term = null;
         if ( strpos( $slug, '/' ) !== false ) {
-            $parts = explode( '/', trim( $slug, '/' ) );
-            $slug  = end( $parts );
+            $parts  = array_filter( explode( '/', trim( $slug, '/' ) ) );
+            $parent = 0;
+            foreach ( $parts as $part ) {
+                $children = get_terms( [
+                    'taxonomy'   => 'product_cat',
+                    'parent'     => $parent,
+                    'hide_empty' => false,
+                ] );
+                if ( is_wp_error( $children ) ) {
+                    $term = null;
+                    break;
+                }
+                $found = null;
+                foreach ( $children as $child ) {
+                    $child_slug = sanitize_title( $child->name );
+                    if ( ! isset( $child->slug ) ) {
+                        $child->slug = $child_slug;
+                    }
+                    if ( $child_slug === $part ) {
+                        $found  = $child;
+                        $parent = $child->term_id;
+                        break;
+                    }
+                }
+                if ( ! $found ) {
+                    $term = null;
+                    break;
+                }
+                $term = $found;
+            }
         }
-        $term = get_term_by( 'slug', $slug, 'product_cat' );
+        if ( ! $term ) {
+            if ( strpos( $slug, '/' ) !== false ) {
+                $parts = explode( '/', trim( $slug, '/' ) );
+                $slug  = end( $parts );
+            }
+            $term = get_term_by( 'slug', $slug, 'product_cat' );
+        }
         if ( ! $term || is_wp_error( $term ) ) {
             return;
         }

--- a/tests/CanonicalAltBaseSlugTest.php
+++ b/tests/CanonicalAltBaseSlugTest.php
@@ -10,6 +10,7 @@ if ( ! function_exists( 'get_query_var' ) ) {
 
 if ( ! function_exists( 'get_term_link' ) ) {
     function get_term_link( $term ) {
+        $GLOBALS['gm2_last_term_id'] = $term->term_id;
         return 'http://example.com/' . $term->slug;
     }
 }

--- a/tests/CanonicalAltBaseTest.php
+++ b/tests/CanonicalAltBaseTest.php
@@ -10,6 +10,7 @@ if ( ! function_exists( 'get_query_var' ) ) {
 
 if ( ! function_exists( 'get_term_link' ) ) {
     function get_term_link( $term ) {
+        $GLOBALS['gm2_last_term_id'] = $term->term_id;
         return 'http://example.com/' . $term->slug;
     }
 }

--- a/tests/RewriteRulesRedirectTest.php
+++ b/tests/RewriteRulesRedirectTest.php
@@ -16,6 +16,7 @@ class RedirectException extends \Exception {}
 
 if ( ! function_exists( 'get_term_link' ) ) {
     function get_term_link( $term ) {
+        $GLOBALS['gm2_last_term_id'] = $term->term_id;
         return 'http://example.com/' . $term->slug;
     }
 }
@@ -37,6 +38,14 @@ if ( ! function_exists( 'get_permalink' ) ) {
     function get_permalink( $post ) {
         $slug = is_object( $post ) ? $post->post_name : $post;
         return 'http://example.com/product/' . $slug;
+    }
+}
+
+if ( ! function_exists( 'sanitize_title' ) ) {
+    function sanitize_title( $str ) {
+        $s = strtolower( $str );
+        $s = preg_replace( '/[^a-z0-9]+/', '-', $s );
+        return trim( $s, '-' );
     }
 }
 }
@@ -123,6 +132,28 @@ class RewriteRulesRedirectTest extends TestCase {
 
         $this->assertSame( 'http://example.com/product/sample-product', $GLOBALS['gm2_wp_redirect']['location'] );
         $this->assertSame( 301, $GLOBALS['gm2_wp_redirect']['status'] );
+    }
+
+    public function test_redirects_with_duplicate_slugs() {
+        $p1 = wp_insert_term( 'Parent1', 'product_cat' );
+        wp_insert_term( 'Shared', 'product_cat', [ 'parent' => $p1['term_id'] ] );
+
+        $p2     = wp_insert_term( 'Parent2', 'product_cat' );
+        $child2 = wp_insert_term( 'Shared', 'product_cat', [ 'parent' => $p2['term_id'] ] );
+
+        $GLOBALS['gm2_query_vars']['gm2_alt_base'] = 'alt';
+        $GLOBALS['gm2_query_vars']['product_cat']  = 'parent2/shared';
+
+        try {
+            Gm2_Category_Sort_Rewrite_Rules::maybe_redirect();
+            $this->fail( 'RedirectException not thrown' );
+        } catch ( RedirectException $e ) {
+            // Expected.
+        }
+
+        $this->assertSame( 'http://example.com/shared', $GLOBALS['gm2_wp_redirect']['location'] );
+        $this->assertSame( 301, $GLOBALS['gm2_wp_redirect']['status'] );
+        $this->assertSame( $child2['term_id'], $GLOBALS['gm2_last_term_id'] );
     }
 }
 }


### PR DESCRIPTION
## Summary
- resolve product_cat paths with parent hierarchy
- expose requested term via `gm2_last_term_id` in stubbed `get_term_link`
- cover redirects when branches share the same slug

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6883fdcd21048327a8e7eb09c0644340