### PR TITLE
Fix rewrite redirect slug handling

### DIFF
--- a/includes/class-rewrite-rules.php
+++ b/includes/class-rewrite-rules.php
@@ -140,7 +140,7 @@ class Gm2_Category_Sort_Rewrite_Rules {
                 }
                 $found = null;
                 foreach ( $children as $child ) {
-                    $child_slug = sanitize_title( $child->name );
+                    $child_slug = isset( $child->slug ) ? $child->slug : sanitize_title( $child->name );
                     if ( ! isset( $child->slug ) ) {
                         $child->slug = $child_slug;
                     }

--- a/tests/RewriteRulesRedirectTest.php
+++ b/tests/RewriteRulesRedirectTest.php
@@ -155,5 +155,27 @@ class RewriteRulesRedirectTest extends TestCase {
         $this->assertSame( 301, $GLOBALS['gm2_wp_redirect']['status'] );
         $this->assertSame( $child2['term_id'], $GLOBALS['gm2_last_term_id'] );
     }
+
+    public function test_redirects_with_custom_parent_slug() {
+        $p1 = wp_insert_term( 'Parent1', 'product_cat' );
+        wp_insert_term( 'Shared', 'product_cat', [ 'parent' => $p1['term_id'] ] );
+
+        $p2     = wp_insert_term( 'Parent2', 'product_cat', [ 'slug' => 'alt-parent' ] );
+        $child2 = wp_insert_term( 'Shared', 'product_cat', [ 'parent' => $p2['term_id'] ] );
+
+        $GLOBALS['gm2_query_vars']['gm2_alt_base'] = 'alt';
+        $GLOBALS['gm2_query_vars']['product_cat']  = 'alt-parent/shared';
+
+        try {
+            Gm2_Category_Sort_Rewrite_Rules::maybe_redirect();
+            $this->fail( 'RedirectException not thrown' );
+        } catch ( RedirectException $e ) {
+            // Expected.
+        }
+
+        $this->assertSame( 'http://example.com/shared', $GLOBALS['gm2_wp_redirect']['location'] );
+        $this->assertSame( 301, $GLOBALS['gm2_wp_redirect']['status'] );
+        $this->assertSame( $child2['term_id'], $GLOBALS['gm2_last_term_id'] );
+    }
 }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -38,6 +38,7 @@ $GLOBALS['gm2_products'] = [];
 $GLOBALS['gm2_set_terms_calls'] = [];
 $GLOBALS['gm2_attributes'] = [];
 $GLOBALS['gm2_attr_terms'] = [];
+$GLOBALS['gm2_term_slugs'] = [];
 
 function gm2_test_reset_terms() {
     $GLOBALS['gm2_test_terms'] = [];
@@ -48,9 +49,18 @@ function gm2_test_reset_terms() {
     $GLOBALS['gm2_products'] = [];
     $GLOBALS['gm2_set_terms_calls'] = [];
     $GLOBALS['gm2_attributes'] = [];
+    $GLOBALS['gm2_term_slugs'] = [];
 }
 
 gm2_test_reset_terms();
+
+if ( ! function_exists( 'sanitize_title' ) ) {
+    function sanitize_title( $str ) {
+        $s = strtolower( $str );
+        $s = preg_replace( '/[^a-z0-9]+/', '-', $s );
+        return trim( $s, '-' );
+    }
+}
 
 function term_exists( $name, $taxonomy = null, $parent = 0 ) {
     if ( $taxonomy && $taxonomy !== 'product_cat' ) {
@@ -75,6 +85,8 @@ function wp_insert_term( $name, $taxonomy, $args = [] ) {
             $GLOBALS['gm2_test_terms'][ $parent ] = [];
         }
         $GLOBALS['gm2_test_terms'][ $parent ][ $name ] = $id;
+        $slug = $args['slug'] ?? sanitize_title( $name );
+        $GLOBALS['gm2_term_slugs'][ $id ] = $slug;
     } else {
         if ( ! isset( $GLOBALS['gm2_attr_terms'][ $taxonomy ] ) ) {
             $GLOBALS['gm2_attr_terms'][ $taxonomy ] = [];
@@ -97,8 +109,7 @@ function get_term_by( $field, $value, $taxonomy ) {
     if ( $taxonomy === 'product_cat' ) {
         foreach ( $GLOBALS['gm2_test_terms'] as $parent => $terms ) {
             foreach ( $terms as $name => $id ) {
-                $slug = strtolower( preg_replace( '/[^a-z0-9]+/i', '-', $name ) );
-                $slug = trim( $slug, '-' );
+                $slug = $GLOBALS['gm2_term_slugs'][ $id ] ?? sanitize_title( $name );
                 if ( ( $field === 'name' && $name === $value ) || ( $field === 'slug' && $slug === $value ) ) {
                     return (object) [ 'term_id' => $id, 'slug' => $slug ];
                 }
@@ -200,7 +211,8 @@ if ( ! function_exists( 'get_terms' ) ) {
         $terms    = [];
         if ( $taxonomy !== 'product_cat' ) {
             foreach ( $GLOBALS['gm2_attr_terms'][ $taxonomy ] ?? [] as $name => $id ) {
-                $terms[] = (object) [ 'term_id' => $id, 'parent' => 0, 'name' => $name ];
+                $slug = $GLOBALS['gm2_term_slugs'][ $id ] ?? sanitize_title( $name );
+                $terms[] = (object) [ 'term_id' => $id, 'parent' => 0, 'name' => $name, 'slug' => $slug ];
             }
             return $terms;
         }
@@ -216,6 +228,7 @@ if ( ! function_exists( 'get_terms' ) ) {
                     'term_id' => $id,
                     'parent'  => $p,
                     'name'    => $name,
+                    'slug'    => $GLOBALS['gm2_term_slugs'][ $id ] ?? sanitize_title( $name ),
                 ];
             }
         }


### PR DESCRIPTION
## Summary
- ensure `maybe_redirect()` compares slug fields from terms when present
- expose slug fields from `get_terms()` in test bootstrap
- allow providing term slugs via `wp_insert_term`
- add regression test for custom parent slug redirect

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6884091b5fd48327a7f46b145728d917