### PR TITLE
Handle custom slugs in redirects

### DIFF
--- a/includes/class-rewrite-rules.php
+++ b/includes/class-rewrite-rules.php
@@ -166,10 +166,7 @@ class Gm2_Category_Sort_Rewrite_Rules {
                 }
                 $found = null;
                 foreach ( $children as $child ) {
-                    $child_slug = isset( $child->slug ) ? $child->slug : sanitize_title( $child->name );
-                    if ( ! isset( $child->slug ) ) {
-                        $child->slug = $child_slug;
-                    }
+                    $child_slug = ( isset( $child->slug ) && $child->slug !== '' ) ? $child->slug : sanitize_title( $child->name );
                     if ( $child_slug === $part ) {
                         $found  = $child;
                         $parent = $child->term_id;

--- a/tests/RewriteRulesRedirectTest.php
+++ b/tests/RewriteRulesRedirectTest.php
@@ -193,6 +193,23 @@ class RewriteRulesRedirectTest extends TestCase {
         $this->assertSame( $child2['term_id'], $GLOBALS['gm2_last_term_id'] );
     }
 
+    public function test_redirects_with_custom_slug() {
+        wp_insert_term( 'Fancy Name', 'product_cat', [ 'slug' => 'special' ] );
+
+        $GLOBALS['gm2_query_vars']['gm2_alt_base'] = 'alt';
+        $GLOBALS['gm2_query_vars']['product_cat']  = 'special';
+
+        try {
+            Gm2_Category_Sort_Rewrite_Rules::maybe_redirect();
+            $this->fail( 'RedirectException not thrown' );
+        } catch ( RedirectException $e ) {
+            // Expected.
+        }
+
+        $this->assertSame( 'http://example.com/special', $GLOBALS['gm2_wp_redirect']['location'] );
+        $this->assertSame( 301, $GLOBALS['gm2_wp_redirect']['status'] );
+    }
+
     public function test_canonical_product_base_handled_by_woocommerce() {
         wp_insert_term( 'Cat', 'product_cat' );
         $GLOBALS['gm2_products']['sample-product'] = (object) [ 'post_name' => 'sample-product' ];

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -212,7 +212,13 @@ if ( ! function_exists( 'get_terms' ) ) {
         if ( $taxonomy !== 'product_cat' ) {
             foreach ( $GLOBALS['gm2_attr_terms'][ $taxonomy ] ?? [] as $name => $id ) {
                 $slug = $GLOBALS['gm2_term_slugs'][ $id ] ?? sanitize_title( $name );
-                $terms[] = (object) [ 'term_id' => $id, 'parent' => 0, 'name' => $name, 'slug' => $slug ];
+                $term       = (object) [
+                    'term_id' => $id,
+                    'parent'  => 0,
+                    'name'    => $name,
+                ];
+                $term->slug = $slug;
+                $terms[]    = $term;
             }
             return $terms;
         }
@@ -224,12 +230,14 @@ if ( ! function_exists( 'get_terms' ) ) {
                 if ( $include && ! in_array( $id, $include, true ) ) {
                     continue;
                 }
-                $terms[] = (object) [
+                $slug      = $GLOBALS['gm2_term_slugs'][ $id ] ?? sanitize_title( $name );
+                $term      = (object) [
                     'term_id' => $id,
                     'parent'  => $p,
                     'name'    => $name,
-                    'slug'    => $GLOBALS['gm2_term_slugs'][ $id ] ?? sanitize_title( $name ),
                 ];
+                $term->slug = $slug;
+                $terms[]    = $term;
             }
         }
         return $terms;


### PR DESCRIPTION
## Summary
- respect each term's `slug` when checking redirect paths
- ensure term objects in the bootstrap test helpers include a slug
- test redirect for a category that uses a custom slug

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6884169ba3748327b157ee8b532c985c