### PR TITLE
Update product rewrite handling

### DIFF
--- a/includes/class-rewrite-rules.php
+++ b/includes/class-rewrite-rules.php
@@ -48,7 +48,7 @@ class Gm2_Category_Sort_Rewrite_Rules {
             // Match products when using an alternate base before the category rule.
             add_rewrite_rule(
                 '^' . preg_quote( $base, '#' ) . '/(.+?)/([^/]+)/?$',
-                'index.php?product_cat=$matches[1]&product=$matches[2]&gm2_alt_base=' . $base,
+                'index.php?product=$matches[2]&gm2_alt_base=' . $base,
                 'top'
             );
         }
@@ -150,6 +150,9 @@ class Gm2_Category_Sort_Rewrite_Rules {
             }
         }
         $slug = get_query_var( 'product_cat' );
+        if ( $slug === '' ) {
+            return;
+        }
         $term = null;
         if ( strpos( $slug, '/' ) !== false ) {
             $parts  = array_filter( explode( '/', trim( $slug, '/' ) ) );

--- a/tests/RewriteRulesRedirectTest.php
+++ b/tests/RewriteRulesRedirectTest.php
@@ -100,7 +100,6 @@ class RewriteRulesRedirectTest extends TestCase {
         $GLOBALS['gm2_products']['sample-product'] = (object) [ 'post_name' => 'sample-product' ];
 
         $GLOBALS['gm2_query_vars']['gm2_alt_base'] = 'alt';
-        $GLOBALS['gm2_query_vars']['product_cat']  = 'cat';
         $GLOBALS['gm2_query_vars']['product']      = 'sample-product';
 
         try {
@@ -119,7 +118,6 @@ class RewriteRulesRedirectTest extends TestCase {
         $GLOBALS['gm2_products']['sample-product'] = (object) [ 'post_name' => 'sample-product' ];
 
         $GLOBALS['gm2_query_vars']['gm2_alt_base'] = 'product';
-        $GLOBALS['gm2_query_vars']['product_cat']  = 'cat';
         $GLOBALS['gm2_query_vars']['product']      = 'sample-product';
         $_SERVER['REQUEST_URI'] = '/product/sample-product';
 
@@ -135,7 +133,25 @@ class RewriteRulesRedirectTest extends TestCase {
         $GLOBALS['gm2_products']['sample-product'] = (object) [ 'post_name' => 'sample-product' ];
 
         $GLOBALS['gm2_query_vars']['gm2_alt_base'] = 'shop';
-        $GLOBALS['gm2_query_vars']['product_cat']  = 'parent/child';
+        $GLOBALS['gm2_query_vars']['product']      = 'sample-product';
+
+        try {
+            Gm2_Category_Sort_Rewrite_Rules::maybe_redirect();
+            $this->fail( 'RedirectException not thrown' );
+        } catch ( RedirectException $e ) {
+            // Expected.
+        }
+
+        $this->assertSame( 'http://example.com/product/sample-product', $GLOBALS['gm2_wp_redirect']['location'] );
+        $this->assertSame( 301, $GLOBALS['gm2_wp_redirect']['status'] );
+    }
+
+    public function test_product_not_in_category_still_redirects() {
+        wp_insert_term( 'CatA', 'product_cat' );
+        wp_insert_term( 'CatB', 'product_cat' );
+        $GLOBALS['gm2_products']['sample-product'] = (object) [ 'post_name' => 'sample-product' ];
+
+        $GLOBALS['gm2_query_vars']['gm2_alt_base'] = 'alt';
         $GLOBALS['gm2_query_vars']['product']      = 'sample-product';
 
         try {

--- a/tests/RewriteRulesSaveTest.php
+++ b/tests/RewriteRulesSaveTest.php
@@ -74,7 +74,7 @@ class RewriteRulesSaveTest extends TestCase {
         $this->assertSame( 'top', $cat_rule['position'] );
 
         $this->assertSame( '^alt/(.+?)/([^/]+)/?$', $product_rule['regex'] );
-        $this->assertSame( 'index.php?product_cat=$matches[1]&product=$matches[2]&gm2_alt_base=alt', $product_rule['query'] );
+        $this->assertSame( 'index.php?product=$matches[2]&gm2_alt_base=alt', $product_rule['query'] );
         $this->assertSame( 'top', $product_rule['position'] );
     }
 
@@ -99,7 +99,7 @@ class RewriteRulesSaveTest extends TestCase {
 
         $rule2 = $GLOBALS['gm2_added_rules'][1];
         $this->assertSame( '^alt/(.+?)/([^/]+)/?$', $rule2['regex'] );
-        $this->assertSame( 'index.php?product_cat=$matches[1]&product=$matches[2]&gm2_alt_base=alt', $rule2['query'] );
+        $this->assertSame( 'index.php?product=$matches[2]&gm2_alt_base=alt', $rule2['query'] );
 
         $rule3 = $GLOBALS['gm2_added_rules'][2];
         $this->assertSame( '^shop/(.+?)/?$', $rule3['regex'] );
@@ -108,7 +108,7 @@ class RewriteRulesSaveTest extends TestCase {
 
         $rule4 = $GLOBALS['gm2_added_rules'][3];
         $this->assertSame( '^shop/(.+?)/([^/]+)/?$', $rule4['regex'] );
-        $this->assertSame( 'index.php?product_cat=$matches[1]&product=$matches[2]&gm2_alt_base=shop', $rule4['query'] );
+        $this->assertSame( 'index.php?product=$matches[2]&gm2_alt_base=shop', $rule4['query'] );
         $this->assertSame( 'top', $rule4['position'] );
     }
 }


### PR DESCRIPTION
## Summary
- simplify product rewrite rule to only capture slug
- early exit in redirect logic when no category slug provided
- update related tests
- ensure products load when category segment doesn't match

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6884184763c08327ba75b1d86fb4ed32