### PR TITLE
Handle product base conflicts

### DIFF
--- a/includes/class-rewrite-rules.php
+++ b/includes/class-rewrite-rules.php
@@ -32,10 +32,12 @@ class Gm2_Category_Sort_Rewrite_Rules {
             if ( $base === '' ) {
                 continue;
             }
+
+            $priority = ( $base === $product_segment ) ? 'bottom' : 'top';
             add_rewrite_rule(
                 '^' . preg_quote( $base, '#' ) . '/(.+?)/?$',
                 'index.php?product_cat=$matches[1]&gm2_alt_base=' . $base,
-                'top'
+                $priority
             );
 
             // When the base matches the canonical product segment, WooCommerce's

--- a/tests/RewriteRulesSaveTest.php
+++ b/tests/RewriteRulesSaveTest.php
@@ -111,5 +111,27 @@ class RewriteRulesSaveTest extends TestCase {
         $this->assertSame( 'index.php?product=$matches[2]&gm2_alt_base=shop', $rule4['query'] );
         $this->assertSame( 'top', $rule4['position'] );
     }
+
+    public function test_canonical_product_base_rule_is_low_priority() {
+        $_POST['gm2_rewrites_nonce'] = 't';
+        $_POST['gm2_rewrite_bases'] = "shop\n";
+        $GLOBALS['gm2_options']['woocommerce_permalinks'] = [
+            'product_base' => 'shop/%product_cat%'
+        ];
+
+        try {
+            Gm2_Category_Sort_Rewrite_Rules::save_rules();
+            $this->fail( 'SaveRedirectException not thrown' );
+        } catch ( SaveRedirectException $e ) {
+            // Expected.
+        }
+
+        $this->assertCount( 1, $GLOBALS['gm2_added_rules'] );
+        $rule = $GLOBALS['gm2_added_rules'][0];
+
+        $this->assertSame( '^shop/(.+?)/?$', $rule['regex'] );
+        $this->assertSame( 'index.php?product_cat=$matches[1]&gm2_alt_base=shop', $rule['query'] );
+        $this->assertSame( 'bottom', $rule['position'] );
+    }
 }
 }


### PR DESCRIPTION
## Summary
- defer category rewrite when it matches the WooCommerce product permalink segment
- test that only a low priority rule is registered when bases conflict with WooCommerce

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6884210b9c348327b537ed6bc04575db