### PR TITLE
Handle canonical product path in rewrite redirect

### DIFF
--- a/includes/class-rewrite-rules.php
+++ b/includes/class-rewrite-rules.php
@@ -118,6 +118,12 @@ class Gm2_Category_Sort_Rewrite_Rules {
             if ( $product ) {
                 $link = get_permalink( $product );
                 if ( $link ) {
+                    $current = home_url( $_SERVER['REQUEST_URI'] ?? '' );
+                    $link_path    = trim( (string) parse_url( $link, PHP_URL_PATH ), '/' );
+                    $current_path = trim( (string) parse_url( $current, PHP_URL_PATH ), '/' );
+                    if ( $link_path === $current_path ) {
+                        return;
+                    }
                     wp_redirect( $link, 301 );
                     exit;
                 }

--- a/tests/RewriteRulesRedirectTest.php
+++ b/tests/RewriteRulesRedirectTest.php
@@ -114,6 +114,21 @@ class RewriteRulesRedirectTest extends TestCase {
         $this->assertSame( 301, $GLOBALS['gm2_wp_redirect']['status'] );
     }
 
+    public function test_no_redirect_when_alt_base_matches_product_segment() {
+        wp_insert_term( 'Cat', 'product_cat' );
+        $GLOBALS['gm2_products']['sample-product'] = (object) [ 'post_name' => 'sample-product' ];
+
+        $GLOBALS['gm2_query_vars']['gm2_alt_base'] = 'product';
+        $GLOBALS['gm2_query_vars']['product_cat']  = 'cat';
+        $GLOBALS['gm2_query_vars']['product']      = 'sample-product';
+        $_SERVER['REQUEST_URI'] = '/product/sample-product';
+
+        Gm2_Category_Sort_Rewrite_Rules::maybe_redirect();
+
+        $this->assertNull( $GLOBALS['gm2_wp_redirect'] );
+        unset( $_SERVER['REQUEST_URI'] );
+    }
+
     public function test_redirects_nested_product_alt_base() {
         $parent = wp_insert_term( 'Parent', 'product_cat' );
         wp_insert_term( 'Child', 'product_cat', [ 'parent' => $parent['term_id'] ] );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -285,6 +285,12 @@ if ( ! function_exists( 'trailingslashit' ) ) {
     }
 }
 
+if ( ! function_exists( 'home_url' ) ) {
+    function home_url( $path = '', $scheme = null ) {
+        return 'http://example.com' . $path;
+    }
+}
+
 if ( ! function_exists( 'wp_upload_dir' ) ) {
     function wp_upload_dir() {
         $base = sys_get_temp_dir() . '/uploads';


### PR DESCRIPTION
## Summary
- check current request before redirecting to avoid loops
- stub `home_url` in tests
- cover redirect skip logic when alt base matches product permalink

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68840b6038348327aa53bd4f0a627637