### PR TITLE
Handle canonical product base in rewrite rules

### DIFF
--- a/includes/class-rewrite-rules.php
+++ b/includes/class-rewrite-rules.php
@@ -15,6 +15,18 @@ class Gm2_Category_Sort_Rewrite_Rules {
         if ( ! is_array( $bases ) ) {
             $bases = [];
         }
+
+        $permalinks      = get_option( 'woocommerce_permalinks' );
+        $product_segment = '';
+        if (
+            is_array( $permalinks ) &&
+            ! empty( $permalinks['product_base'] ) &&
+            strpos( $permalinks['product_base'], '%product_cat%' ) !== false
+        ) {
+            $parts          = explode( '/', trim( $permalinks['product_base'], '/' ) );
+            $product_segment = $parts[0] ?? '';
+        }
+
         foreach ( $bases as $base ) {
             $base = trim( $base, '/' );
             if ( $base === '' ) {
@@ -25,6 +37,14 @@ class Gm2_Category_Sort_Rewrite_Rules {
                 'index.php?product_cat=$matches[1]&gm2_alt_base=' . $base,
                 'top'
             );
+
+            // When the base matches the canonical product segment, WooCommerce's
+            // own rules handle product permalinks. Skip registering a product
+            // rule to avoid conflicts.
+            if ( $base === $product_segment ) {
+                continue;
+            }
+
             // Match products when using an alternate base before the category rule.
             add_rewrite_rule(
                 '^' . preg_quote( $base, '#' ) . '/(.+?)/([^/]+)/?$',

--- a/tests/RewriteRulesRedirectTest.php
+++ b/tests/RewriteRulesRedirectTest.php
@@ -192,5 +192,19 @@ class RewriteRulesRedirectTest extends TestCase {
         $this->assertSame( 301, $GLOBALS['gm2_wp_redirect']['status'] );
         $this->assertSame( $child2['term_id'], $GLOBALS['gm2_last_term_id'] );
     }
+
+    public function test_canonical_product_base_handled_by_woocommerce() {
+        wp_insert_term( 'Cat', 'product_cat' );
+        $GLOBALS['gm2_products']['sample-product'] = (object) [ 'post_name' => 'sample-product' ];
+
+        // Simulate WooCommerce handling the canonical product base. gm2_alt_base
+        // is not set because our plugin should not register a matching rule.
+        $GLOBALS['gm2_query_vars']['product_cat'] = 'cat';
+        $GLOBALS['gm2_query_vars']['product']     = 'sample-product';
+
+        Gm2_Category_Sort_Rewrite_Rules::maybe_redirect();
+
+        $this->assertNull( $GLOBALS['gm2_wp_redirect'] );
+    }
 }
 }


### PR DESCRIPTION
## Summary
- detect WooCommerce's product permalink segment when `%product_cat%` is used
- skip registering product rewrite rules for that segment
- add a regression test showing canonical URLs are untouched

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688415ca7fa88327a38ff6ade996efe7