### PR TITLE
Add missing empty-path redirect test

### DIFF
--- a/tests/RewriteRulesRedirectTest.php
+++ b/tests/RewriteRulesRedirectTest.php
@@ -239,5 +239,15 @@ class RewriteRulesRedirectTest extends TestCase {
 
         $this->assertNull( $GLOBALS['gm2_wp_redirect'] );
     }
+
+    public function test_no_redirect_on_empty_path() {
+        $GLOBALS['gm2_query_vars']['gm2_alt_base'] = 'shop';
+        $GLOBALS['gm2_query_vars']['product_cat']  = '';
+        $GLOBALS['gm2_query_vars']['product']      = '';
+
+        Gm2_Category_Sort_Rewrite_Rules::maybe_redirect();
+
+        $this->assertNull( $GLOBALS['gm2_wp_redirect'] );
+    }
 }
 }


### PR DESCRIPTION
## Summary
- cover no-redirect case when gm2_alt_base is set but no path is present

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68842956a410832797726a31d7bc8134